### PR TITLE
fix(core-api): refuse OIDC login when email_verified=false (#28)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,6 +92,15 @@ SESSION_COOKIE_NAME=panorama_session
 # ===========================================================================
 OIDC_GOOGLE_CLIENT_ID=
 OIDC_GOOGLE_CLIENT_SECRET=
+# Google Workspace `hd` (hosted domain) values, comma-separated, that we
+# trust to stand in for the per-account `email_verified` claim.
+# Workspace admins prove domain ownership out-of-band, so an `hd` claim
+# from Google is itself the verification signal.
+# Leave empty for strict mode: any login with `email_verified !== true`
+# is refused. Microsoft has no equivalent claim — Entra deployments must
+# enforce email verification on the IdP side.
+# Example: OIDC_GOOGLE_TRUSTED_HD_DOMAINS=acme.com,beta.example
+OIDC_GOOGLE_TRUSTED_HD_DOMAINS=
 OIDC_MICROSOFT_CLIENT_ID=
 OIDC_MICROSOFT_CLIENT_SECRET=
 OIDC_MICROSOFT_TENANT=

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,6 +37,23 @@ Panorama ships with sane defaults (see `apps/core-api/src/config/security.ts`):
   _(NOTE: audit-flagged as not yet implemented — see issue [#34](https://github.com/VitorMRodovalho/panorama/issues/34))_
 - HSTS + CSP + X-Content-Type-Options + Referrer-Policy set via middleware
 - Argon2id password hashing (with bcrypt fallback for Snipe-IT migrations)
+- OIDC logins refused unless the IdP asserts `email_verified=true`.
+  A narrow exception trusts the Google Workspace `hd` (hosted domain)
+  claim when (a) the domain is listed in `OIDC_GOOGLE_TRUSTED_HD_DOMAINS`,
+  (b) the token's `iss` is the actual Google issuer, and (c) the email
+  ends with `@<hd>` — Workspace admin verification stands in for the
+  per-account flag. Under the `hd` override, linking a Google identity
+  to a pre-existing local account at the same email is also refused;
+  the override proves domain ownership, not control of an existing
+  account. Microsoft Entra has no equivalent claim; deployments must
+  enforce email verification on the IdP side. Refusals are recorded as
+  `panorama.auth.oidc_refused` audit events with the structured reason
+  (`email_not_verified` / `hd_not_allowlisted` / `hd_iss_mismatch` /
+  `hd_email_mismatch` / `oidc_account_link_requires_verified_email`).
+  **On-call runbook for a Workspace tenant locked out at pilot
+  launch:** add their domain to `OIDC_GOOGLE_TRUSTED_HD_DOMAINS`
+  (comma-separated, lowercase) and roll the deployment. There is no
+  knob to disable the gate entirely — that is intentional.
 - All outbound fetches disable follow-redirects unless the caller opts in
 - Rate limiting on auth endpoints (configurable per-tenant)
 - Audit log appended to every write operation (tamper-evident hash chain)

--- a/apps/core-api/src/modules/auth/auth.config.ts
+++ b/apps/core-api/src/modules/auth/auth.config.ts
@@ -13,6 +13,18 @@ export interface OidcProviderConfig {
   extraScopes?: string[];
   /** For Google Workspace / Microsoft Entra single-tenant hints. */
   hostedDomainHint?: string;
+  /**
+   * Google Workspace `hd` claim values (lowercased domains) we trust to
+   * stand in for `email_verified=true`. Workspace admins prove domain
+   * ownership out-of-band, so the IdP issuing an `hd` claim is itself
+   * the verification signal — independent of the per-account
+   * `email_verified` flag, which Workspace doesn't always set.
+   *
+   * Empty (default) means the gate is strict: any login with
+   * `email_verified !== true` is refused. Only meaningful for the
+   * `google` provider; ignored elsewhere.
+   */
+  trustedHdDomains?: string[];
 }
 
 export interface AuthConfig {
@@ -59,6 +71,10 @@ export class AuthConfigService {
       if (process.env.OIDC_GOOGLE_HOSTED_DOMAIN) {
         google.hostedDomainHint = process.env.OIDC_GOOGLE_HOSTED_DOMAIN;
       }
+      const trusted = parseDomainList(process.env.OIDC_GOOGLE_TRUSTED_HD_DOMAINS);
+      if (trusted.length > 0) {
+        google.trustedHdDomains = trusted;
+      }
       providers.google = google;
     }
     if (process.env.OIDC_MICROSOFT_CLIENT_ID) {
@@ -90,4 +106,12 @@ export class AuthConfigService {
   hasProvider(name: 'google' | 'microsoft'): boolean {
     return !!this.config.providers[name]?.clientId;
   }
+}
+
+function parseDomainList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((d) => d.trim().toLowerCase())
+    .filter((d) => d.length > 0);
 }

--- a/apps/core-api/src/modules/auth/auth.controller.ts
+++ b/apps/core-api/src/modules/auth/auth.controller.ts
@@ -259,13 +259,9 @@ export class AuthController {
       expectedNonce: stored.nonce,
     });
 
-    const session = await this.auth.loginWithOidc({
-      provider,
-      subject: userInfo.subject,
-      email: userInfo.email,
-      firstName: userInfo.firstName,
-      lastName: userInfo.lastName,
-      displayName: userInfo.displayName,
+    const session = await this.auth.loginWithOidc(provider, userInfo, {
+      ipAddress: req.ip ?? null,
+      userAgent: req.headers['user-agent'] ?? null,
     });
     await this.sessions.setSession(req, res, session);
 

--- a/apps/core-api/src/modules/auth/auth.service.ts
+++ b/apps/core-api/src/modules/auth/auth.service.ts
@@ -1,8 +1,25 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import type { Prisma } from '@prisma/client';
+import { createHash } from 'node:crypto';
+import { AuditService } from '../audit/audit.service.js';
 import { PrismaService } from '../prisma/prisma.service.js';
+import { AuthConfigService } from './auth.config.js';
+import type { OidcUserInfo } from './oidc.service.js';
 import { PasswordService } from './password.service.js';
 import type { PanoramaSession, PanoramaSessionMembership } from './session.types.js';
+
+const GOOGLE_ISSUER = 'https://accounts.google.com';
+
+type OidcGateOutcome =
+  | { ok: true; viaHdOverride: boolean }
+  | {
+      ok: false;
+      reason:
+        | 'email_not_verified'
+        | 'hd_not_allowlisted'
+        | 'hd_iss_mismatch'
+        | 'hd_email_mismatch';
+    };
 
 export interface LoginOutcome {
   session: PanoramaSession;
@@ -24,6 +41,8 @@ export class AuthService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly passwords: PasswordService,
+    private readonly cfg: AuthConfigService,
+    private readonly audit: AuditService,
   ) {}
 
   /**
@@ -79,48 +98,93 @@ export class AuthService {
    * session. Memberships are resolved to whatever the user already has;
    * just-in-time tenant assignment by email domain lands in a later step
    * (0.3) together with the invitation UI.
+   *
+   * Refuses login when the IdP did not assert `email_verified=true`
+   * (SEC-01 / #28). One narrow exception: a Google Workspace `hd`
+   * claim that matches `OIDC_GOOGLE_TRUSTED_HD_DOMAINS` AND the
+   * email's own domain AND the actual Google issuer — Workspace admin
+   * verification stands in for the per-account verified bit, which
+   * Google Workspace doesn't always set.
+   *
+   * Under the hd-override path, the legacy "link this OIDC identity to
+   * a pre-existing User with the same email" branch is refused: the
+   * Workspace admin proved domain ownership, not control of an
+   * already-existing local account. Linking would let an attacker who
+   * controls a Workspace tenant for `acme.example` graft a Google
+   * identity onto a victim's prior password-account at the same email.
    */
-  async loginWithOidc(params: {
-    provider: 'google' | 'microsoft';
-    subject: string;
-    email: string;
-    firstName?: string | null;
-    lastName?: string | null;
-    displayName?: string | null;
-  }): Promise<PanoramaSession> {
-    const email = params.email.toLowerCase().trim();
+  async loginWithOidc(
+    provider: 'google' | 'microsoft',
+    userInfo: OidcUserInfo,
+    context: { ipAddress?: string | null; userAgent?: string | null } = {},
+  ): Promise<PanoramaSession> {
+    const email = userInfo.email.toLowerCase().trim();
+    const gate = this.evaluateOidcGate(provider, userInfo, email);
+    if (!gate.ok) {
+      await this.recordOidcRefusal(provider, userInfo, email, gate.reason, context);
+      this.log.warn(
+        {
+          provider,
+          reason: gate.reason,
+          subjectHash: hashSubject(provider, userInfo.subject),
+          emailDomain: emailDomain(email),
+          hd: userInfo.hd,
+        },
+        'oidc_login_refused',
+      );
+      throw new UnauthorizedException(gate.reason);
+    }
+
+    const allowEmailLink = !gate.viaHdOverride;
     const displayName =
-      params.displayName?.trim() ||
-      [params.firstName, params.lastName].filter(Boolean).join(' ').trim() ||
+      userInfo.displayName?.trim() ||
+      [userInfo.firstName, userInfo.lastName].filter(Boolean).join(' ').trim() ||
       email;
 
-    const userId = await this.prisma.runAsSuperAdmin(
+    // Sentinel pattern (`{ kind: 'ok' | 'refused' }`) instead of throwing
+    // inside the closure: the audit row for a refusal must commit in
+    // its own transaction (recordOidcRefusal -> AuditService.record),
+    // not interleave with this find-or-create. Throwing inside
+    // runAsSuperAdmin would either roll the audit back with the
+    // refusal or split the refusal across two contexts. Returning a
+    // sentinel keeps the gate decision contiguous and the audit
+    // emission happens exactly once, after the closure has cleanly
+    // exited with no writes.
+    const resolution = await this.prisma.runAsSuperAdmin(
       async (tx) => {
         // Subject is IdP-unique; use it as the strongest key.
         const existing = await tx.authIdentity.findUnique({
-          where: { provider_subject: { provider: params.provider, subject: params.subject } },
+          where: { provider_subject: { provider, subject: userInfo.subject } },
         });
         if (existing) {
           await tx.authIdentity.update({
             where: { id: existing.id },
             data: { lastUsedAt: new Date(), emailAtLink: email },
           });
-          return existing.userId;
+          return { kind: 'ok' as const, userId: existing.userId };
         }
 
-        // Second chance: link this OIDC identity to an existing User with the same email.
+        // Second chance: link this OIDC identity to an existing User with
+        // the same email. Refused under the hd-override path: the
+        // Workspace admin proved domain ownership, not control of an
+        // already-existing local account; linking would graft this OIDC
+        // identity onto whatever (password, prior OIDC) account had
+        // claimed the email first.
         const byEmail = await tx.user.findUnique({ where: { email } });
         if (byEmail) {
+          if (!allowEmailLink) {
+            return { kind: 'refused' as const };
+          }
           await tx.authIdentity.create({
             data: {
               userId: byEmail.id,
-              provider: params.provider,
-              subject: params.subject,
+              provider,
+              subject: userInfo.subject,
               emailAtLink: email,
               lastUsedAt: new Date(),
             },
           });
-          return byEmail.id;
+          return { kind: 'ok' as const, userId: byEmail.id };
         }
 
         // Brand new — create the global User + the OIDC identity linking it.
@@ -128,25 +192,112 @@ export class AuthService {
           data: {
             email,
             displayName,
-            firstName: params.firstName ?? null,
-            lastName: params.lastName ?? null,
+            firstName: userInfo.firstName ?? null,
+            lastName: userInfo.lastName ?? null,
           },
         });
         await tx.authIdentity.create({
           data: {
             userId: created.id,
-            provider: params.provider,
-            subject: params.subject,
+            provider,
+            subject: userInfo.subject,
             emailAtLink: email,
             lastUsedAt: new Date(),
           },
         });
-        return created.id;
+        return { kind: 'ok' as const, userId: created.id };
       },
       { reason: 'oidc find-or-create' },
     );
 
-    return this.buildSessionForUser(userId, params.provider);
+    if (resolution.kind === 'refused') {
+      const reason = 'oidc_account_link_requires_verified_email' as const;
+      await this.recordOidcRefusal(provider, userInfo, email, reason, context);
+      this.log.warn(
+        {
+          provider,
+          reason,
+          subjectHash: hashSubject(provider, userInfo.subject),
+          emailDomain: emailDomain(email),
+          hd: userInfo.hd,
+        },
+        'oidc_login_refused_account_link',
+      );
+      throw new UnauthorizedException(reason);
+    }
+
+    return this.buildSessionForUser(resolution.userId, provider);
+  }
+
+  private evaluateOidcGate(
+    provider: 'google' | 'microsoft',
+    userInfo: OidcUserInfo,
+    normalisedEmail: string,
+  ): OidcGateOutcome {
+    if (userInfo.emailVerified) return { ok: true, viaHdOverride: false };
+
+    if (provider !== 'google' || !userInfo.hd) {
+      return { ok: false, reason: 'email_not_verified' };
+    }
+    const trusted = this.cfg.config.providers.google?.trustedHdDomains ?? [];
+    if (trusted.length === 0) {
+      return { ok: false, reason: 'email_not_verified' };
+    }
+    const hd = userInfo.hd.toLowerCase();
+    if (!trusted.includes(hd)) {
+      return { ok: false, reason: 'hd_not_allowlisted' };
+    }
+    if (userInfo.iss !== GOOGLE_ISSUER) {
+      // Defence-in-depth against a misconfigured provider entry whose
+      // `provider` slot says "google" but discovers a different issuer.
+      return { ok: false, reason: 'hd_iss_mismatch' };
+    }
+    if (!normalisedEmail.endsWith(`@${hd}`)) {
+      return { ok: false, reason: 'hd_email_mismatch' };
+    }
+    return { ok: true, viaHdOverride: true };
+  }
+
+  private async recordOidcRefusal(
+    provider: 'google' | 'microsoft',
+    userInfo: OidcUserInfo,
+    normalisedEmail: string,
+    reason:
+      | 'email_not_verified'
+      | 'hd_not_allowlisted'
+      | 'hd_iss_mismatch'
+      | 'hd_email_mismatch'
+      | 'oidc_account_link_requires_verified_email',
+    context: { ipAddress?: string | null; userAgent?: string | null },
+  ): Promise<void> {
+    // `record()` (its own transaction) rather than `recordWithin(tx)`:
+    // refusal writes nothing else, so there is no domain row to
+    // commit-with. The audit-co-transaction rule applies to state
+    // transitions on tenant data, not to pre-tenant cluster events.
+    try {
+      await this.audit.record({
+        action: 'panorama.auth.oidc_refused',
+        resourceType: 'auth_identity',
+        resourceId: null,
+        tenantId: null,
+        actorUserId: null,
+        ipAddress: context.ipAddress ?? null,
+        userAgent: context.userAgent ?? null,
+        metadata: {
+          provider,
+          reason,
+          emailDomain: emailDomain(normalisedEmail),
+          hd: userInfo.hd,
+          subjectHash: hashSubject(provider, userInfo.subject),
+          iss: userInfo.iss,
+        },
+      });
+    } catch (err) {
+      // Audit-log failure must not mask the auth refusal — the throw
+      // happens immediately after this call. Log loudly so the gap is
+      // detectable.
+      this.log.error({ err: String(err) }, 'oidc_refusal_audit_write_failed');
+    }
   }
 
   /**
@@ -270,4 +421,16 @@ export class AuthService {
       }
     }, { reason: 'setPasswordForUser' });
   }
+}
+
+function hashSubject(provider: string, subject: string): string {
+  // Truncated SHA-256 — enough entropy to correlate refusals across
+  // log lines without exposing the IdP-stable user ID itself.
+  return createHash('sha256').update(`${provider}:${subject}`).digest('hex').slice(0, 16);
+}
+
+function emailDomain(normalisedEmail: string): string | null {
+  const at = normalisedEmail.lastIndexOf('@');
+  if (at < 0 || at === normalisedEmail.length - 1) return null;
+  return normalisedEmail.slice(at + 1);
 }

--- a/apps/core-api/src/modules/auth/oidc.service.ts
+++ b/apps/core-api/src/modules/auth/oidc.service.ts
@@ -31,6 +31,22 @@ export interface OidcUserInfo {
   lastName: string | null;
   displayName: string | null;
   emailVerified: boolean;
+  /**
+   * Google Workspace `hd` (hosted domain) claim, lowercased. Set by
+   * Google only for Workspace accounts where the admin has proven
+   * domain ownership; absent for consumer @gmail.com and for non-Google
+   * providers. Used by AuthService to allow a workspace-domain
+   * exception to the `email_verified` gate.
+   */
+  hd: string | null;
+  /**
+   * ID-token `iss` claim. Used to pin the hd-override to actual Google.
+   * NULL only if a token somehow arrives without an `iss` claim — a
+   * spec violation (RFC 7519). The gate refuses such tokens; the
+   * NULL is preserved here so the audit metadata isn't poisoned with
+   * the literal string `"undefined"`.
+   */
+  iss: string | null;
 }
 
 /**
@@ -116,14 +132,29 @@ export class OidcService {
 
     const claims = tokens.claims();
     if (!claims.email) throw new UnauthorizedException('oidc_missing_email');
+    // `sub` is mandatory per RFC 7519. If it's missing or non-string,
+    // the (provider, subject) tuple we use as the strongest identity
+    // key would degrade to `(provider, 'undefined')` and start
+    // colliding across upstream IdP misconfigurations. Refuse loudly.
+    if (typeof claims.sub !== 'string' || claims.sub.length === 0) {
+      throw new UnauthorizedException('oidc_missing_subject');
+    }
+
+    const rawHd = claims['hd'];
+    const hd =
+      typeof rawHd === 'string' && rawHd.trim().length > 0
+        ? rawHd.trim().toLowerCase()
+        : null;
 
     return {
-      subject: String(claims.sub),
+      subject: claims.sub,
       email: String(claims.email).toLowerCase().trim(),
       firstName: (claims['given_name'] as string | undefined) ?? null,
       lastName: (claims['family_name'] as string | undefined) ?? null,
       displayName: (claims['name'] as string | undefined) ?? null,
       emailVerified: claims['email_verified'] === true,
+      hd,
+      iss: typeof claims.iss === 'string' && claims.iss.length > 0 ? claims.iss : null,
     };
   }
 }

--- a/apps/core-api/test/auth-oidc-email-verification.test.ts
+++ b/apps/core-api/test/auth-oidc-email-verification.test.ts
@@ -1,0 +1,405 @@
+import 'reflect-metadata';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UnauthorizedException } from '@nestjs/common';
+import { AuthService } from '../src/modules/auth/auth.service.js';
+import { AuthConfigService } from '../src/modules/auth/auth.config.js';
+import type { AuditService } from '../src/modules/audit/audit.service.js';
+import type { OidcUserInfo } from '../src/modules/auth/oidc.service.js';
+import type { PasswordService } from '../src/modules/auth/password.service.js';
+import type { PrismaService } from '../src/modules/prisma/prisma.service.js';
+
+/**
+ * Unit coverage for SEC-01 / #28 — OIDC login rejects unverified
+ * emails, with a narrow Google Workspace `hd` override.
+ *
+ * The gate sits in AuthService.loginWithOidc before any DB write,
+ * so a mock PrismaService + AuditService is enough — we observe
+ * whether the call short-circuits to UnauthorizedException, whether
+ * an audit row would be written with the correct reason, and (for
+ * the hd-override path) whether the email-link branch is refused.
+ */
+
+const GOOGLE_ISSUER = 'https://accounts.google.com';
+
+function makeUserInfo(overrides: Partial<OidcUserInfo> = {}): OidcUserInfo {
+  return {
+    subject: 'google-sub-alice',
+    email: 'alice@acme.example',
+    firstName: 'Alice',
+    lastName: 'Driver',
+    displayName: 'Alice Driver',
+    emailVerified: false,
+    hd: null,
+    iss: GOOGLE_ISSUER,
+    ...overrides,
+  };
+}
+
+function makeService(envOverrides: Record<string, string | undefined> = {}) {
+  vi.stubEnv('SESSION_SECRET', 'a'.repeat(32));
+  vi.stubEnv('OIDC_GOOGLE_CLIENT_ID', 'fake-google-id');
+  vi.stubEnv('OIDC_GOOGLE_CLIENT_SECRET', 'fake-google-secret');
+  for (const [k, v] of Object.entries(envOverrides)) {
+    if (v === undefined) vi.stubEnv(k, '');
+    else vi.stubEnv(k, v);
+  }
+
+  const cfg = new AuthConfigService();
+  const runAsSuperAdmin = vi.fn() as ReturnType<typeof vi.fn>;
+  const prisma = { runAsSuperAdmin } as unknown as PrismaService;
+  const passwords = {} as unknown as PasswordService;
+  const auditRecord = vi.fn() as ReturnType<typeof vi.fn>;
+  const audit = { record: auditRecord } as unknown as AuditService;
+  const svc = new AuthService(prisma, passwords, cfg, audit);
+  return { svc, runAsSuperAdmin, auditRecord };
+}
+
+function lastAuditEvent(auditRecord: ReturnType<typeof vi.fn>): Record<string, unknown> {
+  const calls = auditRecord.mock.calls;
+  if (calls.length === 0) throw new Error('auditRecord was not called');
+  const last = calls[calls.length - 1];
+  if (!last || last.length === 0) throw new Error('auditRecord called with no arguments');
+  return last[0] as Record<string, unknown>;
+}
+
+function lastAuditMetadata(auditRecord: ReturnType<typeof vi.fn>): Record<string, unknown> {
+  const event = lastAuditEvent(auditRecord) as { metadata?: Record<string, unknown> };
+  if (!event.metadata) throw new Error('audit event has no metadata');
+  return event.metadata;
+}
+
+describe('AuthService.loginWithOidc — email_verified gate (#28)', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('refuses Google login when email_verified=false and no hd', async () => {
+    const { svc, runAsSuperAdmin, auditRecord } = makeService();
+
+    await expect(
+      svc.loginWithOidc('google', makeUserInfo({ emailVerified: false, hd: null })),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(runAsSuperAdmin).not.toHaveBeenCalled();
+    expect(auditRecord).toHaveBeenCalledOnce();
+    expect(lastAuditEvent(auditRecord)).toMatchObject({
+      action: 'panorama.auth.oidc_refused',
+      tenantId: null,
+      actorUserId: null,
+      metadata: expect.objectContaining({
+        provider: 'google',
+        reason: 'email_not_verified',
+        emailDomain: 'acme.example',
+      }),
+    });
+  });
+
+  it('refuses Microsoft login when email_verified=false (no hd override available)', async () => {
+    const { svc, runAsSuperAdmin, auditRecord } = makeService({
+      OIDC_MICROSOFT_CLIENT_ID: 'fake-ms-id',
+      OIDC_MICROSOFT_CLIENT_SECRET: 'fake-ms-secret',
+    });
+
+    await expect(
+      svc.loginWithOidc(
+        'microsoft',
+        makeUserInfo({
+          emailVerified: false,
+          hd: null,
+          iss: 'https://login.microsoftonline.com/common/v2.0',
+        }),
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(runAsSuperAdmin).not.toHaveBeenCalled();
+    expect(lastAuditMetadata(auditRecord)).toMatchObject({
+      reason: 'email_not_verified',
+    });
+  });
+
+  it('refuses Google login with hd set but allowlist empty (default strict mode)', async () => {
+    const { svc, runAsSuperAdmin, auditRecord } = makeService();
+
+    await expect(
+      svc.loginWithOidc('google', makeUserInfo({ emailVerified: false, hd: 'acme.example' })),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(runAsSuperAdmin).not.toHaveBeenCalled();
+    expect(lastAuditMetadata(auditRecord)).toMatchObject({
+      reason: 'email_not_verified',
+    });
+  });
+
+  it('refuses Google login with hd outside the configured allowlist', async () => {
+    const { svc, runAsSuperAdmin, auditRecord } = makeService({
+      OIDC_GOOGLE_TRUSTED_HD_DOMAINS: 'acme.example,beta.example',
+    });
+
+    await expect(
+      svc.loginWithOidc(
+        'google',
+        makeUserInfo({
+          email: 'mallory@evil.example',
+          emailVerified: false,
+          hd: 'evil.example',
+        }),
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(runAsSuperAdmin).not.toHaveBeenCalled();
+    expect(lastAuditMetadata(auditRecord)).toMatchObject({
+      reason: 'hd_not_allowlisted',
+    });
+  });
+
+  it('refuses when hd is allowlisted but iss is not the actual Google issuer (B1 defence-in-depth)', async () => {
+    // Worked example: a developer copy-pastes OIDC_GOOGLE_CLIENT_ID
+    // pointing at a non-Google IdP whose discovery doc has its own
+    // issuer URL. provider='google' but the token actually came from
+    // somewhere else; refusing on iss-mismatch keeps the override
+    // honest.
+    const { svc, runAsSuperAdmin, auditRecord } = makeService({
+      OIDC_GOOGLE_TRUSTED_HD_DOMAINS: 'acme.example',
+    });
+
+    await expect(
+      svc.loginWithOidc(
+        'google',
+        makeUserInfo({
+          email: 'alice@acme.example',
+          emailVerified: false,
+          hd: 'acme.example',
+          iss: 'https://accounts.google.com.evil.example',
+        }),
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(runAsSuperAdmin).not.toHaveBeenCalled();
+    expect(lastAuditMetadata(auditRecord)).toMatchObject({
+      reason: 'hd_iss_mismatch',
+    });
+  });
+
+  it('refuses when hd is allowlisted but email domain does not match (anti-spoof)', async () => {
+    const { svc, runAsSuperAdmin, auditRecord } = makeService({
+      OIDC_GOOGLE_TRUSTED_HD_DOMAINS: 'acme.example',
+    });
+
+    await expect(
+      svc.loginWithOidc(
+        'google',
+        makeUserInfo({
+          email: 'mallory@gmail.com',
+          emailVerified: false,
+          hd: 'acme.example',
+        }),
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(runAsSuperAdmin).not.toHaveBeenCalled();
+    expect(lastAuditMetadata(auditRecord)).toMatchObject({
+      reason: 'hd_email_mismatch',
+    });
+  });
+
+  it('refuses when hd substring-matches a allowlisted domain (e.g. evilacme.example vs acme.example)', async () => {
+    // Defence against "endsWith without @ separator" trickery:
+    // `mallory@evilacme.example` doesn't end with `@acme.example`.
+    const { svc, runAsSuperAdmin, auditRecord } = makeService({
+      OIDC_GOOGLE_TRUSTED_HD_DOMAINS: 'acme.example',
+    });
+
+    await expect(
+      svc.loginWithOidc(
+        'google',
+        makeUserInfo({
+          email: 'mallory@evilacme.example',
+          emailVerified: false,
+          hd: 'evilacme.example',
+        }),
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(runAsSuperAdmin).not.toHaveBeenCalled();
+    expect(lastAuditMetadata(auditRecord)).toMatchObject({
+      reason: 'hd_not_allowlisted',
+    });
+  });
+
+  it('refuses Microsoft even when hd happens to be allowlisted (override is Google-only)', async () => {
+    const { svc, runAsSuperAdmin, auditRecord } = makeService({
+      OIDC_GOOGLE_TRUSTED_HD_DOMAINS: 'acme.example',
+      OIDC_MICROSOFT_CLIENT_ID: 'fake-ms-id',
+      OIDC_MICROSOFT_CLIENT_SECRET: 'fake-ms-secret',
+    });
+
+    await expect(
+      svc.loginWithOidc(
+        'microsoft',
+        makeUserInfo({
+          emailVerified: false,
+          hd: 'acme.example',
+          iss: 'https://login.microsoftonline.com/common/v2.0',
+        }),
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(runAsSuperAdmin).not.toHaveBeenCalled();
+    expect(lastAuditMetadata(auditRecord)).toMatchObject({
+      reason: 'email_not_verified',
+    });
+  });
+
+  it('proceeds when email_verified=true (strict-mode happy path)', async () => {
+    const { svc, runAsSuperAdmin } = makeService();
+    runAsSuperAdmin.mockRejectedValueOnce(new Error('stop_after_gate'));
+
+    await expect(
+      svc.loginWithOidc('google', makeUserInfo({ emailVerified: true, hd: null })),
+    ).rejects.toThrow('stop_after_gate');
+    expect(runAsSuperAdmin).toHaveBeenCalledOnce();
+  });
+
+  it('proceeds when email_verified=false but hd matches allowlist + email domain + iss', async () => {
+    const { svc, runAsSuperAdmin } = makeService({
+      OIDC_GOOGLE_TRUSTED_HD_DOMAINS: 'acme.example,beta.example',
+    });
+    runAsSuperAdmin.mockRejectedValueOnce(new Error('stop_after_gate'));
+
+    await expect(
+      svc.loginWithOidc(
+        'google',
+        makeUserInfo({
+          email: 'alice@acme.example',
+          emailVerified: false,
+          hd: 'acme.example',
+        }),
+      ),
+    ).rejects.toThrow('stop_after_gate');
+    expect(runAsSuperAdmin).toHaveBeenCalledOnce();
+  });
+
+  it('allowlist comparison is case-insensitive on hd and configured domains', async () => {
+    const { svc, runAsSuperAdmin } = makeService({
+      OIDC_GOOGLE_TRUSTED_HD_DOMAINS: 'Acme.Example',
+    });
+    runAsSuperAdmin.mockRejectedValueOnce(new Error('stop_after_gate'));
+
+    await expect(
+      svc.loginWithOidc(
+        'google',
+        makeUserInfo({
+          email: 'alice@acme.example',
+          emailVerified: false,
+          hd: 'ACME.EXAMPLE',
+        }),
+      ),
+    ).rejects.toThrow('stop_after_gate');
+    expect(runAsSuperAdmin).toHaveBeenCalledOnce();
+  });
+
+  it('audit metadata hashes the IdP subject (no PII leak)', async () => {
+    const { svc, auditRecord } = makeService();
+
+    await expect(
+      svc.loginWithOidc(
+        'google',
+        makeUserInfo({
+          subject: 'google-sub-very-secret-12345',
+          emailVerified: false,
+          hd: null,
+        }),
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+    const meta = lastAuditMetadata(auditRecord) as Record<string, unknown>;
+    expect(meta.subjectHash).toMatch(/^[0-9a-f]{16}$/);
+    expect(meta.subjectHash).not.toContain('google-sub-very-secret');
+  });
+
+  it('still throws UnauthorizedException when the audit write fails', async () => {
+    // Defence-in-depth: an audit-infra outage must not silently
+    // promote a refused login into a successful one. The refusal
+    // throws regardless of whether the audit row landed.
+    const { svc, auditRecord } = makeService();
+    auditRecord.mockRejectedValueOnce(new Error('audit_db_unreachable'));
+
+    await expect(
+      svc.loginWithOidc('google', makeUserInfo({ emailVerified: false, hd: null })),
+    ).rejects.toThrow(UnauthorizedException);
+    expect(auditRecord).toHaveBeenCalledOnce();
+  });
+});
+
+describe('AuthService.loginWithOidc — hd-override account-link refusal (B3)', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('refuses to link a Google identity to a pre-existing User under hd-override', async () => {
+    // Threat: attacker controls a Google Workspace tenant for
+    // acme.example. They sign in to Panorama with email
+    // alice@acme.example. A prior Panorama account at that email
+    // exists (created via password). Without this guard, we would
+    // attach a Google identity to Alice's account, granting the
+    // attacker permanent OIDC login as Alice.
+    const { svc, runAsSuperAdmin, auditRecord } = makeService({
+      OIDC_GOOGLE_TRUSTED_HD_DOMAINS: 'acme.example',
+    });
+
+    runAsSuperAdmin.mockImplementationOnce(async (fn: any) => {
+      const tx = {
+        authIdentity: {
+          findUnique: vi.fn(async () => null),
+          create: vi.fn(),
+          update: vi.fn(),
+        },
+        user: {
+          findUnique: vi.fn(async () => ({ id: 'pre-existing-user-id', email: 'alice@acme.example' })),
+          create: vi.fn(),
+        },
+      };
+      return fn(tx);
+    });
+
+    await expect(
+      svc.loginWithOidc(
+        'google',
+        makeUserInfo({
+          email: 'alice@acme.example',
+          emailVerified: false,
+          hd: 'acme.example',
+        }),
+      ),
+    ).rejects.toMatchObject({ message: 'oidc_account_link_requires_verified_email' });
+
+    expect(auditRecord).toHaveBeenCalledOnce();
+    expect(lastAuditEvent(auditRecord)).toMatchObject({
+      action: 'panorama.auth.oidc_refused',
+      metadata: expect.objectContaining({ reason: 'oidc_account_link_requires_verified_email' }),
+    });
+  });
+
+  it('allows the link path under strict mode (email_verified=true)', async () => {
+    const { svc, runAsSuperAdmin } = makeService();
+
+    const create = vi.fn(async () => undefined);
+    runAsSuperAdmin.mockImplementationOnce(async (fn: any) => {
+      const tx = {
+        authIdentity: {
+          findUnique: vi.fn(async () => null),
+          create,
+          update: vi.fn(),
+        },
+        user: {
+          findUnique: vi.fn(async () => ({ id: 'pre-existing-user-id', email: 'alice@acme.example' })),
+          create: vi.fn(),
+        },
+      };
+      return fn(tx);
+    });
+    runAsSuperAdmin.mockRejectedValueOnce(new Error('stop_after_link'));
+
+    await expect(
+      svc.loginWithOidc('google', makeUserInfo({ emailVerified: true })),
+    ).rejects.toThrow('stop_after_link');
+    expect(create).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Closes #28 (SEC-01, audit Wave 1, 2026-04-23).

## Summary

`OidcService.callback()` extracted `email_verified` from claims but `AuthService.loginWithOidc` never enforced it. A user authenticating via an IdP that returns `email_verified=false` (Microsoft Entra allows sign-in before verification) could take over any existing local account at the same email by being silently linked to the victim's `User` row.

Four guarantees now layered:

1. **Strict gate.** `loginWithOidc` refuses any token with `email_verified !== true` unless a single, narrow override applies.
2. **Workspace `hd` override.** A Google Workspace `hd` claim trusts the Workspace admin's out-of-band domain verification — only when (a) the domain is in `OIDC_GOOGLE_TRUSTED_HD_DOMAINS`, (b) the token's `iss` is the actual Google issuer, and (c) the email ends with `@<hd>`. Microsoft Entra has no equivalent claim and must enforce verification on the IdP.
3. **Linking refusal under override.** The "second-chance email-link to existing User" branch is gated behind `email_verified=true`. Workspace admin proved domain ownership, not control of an already-existing local account.
4. **Audit + structured reasons.** Every refusal lands a `panorama.auth.oidc_refused` row with one of: `email_not_verified` / `hd_not_allowlisted` / `hd_iss_mismatch` / `hd_email_mismatch` / `oidc_account_link_requires_verified_email`. Logs use a truncated SHA-256 of `(provider, subject)` so the IdP-stable user ID isn't sprayed across log aggregators.

Also hardens claim extraction: `oidc_missing_subject` is now a hard refusal (was `String(undefined)` coercion), and `iss` is preserved as `string | null` instead of the literal `"undefined"` string.

## Diff size

636 LOC (~280 src + ~390 test), over CONTRIBUTING's 400 target. Splitting forces temporary scaffolding because the gate, override, B3 linking refusal, and audit emission depend on each other end-to-end. Single PR by intent.

## Reviews (2 rounds, parallel)

- **security-reviewer**: round 1 REQUEST-CHANGES (B1 iss-pin, B2 PII in log, B3 linking bypass) → round 2 **APPROVE-WITH-CONCERNS** ("Ship it. The two concerns I'd address before merging the next OIDC change (not this one): validate `claims.sub` non-empty in `oidc.service.ts`, and harden `parseDomainList` with a domain-shape regex + boot-time warning.")
- **tech-lead**: round 1 REQUEST-CHANGES (audit event missing + dispatch caveats) → round 2 **APPROVE** (zero blockers)

## Follow-ups (separate issues)

- `parseDomainList` syntax validation (regex + boot-time warn)
- `panorama.auth.*` action namespace registry (typed enum or docs/audit-events.md)
- `panorama.auth.oidc_login` success audit event (symmetric to refused)
- OIDC integration test driving the controller end-to-end with a stubbed IdP

## Test plan

- [x] 15 unit tests in `apps/core-api/test/auth-oidc-email-verification.test.ts` cover each refusal arm, override happy path, substring-trick anti-spoof, B3 link refusal, audit-write-failure escape hatch, case-insensitive hd comparison
- [x] 7 existing `auth.e2e.test.ts` pass (DI through AppModule confirms constructor change)
- [x] `pnpm typecheck` green
- [ ] CI green
- [ ] Manual smoke through a real IdP after deploy to staging — recommended before flipping the OIDC providers on the first pilot tenant