### PR TITLE
fix(core-api): drop dev session-secret fallback (#35)

### DIFF
--- a/apps/core-api/src/modules/auth/auth.config.ts
+++ b/apps/core-api/src/modules/auth/auth.config.ts
@@ -53,11 +53,15 @@ export class AuthConfigService {
 
     const sessionSecret = process.env.SESSION_SECRET ?? '';
     if (sessionSecret.length < 32) {
-      const msg =
+      // Throw in EVERY environment, not just production. The previous
+      // dev-only fallback (`'dev-only-insecure-session-secret-replace-me-32b'`)
+      // turned into deterministic session forgery on any non-production
+      // environment carrying real tenant data — staging, UAT, even CI
+      // when NODE_ENV happened to differ from "production". SEC-03 / #35.
+      throw new Error(
         'SESSION_SECRET must be at least 32 characters. Generate with ' +
-        '`node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'base64url\'))"`';
-      if (isProduction) throw new Error(msg);
-      this.log.warn({ secretLength: sessionSecret.length }, msg);
+          '`node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'base64url\'))"`',
+      );
     }
 
     const providers: AuthConfig['providers'] = {};
@@ -89,7 +93,7 @@ export class AuthConfigService {
     }
 
     this.config = {
-      sessionSecret: sessionSecret || 'dev-only-insecure-session-secret-replace-me-32b',
+      sessionSecret,
       sessionCookieName: process.env.SESSION_COOKIE_NAME ?? 'panorama_session',
       oauthStateCookieName: process.env.OAUTH_STATE_COOKIE_NAME ?? 'panorama_oauth',
       sessionMaxAgeSeconds: Number(process.env.SESSION_MAX_AGE_SECONDS ?? 60 * 60 * 24 * 7), // 7d

--- a/apps/core-api/test/auth-config-session-secret.test.ts
+++ b/apps/core-api/test/auth-config-session-secret.test.ts
@@ -1,0 +1,70 @@
+import 'reflect-metadata';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthConfigService } from '../src/modules/auth/auth.config.js';
+
+/**
+ * Regression coverage for SEC-03 / #35 — the dev-only session-secret
+ * fallback (`'dev-only-insecure-session-secret-replace-me-32b'`) used
+ * to land in `config.sessionSecret` for any non-production environment
+ * when `SESSION_SECRET` was unset or too short. That meant staging,
+ * UAT, and CI environments carrying real tenant data ended up
+ * signing sessions with a value committed in source — full session
+ * forgery on those environments.
+ *
+ * Now: the constructor throws in every environment, no fallback in
+ * the resolved config.
+ */
+describe('AuthConfigService — SESSION_SECRET enforcement (#35)', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('throws when SESSION_SECRET is unset, even outside production', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('SESSION_SECRET', '');
+
+    expect(() => new AuthConfigService()).toThrow(/SESSION_SECRET must be at least 32/);
+  });
+
+  it('throws when SESSION_SECRET is shorter than 32 chars in staging', () => {
+    vi.stubEnv('NODE_ENV', 'staging');
+    vi.stubEnv('SESSION_SECRET', 'too-short');
+
+    expect(() => new AuthConfigService()).toThrow(/SESSION_SECRET/);
+  });
+
+  it('throws in production with no SESSION_SECRET', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SESSION_SECRET', '');
+
+    expect(() => new AuthConfigService()).toThrow(/SESSION_SECRET/);
+  });
+
+  it('does NOT silently install the legacy dev fallback string', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('SESSION_SECRET', 'a'.repeat(32));
+
+    const cfg = new AuthConfigService();
+    expect(cfg.config.sessionSecret).toBe('a'.repeat(32));
+    expect(cfg.config.sessionSecret).not.toContain('dev-only-insecure');
+  });
+
+  it('accepts a valid 32-char secret', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('SESSION_SECRET', 'a'.repeat(32));
+
+    expect(() => new AuthConfigService()).not.toThrow();
+  });
+
+  it('accepts a longer secret', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('SESSION_SECRET', 'b'.repeat(64));
+
+    const cfg = new AuthConfigService();
+    expect(cfg.config.sessionSecret).toBe('b'.repeat(64));
+    expect(cfg.config.isProduction).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #35 (SEC-03, audit Wave 1, 2026-04-23).

## Summary

`auth.config.ts` used to fall back to a hardcoded `'dev-only-insecure-session-secret-replace-me-32b'` whenever `SESSION_SECRET` was unset or shorter than 32 chars in any non-production environment. Staging, UAT, and CI environments carrying real tenant data ended up signing sessions with a value committed in source — full session forgery on those environments by anyone who could read the repo.

## Fix

- Throw at boot in **every** environment when `SESSION_SECRET` is missing or `<32` chars.
- The legacy fallback string is no longer a reachable value — `config.sessionSecret` mirrors env input verbatim.
- `session.service.ts` is the only consumer; boot-time guarantee makes its `password` arg non-empty by construction.

## Test plan

- [x] 6 unit tests in `test/auth-config-session-secret.test.ts`: unset → throw, short → throw, production → throw, valid 32-char → config holds actual env value, longer → accepted, `isProduction` stays correct
- [x] 7 existing `auth.e2e.test.ts` tests still pass (DI bootstraps because `_setup.ts` provides a 32-char default)
- [x] `pnpm typecheck` green
- [ ] CI green (note: pre-existing CI red since 2026-04-19, see #93)
- [ ] Smoke before deploy: confirm staging env has a real `SESSION_SECRET` set; otherwise the next pod will crashloop

## Reviewer

security-reviewer **APPROVE** (one round). Minor non-blocking concerns tracked as follow-ups: entropy floor on low-quality secrets like `'a'.repeat(32)`, vi.stubEnv comment about `_setup.ts` interaction.