### PR TITLE
chore(ci): migration convention checker + 3 NO_RLS skip markers (#71)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
       - run: pnpm --filter @panorama/core-api prisma:generate
       - run: pnpm lint
       - run: pnpm typecheck
+      # Closes Wave 1 ARCH-11 / #71 — every Prisma migration folder
+      # must contain migration.sql + ROLLBACK.md + exactly one of
+      # rls.sql / NO_RLS.md. Fails CI on any drift.
+      - run: pnpm migrations:check
 
   test:
     name: Unit tests

--- a/apps/core-api/prisma/migrations/20260418021614_0002_import_identity_map/NO_RLS.md
+++ b/apps/core-api/prisma/migrations/20260418021614_0002_import_identity_map/NO_RLS.md
@@ -1,0 +1,28 @@
+# NO_RLS — 0002_import_identity_map
+
+Migration 0002 introduces `import_identity_map` — a system-scoped
+table that maps Snipe-IT legacy ids to Panorama UUIDs during the
+import roundtrip. It has no `tenantId` column by design: a single
+import run touches multiple tenants, and the mapper is consumed only
+by the migrator binary running under a privileged role
+(`panorama_super_admin` with `panorama.bypass_rls = 'on'`).
+
+There is no tenant-routed reader path that should see this table.
+panorama_app cannot SELECT it — the GRANT in 0001/rls.sql does not
+extend to system tables, which is the right shape. RLS would add
+ceremony without a security gain because the access surface is
+already gated at the role + grant layer.
+
+## Re-evaluate when
+
+- A non-import code path needs to read import_identity_map (very
+  unlikely; the table is only referenced by the migrator).
+- A tenantId column is added (e.g., per-tenant import audits) — at
+  which point this NO_RLS.md must be deleted and a real `rls.sql`
+  authored.
+
+## Reviewer
+
+- 2026-04-23 audit Wave 1 (data-architect) — confirmed system-scope
+- 2026-04-26 (audit Wave 2d.F closure) — confirmed at NO_RLS.md
+  introduction, paired with `scripts/check-migration-conventions.ts`

--- a/apps/core-api/prisma/migrations/20260418025404_0003_auth_multi_tenant/NO_RLS.md
+++ b/apps/core-api/prisma/migrations/20260418025404_0003_auth_multi_tenant/NO_RLS.md
@@ -1,0 +1,27 @@
+# NO_RLS — 0003_auth_multi_tenant
+
+Migration 0003 is a pure ALTER on tables that already have RLS
+policies installed by 0001 — `users`, `tenant_memberships`,
+`auth_identities`, `tenants`. It adds columns and FK relationships
+but does not introduce a new table that needs its own policy.
+
+The policies on the affected tables continue to apply unmodified:
+`tenants_tenant_isolation`, `tenant_memberships_tenant_isolation`,
+`users_self_or_tenant`, `auth_identities_self_or_tenant`. No new
+RLS surface is created by this migration; nothing to author here.
+
+## Re-evaluate when
+
+- The migration is amended to add a new table (very unlikely — it
+  is a column-only ALTER).
+- A future audit determines that the column additions changed the
+  RLS posture (e.g., a new tenant-routed column on users that
+  needs a column-grant). At that point this NO_RLS.md must be
+  superseded by a real `rls.sql`.
+
+## Reviewer
+
+- 2026-04-23 audit Wave 1 (data-architect) — confirmed pure ALTER,
+  RLS policies on parent tables are unchanged
+- 2026-04-26 (audit Wave 2d.F closure) — confirmed at NO_RLS.md
+  introduction, paired with `scripts/check-migration-conventions.ts`

--- a/apps/core-api/prisma/migrations/20260419120000_0013_bypassrls_refactor_panorama_namespace/NO_RLS.md
+++ b/apps/core-api/prisma/migrations/20260419120000_0013_bypassrls_refactor_panorama_namespace/NO_RLS.md
@@ -1,0 +1,31 @@
+# NO_RLS — 0013_bypassrls_refactor_panorama_namespace
+
+Migration 0013 IS the RLS infrastructure refactor (ADR-0015 v2).
+It defines the `panorama_current_tenant()` helper, the
+`panorama_enable_bypass_rls()` SECURITY DEFINER wrapper, the GUC
+namespace migration from `app.*` to `panorama.*`, and the
+DO-block sweep that re-applies tenant-isolation + super-admin-bypass
+policies across every existing tenant-scoped table.
+
+It does not introduce a new tenant-scoped table that would need its
+own `rls.sql`. Its work is to FIX the RLS surface globally — every
+prior table's policies are rewritten in-place.
+
+## Re-evaluate when
+
+- The next BYPASSRLS-style refactor lands. By design those become
+  their own migrations with the same NO_RLS posture.
+- A future audit identifies that the sweep missed a table (none
+  found in the 2026-04-23 Wave 1 review, but the audit explicitly
+  flagged this as a one-shot sweep that won't auto-fire on tables
+  landing post-0013 — see migration 0014 §4 cross-tenant FK
+  trigger discussion + data-architect blocker B3 from Wave 1).
+
+## Reviewer
+
+- 2026-04-23 audit Wave 1 (data-architect blocker B3) — confirmed
+  one-shot sweep is correct for this migration's intent; flagged
+  separately that post-0013 tables must each ship their own
+  `rls.sql` (followed up in 0014 + 0015)
+- 2026-04-26 (audit Wave 2d.F closure) — confirmed at NO_RLS.md
+  introduction, paired with `scripts/check-migration-conventions.ts`

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "clean": "turbo run clean && rimraf node_modules .turbo",
     "i18n:check": "tsx scripts/i18n-check.ts",
     "license:check": "tsx scripts/license-check.ts",
+    "migrations:check": "tsx scripts/check-migration-conventions.ts",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",

--- a/scripts/check-migration-conventions.ts
+++ b/scripts/check-migration-conventions.ts
@@ -1,0 +1,136 @@
+/**
+ * Migration convention gate (Wave 2d.F / #71 / closes Wave 1 ARCH-11).
+ *
+ * Every Prisma migration folder under apps/core-api/prisma/migrations
+ * must contain:
+ *
+ *   1. migration.sql       — what Prisma executes
+ *   2. ROLLBACK.md (≥40 chars) — reversibility note per CONTRIBUTING #4
+ *   3. EXACTLY ONE of:
+ *        rls.sql              — applied by the CI's RLS apply loop
+ *        NO_RLS.md (≥80 chars) — explicit skip with reviewer rationale
+ *
+ * The script exits non-zero on any violation so CI fails fast. It
+ * also rejects folders that contain BOTH rls.sql and NO_RLS.md
+ * (ambiguity defeats the gate).
+ *
+ * Symlinks under migrations/ are followed; non-directory entries
+ * other than `migration_lock.toml` and `README.md` are flagged.
+ */
+
+import { promises as fs } from 'node:fs';
+import { join, basename } from 'node:path';
+
+const MIGRATIONS_DIR = new URL(
+  '../apps/core-api/prisma/migrations/',
+  import.meta.url,
+);
+
+const ROLLBACK_MIN_CHARS = 40;
+const NO_RLS_MIN_CHARS = 80;
+const ALLOWED_TOP_LEVEL_FILES = new Set(['migration_lock.toml', 'README.md']);
+const REQUIRED_FILE = 'migration.sql';
+const ROLLBACK_FILE = 'ROLLBACK.md';
+const RLS_FILE = 'rls.sql';
+const NO_RLS_FILE = 'NO_RLS.md';
+
+interface Violation {
+  folder: string;
+  message: string;
+}
+
+async function statSize(path: string): Promise<number | null> {
+  try {
+    const s = await fs.stat(path);
+    return s.size;
+  } catch {
+    return null;
+  }
+}
+
+async function checkFolder(folderUrl: URL, name: string): Promise<Violation[]> {
+  const violations: Violation[] = [];
+  const folderPath = folderUrl.pathname;
+
+  const migrationSql = join(folderPath, REQUIRED_FILE);
+  if ((await statSize(migrationSql)) === null) {
+    violations.push({ folder: name, message: `missing ${REQUIRED_FILE}` });
+  }
+
+  const rollbackPath = join(folderPath, ROLLBACK_FILE);
+  const rollbackSize = await statSize(rollbackPath);
+  if (rollbackSize === null) {
+    violations.push({ folder: name, message: `missing ${ROLLBACK_FILE}` });
+  } else if (rollbackSize < ROLLBACK_MIN_CHARS) {
+    violations.push({
+      folder: name,
+      message: `${ROLLBACK_FILE} is too short (${rollbackSize} chars, need ≥${ROLLBACK_MIN_CHARS}). Describe revert SQL + when to use it.`,
+    });
+  }
+
+  const rlsPath = join(folderPath, RLS_FILE);
+  const noRlsPath = join(folderPath, NO_RLS_FILE);
+  const rlsSize = await statSize(rlsPath);
+  const noRlsSize = await statSize(noRlsPath);
+  const hasRls = rlsSize !== null;
+  const hasNoRls = noRlsSize !== null;
+
+  if (hasRls && hasNoRls) {
+    violations.push({
+      folder: name,
+      message: `cannot have BOTH ${RLS_FILE} and ${NO_RLS_FILE}. Pick one — the migration either touches RLS or it does not.`,
+    });
+  } else if (!hasRls && !hasNoRls) {
+    violations.push({
+      folder: name,
+      message: `missing one of ${RLS_FILE} or ${NO_RLS_FILE}. If the migration intentionally has no RLS surface, add ${NO_RLS_FILE} (≥${NO_RLS_MIN_CHARS} chars rationale).`,
+    });
+  } else if (hasNoRls && noRlsSize! < NO_RLS_MIN_CHARS) {
+    violations.push({
+      folder: name,
+      message: `${NO_RLS_FILE} is too short (${noRlsSize} chars, need ≥${NO_RLS_MIN_CHARS}). Skip rationale must include reviewer name + review date + re-evaluation criteria.`,
+    });
+  }
+
+  return violations;
+}
+
+async function main(): Promise<void> {
+  const entries = await fs.readdir(MIGRATIONS_DIR, { withFileTypes: true });
+  const violations: Violation[] = [];
+
+  for (const entry of entries) {
+    if (entry.isFile()) {
+      if (!ALLOWED_TOP_LEVEL_FILES.has(entry.name)) {
+        violations.push({
+          folder: '<root>',
+          message: `unexpected top-level file: ${entry.name}. Allowed: ${[...ALLOWED_TOP_LEVEL_FILES].join(', ')}.`,
+        });
+      }
+      continue;
+    }
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+
+    const folderUrl = new URL(`${entry.name}/`, MIGRATIONS_DIR);
+    const found = await checkFolder(folderUrl, entry.name);
+    violations.push(...found);
+  }
+
+  if (violations.length > 0) {
+    console.error('Migration convention violations:');
+    for (const v of violations) {
+      console.error(`  ${v.folder}: ${v.message}`);
+    }
+    console.error(
+      `\n${violations.length} violation${violations.length === 1 ? '' : 's'}. ` +
+        'See CONTRIBUTING.md "Migrations must be reversible" + the audit Wave 2d.F write-up.',
+    );
+    process.exit(1);
+  }
+  console.log(`Migration conventions OK (${entries.length} entries scanned).`);
+}
+
+main().catch((err) => {
+  console.error('Migration convention check failed unexpectedly:', err);
+  process.exit(2);
+});


### PR DESCRIPTION
Closes #71 (Wave 2d.F) and Wave 1 ARCH-11 (rollup #53).

## Summary

`scripts/check-migration-conventions.ts` enforces the rules documented in `CONTRIBUTING.md` "Migrations must be reversible" plus the RLS-pairing convention from ADR-0015 v2.

For every migration folder under `apps/core-api/prisma/migrations`:
- `migration.sql` — present
- `ROLLBACK.md` — present, ≥40 chars
- Exactly one of `rls.sql` (applied by CI's RLS loop) or `NO_RLS.md` (≥80 chars rationale with reviewer + date + re-evaluation criteria). Both present → rejected (ambiguity).
- Top-level files other than `migration_lock.toml` and `README.md` → flagged.

## Three new NO_RLS.md skip markers

- `0002_import_identity_map` — system-scoped table, not tenant-routed reader.
- `0003_auth_multi_tenant` — pure ALTER on tables already policied by 0001.
- `0013_bypassrls_refactor_panorama_namespace` — IS the RLS refactor; sweep rewrites policies in-place across every existing table.

Each marker carries reviewer name + review date + re-evaluation criteria.

## CI wiring

New step in the `lint` job: `pnpm migrations:check`. Fails fast with an exit-1 punchlist if any folder violates the conventions.

## Test plan

- [x] `pnpm migrations:check` returns 0 on the current tree (17 entries scanned)
- [x] `mv NO_RLS.md /tmp/...; pnpm migrations:check` returns 1 with `missing one of rls.sql or NO_RLS.md`
- [x] Restore + re-run → 0
- [ ] CI green (note: pre-existing CI red since 2026-04-19 unrelated to this PR — see #93)