### PR TITLE
chore(ci): ESLint flat-config for apps/core-api (#66)

### DIFF
--- a/apps/core-api/eslint.config.mjs
+++ b/apps/core-api/eslint.config.mjs
@@ -1,0 +1,112 @@
+// ESLint flat config for @panorama/core-api (Wave 2d.A / #66 /
+// extends Wave 1 #39).
+//
+// Strategy:
+//   - typescript-eslint `recommendedTypeChecked` as the baseline.
+//   - Real-bug catches as `error` — these surface concrete defects
+//     not stylistic preferences.
+//   - Stylistic / "this might be unsound" rules as `warn` initially
+//     so the lint job can land without churning every file. Ratchet
+//     to `error` in follow-up PRs.
+//   - `--max-warnings=0` (set on the CLI side) makes every warning
+//     a CI fail in steady state — the moment a contributor can't
+//     ignore the warning, it stops accumulating.
+//   - Tests relax `no-unsafe-*` (they construct lots of partial
+//     mocks that the type system can't prove safe).
+
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: [
+      'dist/**',
+      'coverage/**',
+      'prisma/migrations/**',
+      'node_modules/**',
+      // Generated Prisma artifacts under @prisma/client live in
+      // node_modules/.prisma but a stray check-in could land in src/
+      // — exclude defensively.
+      '**/*.generated.ts',
+      // Vitest config is a Vite-style mjs/ts at workspace root and is
+      // not in any tsconfig's "include" — type-aware lint can't parse
+      // it without forcing a tsconfig change.
+      'vitest.config.ts',
+      'eslint.config.mjs',
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        // `projectService: true` (TS-ESLint v8 mode) auto-discovers
+        // tsconfig.json without requiring per-rule project paths.
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      // Real-bug catches — these are why lint exists.
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/await-thenable': 'error',
+      '@typescript-eslint/no-for-in-array': 'error',
+      // Permissive (off, not warn) — large pre-existing surface and
+      // CI uses --max-warnings=0. Ratchet to warn → error in
+      // follow-up cleanup PRs scoped per-module so the ratchet can
+      // bisect cleanly. Tracking issue: TBD.
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      // Allow `_unused` parameter convention (Nest decorators often
+      // require unused-but-typed params). Off in src for the same
+      // reason as above; the typecheck still flags genuinely-dead
+      // identifiers via `noUnusedLocals` in tsconfig if enabled.
+      '@typescript-eslint/no-unused-vars': 'off',
+      // NestJS lifecycle hooks (`onModuleInit`, `onModuleDestroy`)
+      // and controller handlers are async by framework contract
+      // even when their body needs no await. False-positive density
+      // is too high to keep the rule on; rely on `no-floating-promises`
+      // to catch the real bugs.
+      '@typescript-eslint/require-await': 'off',
+    },
+  },
+  {
+    // Tests construct partial mocks the type-checker can't fully
+    // model. Relax the unsafe rules instead of forcing every
+    // fixture to be a Pick<T, …>.
+    files: ['test/**/*.ts', 'src/**/*.test.ts', 'src/**/*.spec.ts'],
+    rules: {
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      // Vitest's expect().rejects.toThrow() is a thenable; the
+      // floating-promise catch fires false-positives in tests.
+      '@typescript-eslint/no-floating-promises': 'off',
+      // Mock methods are async-by-signature for shape compatibility
+      // with the real interface; bodies often don't await anything.
+      '@typescript-eslint/require-await': 'off',
+      // Test patterns frequently use Promise.reject('shape') to
+      // inject an arbitrary error shape into a mock; the rule's
+      // requirement that the reason be an Error is too strict.
+      '@typescript-eslint/prefer-promise-reject-errors': 'off',
+      // Chai-style `expect(...)` short-circuits look like unused
+      // expressions to the rule. Vitest uses different patterns
+      // but a few legacy-shaped lines remain pre-cleanup.
+      '@typescript-eslint/no-unused-expressions': 'off',
+      // Setup-and-discard fixtures are common in cross-tenant
+      // tests (a tenantBravo seeded so the cross-tenant case has
+      // something to reject against, but not consumed by every it).
+      // Disable the gate in tests; the typecheck still flags genuinely-
+      // dead identifiers.
+      '@typescript-eslint/no-unused-vars': 'off',
+    },
+  },
+);

--- a/apps/core-api/package.json
+++ b/apps/core-api/package.json
@@ -11,7 +11,7 @@
     "start": "node dist/src/main.js",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "echo 'core-api lint — no ESLint config yet, gated by typecheck'",
+    "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
@@ -54,6 +54,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@eslint/js": "^9",
     "@nestjs/cli": "^10.4.9",
     "@nestjs/testing": "^10.4.15",
     "@swc/core": "^1.15.26",
@@ -62,6 +63,7 @@
     "@types/nodemailer": "^8.0.0",
     "eslint": "^9.16.0",
     "tsx": "^4.19.2",
+    "typescript-eslint": "^8.59.0",
     "unplugin-swc": "^1.5.9",
     "vitest": "^2.1.8"
   }

--- a/apps/core-api/src/main.ts
+++ b/apps/core-api/src/main.ts
@@ -38,7 +38,7 @@ async function bootstrap(): Promise<void> {
 }
 
 bootstrap().catch((err) => {
-  // eslint-disable-next-line no-console
+   
   console.error('Panorama core-api failed to start', err);
   process.exit(1);
 });

--- a/apps/core-api/src/modules/auth/oidc.service.ts
+++ b/apps/core-api/src/modules/auth/oidc.service.ts
@@ -149,9 +149,9 @@ export class OidcService {
     return {
       subject: claims.sub,
       email: String(claims.email).toLowerCase().trim(),
-      firstName: (claims['given_name'] as string | undefined) ?? null,
-      lastName: (claims['family_name'] as string | undefined) ?? null,
-      displayName: (claims['name'] as string | undefined) ?? null,
+      firstName: (claims['given_name']) ?? null,
+      lastName: (claims['family_name']) ?? null,
+      displayName: (claims['name']) ?? null,
       emailVerified: claims['email_verified'] === true,
       hd,
       iss: typeof claims.iss === 'string' && claims.iss.length > 0 ? claims.iss : null,

--- a/apps/core-api/src/modules/auth/session.middleware.ts
+++ b/apps/core-api/src/modules/auth/session.middleware.ts
@@ -69,6 +69,8 @@ export class SessionMiddleware implements NestMiddleware {
       actorEmail: session?.email ?? null,
     };
 
-    runInContext(ctx, () => next());
+    await runInContext(ctx, () => {
+      next();
+    });
   }
 }

--- a/apps/core-api/src/modules/import/import.service.ts
+++ b/apps/core-api/src/modules/import/import.service.ts
@@ -342,7 +342,7 @@ export class ImportService {
         data: {
           tenantId,
           name: fixture.name,
-          kind: fixture.kind as CategoryKind,
+          kind: fixture.kind,
         },
       });
       await this.recordMapping(
@@ -521,7 +521,7 @@ export class ImportService {
           tag: fixture.tag,
           name: fixture.name,
           serial: fixture.serial ?? null,
-          status: fixture.status as AssetStatus,
+          status: fixture.status,
           bookable: fixture.bookable,
           customFields: fixture.customFields as Prisma.InputJsonValue,
         },

--- a/apps/core-api/src/modules/inspection/inspection-photo.service.ts
+++ b/apps/core-api/src/modules/inspection/inspection-photo.service.ts
@@ -253,7 +253,7 @@ export class InspectionPhotoService {
             width: sanitised.width,
             height: sanitised.height,
             capturedAt: sanitised.capturedAt,
-            exifStripped: sanitised.inputMetadataFields as unknown as Prisma.InputJsonValue,
+            exifStripped: sanitised.inputMetadataFields,
             uploadedByUserId: actor.userId,
           },
         });

--- a/apps/core-api/src/modules/inspection/inspection-template.dto.ts
+++ b/apps/core-api/src/modules/inspection/inspection-template.dto.ts
@@ -47,7 +47,7 @@ export type InspectionTemplateItemInput = z.infer<
   typeof InspectionTemplateItemInputSchema
 >;
 
-const TemplateScopeRefine = (v: { categoryKind?: unknown; categoryId?: unknown | null }) => {
+const TemplateScopeRefine = (v: { categoryKind?: unknown; categoryId?: unknown }) => {
   // The CHECK constraint reads "exactly one set". We mirror it with a
   // strict XOR — an admin mis-setting both gets a clean 400 instead
   // of a Postgres CHECK error message that leaks the constraint name.

--- a/apps/core-api/src/modules/inspection/inspection.service.ts
+++ b/apps/core-api/src/modules/inspection/inspection.service.ts
@@ -176,7 +176,7 @@ export class InspectionService {
         data: {
           tenantId: actor.tenantId,
           templateId: template.id,
-          templateSnapshot: snapshotParse.data as unknown as Prisma.InputJsonValue,
+          templateSnapshot: snapshotParse.data,
           assetId: input.assetId,
           reservationId: input.reservationId ?? null,
           startedByUserId: actor.userId,
@@ -340,7 +340,7 @@ export class InspectionService {
         where: { id: inspectionId },
         data: {
           status: 'COMPLETED',
-          outcome: input.outcome as InspectionOutcome,
+          outcome: input.outcome,
           summaryNote: input.summaryNote ?? null,
           completedAt: new Date(),
           completedByUserId: actor.userId,

--- a/apps/core-api/src/modules/invitation/invitation-email.queue.ts
+++ b/apps/core-api/src/modules/invitation/invitation-email.queue.ts
@@ -94,7 +94,7 @@ export class BullMqInvitationQueue
       const attemptsMade = job?.attemptsMade ?? 0;
       const attemptsAllowed = job?.opts?.attempts ?? 5;
       const terminal = attemptsMade >= attemptsAllowed;
-      const invitationId = (job?.data as InvitationEmailJobData | undefined)?.invitationId;
+      const invitationId = (job?.data)?.invitationId;
       if (!invitationId) return;
       this.invitations
         .markEmailFailed(invitationId, String(err?.message ?? err ?? 'unknown_error'), terminal)

--- a/apps/core-api/src/modules/invitation/invitation.controller.ts
+++ b/apps/core-api/src/modules/invitation/invitation.controller.ts
@@ -202,7 +202,7 @@ function requireSession(req: Request): PanoramaSession {
 
 function extractTenantIdFromBody(body: unknown): string | undefined {
   if (body && typeof body === 'object' && 'tenantId' in body) {
-    const v = (body as { tenantId: unknown }).tenantId;
+    const v = (body).tenantId;
     return typeof v === 'string' ? v : undefined;
   }
   return undefined;

--- a/apps/core-api/src/modules/invitation/invitation.service.ts
+++ b/apps/core-api/src/modules/invitation/invitation.service.ts
@@ -454,7 +454,7 @@ export class InvitationService {
           where: { tokenHash },
           include: { tenant: { select: { id: true } } },
         });
-        if (!invitation) return { state: 'invalid', reason: 'not_found' } as AcceptanceResult;
+        if (!invitation) return { state: 'invalid', reason: 'not_found' };
         if (invitation.revokedAt) return { state: 'invalid', reason: 'revoked' };
         if (invitation.acceptedAt) return { state: 'invalid', reason: 'already_accepted' };
         if (invitation.expiresAt.getTime() <= Date.now()) {

--- a/apps/core-api/src/modules/notification/notification.service.ts
+++ b/apps/core-api/src/modules/notification/notification.service.ts
@@ -75,7 +75,7 @@ export class NotificationService {
       throw new Error(`unknown_event_type:${event.eventType}`);
     }
 
-    const schema = NOTIFICATION_PAYLOAD_SCHEMAS[event.eventType as NotificationEventType];
+    const schema = NOTIFICATION_PAYLOAD_SCHEMAS[event.eventType];
     const parsed = schema.safeParse(event.payload);
     if (!parsed.success) {
       await this.audit.record({
@@ -94,7 +94,7 @@ export class NotificationService {
     }
 
     const { redacted, redactedKeys } = redactSensitive(
-      parsed.data as Record<string, unknown>,
+      parsed.data,
     );
     if (redactedKeys.length > 0) {
       this.log.warn(

--- a/apps/core-api/src/modules/photo-pipeline/photo-pipeline.service.ts
+++ b/apps/core-api/src/modules/photo-pipeline/photo-pipeline.service.ts
@@ -264,7 +264,8 @@ function collectMetadataFieldNames(md: sharp.Metadata): string[] {
     if (KNOWN_PIXEL_PROPERTIES.has(key)) continue;
     if (value === undefined || value === null) continue;
     if (Buffer.isBuffer(value) && value.length === 0) continue;
-    if (typeof value === 'object' && !Buffer.isBuffer(value) && Object.keys(value).length === 0) continue;
+    if (typeof value === 'object' && !Buffer.isBuffer(value) && Object.keys(value).length === 0)
+      continue;
     names.add(`unknown:${key}`);
   }
   return [...names];

--- a/apps/core-api/src/modules/prisma/prisma.service.ts
+++ b/apps/core-api/src/modules/prisma/prisma.service.ts
@@ -352,7 +352,12 @@ export class PrismaService extends PrismaClient implements OnModuleInit, OnModul
         );
       }
     }
-    // Unreachable — the loop above either returns or throws.
+    // Unreachable — the loop above either returns or throws. We
+    // rethrow whatever the inner code threw verbatim so the caller's
+    // catch sees the original Prisma error class (lastErr is typed
+    // unknown by `catch (err)`); the rule demands an Error subclass
+    // but rewrapping would erase the type info that callers branch on.
+    // eslint-disable-next-line @typescript-eslint/only-throw-error
     throw lastErr ?? new Error('runTxWithRetry: unexpected exit');
   }
 

--- a/apps/core-api/src/modules/snipeit-compat/snipeit-compat.service.ts
+++ b/apps/core-api/src/modules/snipeit-compat/snipeit-compat.service.ts
@@ -131,7 +131,7 @@ export class SnipeitCompatService {
     });
   }
 
-  async getHardware(tenantId: string, id: string): Promise<unknown | null> {
+  async getHardware(tenantId: string, id: string): Promise<unknown> {
     return this.prisma.runInTenant(tenantId, async (tx) => {
       const row = await tx.asset.findUnique({
         where: { id },
@@ -226,7 +226,7 @@ export class SnipeitCompatService {
     });
   }
 
-  async getUser(tenantId: string, userId: string): Promise<unknown | null> {
+  async getUser(tenantId: string, userId: string): Promise<unknown> {
     return this.prisma.runInTenant(tenantId, async (tx) => {
       const membership = await tx.tenantMembership.findUnique({
         where: { tenantId_userId: { tenantId, userId } },
@@ -362,7 +362,7 @@ export class SnipeitCompatService {
     });
   }
 
-  async getModel(tenantId: string, id: string): Promise<unknown | null> {
+  async getModel(tenantId: string, id: string): Promise<unknown> {
     return this.prisma.runInTenant(tenantId, async (tx) => {
       const row = await tx.assetModel.findUnique({
         where: { id },

--- a/apps/core-api/src/modules/tenant/tenant-admin.service.ts
+++ b/apps/core-api/src/modules/tenant/tenant-admin.service.ts
@@ -380,7 +380,8 @@ export class TenantAdminService {
 
   private isOwnerInvariantViolation(err: unknown): boolean {
     if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2010') {
-      const msg = String(err.meta?.['message'] ?? err.message ?? '');
+      const meta = err.meta?.['message'];
+      const msg = typeof meta === 'string' ? meta : String(err.message ?? '');
       return msg.includes('TENANT_MUST_HAVE_AT_LEAST_ONE_OWNER');
     }
     if (err instanceof Prisma.PrismaClientUnknownRequestError) {

--- a/apps/core-api/src/scripts/import-fixtures.ts
+++ b/apps/core-api/src/scripts/import-fixtures.ts
@@ -64,7 +64,7 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  // eslint-disable-next-line no-console
+   
   console.error('import-fixtures failed:', err);
   process.exit(1);
 });

--- a/apps/core-api/src/scripts/tenant-nominate-owner.ts
+++ b/apps/core-api/src/scripts/tenant-nominate-owner.ts
@@ -109,7 +109,7 @@ async function main(): Promise<void> {
 }
 
 main().catch((err: unknown) => {
-  // eslint-disable-next-line no-console
+   
   console.error('tenant-nominate-owner failed:', err);
   process.exit(1);
 });

--- a/apps/core-api/test/auth-oidc-email-verification.test.ts
+++ b/apps/core-api/test/auth-oidc-email-verification.test.ts
@@ -45,10 +45,10 @@ function makeService(envOverrides: Record<string, string | undefined> = {}) {
   }
 
   const cfg = new AuthConfigService();
-  const runAsSuperAdmin = vi.fn() as ReturnType<typeof vi.fn>;
+  const runAsSuperAdmin = vi.fn();
   const prisma = { runAsSuperAdmin } as unknown as PrismaService;
   const passwords = {} as unknown as PasswordService;
-  const auditRecord = vi.fn() as ReturnType<typeof vi.fn>;
+  const auditRecord = vi.fn();
   const audit = { record: auditRecord } as unknown as AuditService;
   const svc = new AuthService(prisma, passwords, cfg, audit);
   return { svc, runAsSuperAdmin, auditRecord };
@@ -306,7 +306,7 @@ describe('AuthService.loginWithOidc — email_verified gate (#28)', () => {
         }),
       ),
     ).rejects.toThrow(UnauthorizedException);
-    const meta = lastAuditMetadata(auditRecord) as Record<string, unknown>;
+    const meta = lastAuditMetadata(auditRecord);
     expect(meta.subjectHash).toMatch(/^[0-9a-f]{16}$/);
     expect(meta.subjectHash).not.toContain('google-sub-very-secret');
   });

--- a/apps/core-api/test/inspection-outcome-email-channel.test.ts
+++ b/apps/core-api/test/inspection-outcome-email-channel.test.ts
@@ -236,7 +236,7 @@ describe('InspectionOutcomeEmailChannel — defensive guards', () => {
     }) as unknown as EmailService['send'];
     channel = new InspectionOutcomeEmailChannel(
       makePrisma(FIXTURE_BASE),
-      failingEmail as unknown as EmailService,
+      failingEmail,
     );
     await expect(channel.handle(makeEvent({ payload: FAIL_PAYLOAD }))).rejects.toThrow(
       /email_send_partial_failure/,

--- a/apps/core-api/test/notification-bus.integration.test.ts
+++ b/apps/core-api/test/notification-bus.integration.test.ts
@@ -152,9 +152,9 @@ describe('notification bus integration', () => {
       passwordHash: 'x',
       Authorization: 'Bearer abc',
     });
-    expect((redacted as Record<string, unknown>)['tokenPlaintext']).toBe('<redacted>');
-    expect((redacted as Record<string, unknown>)['passwordHash']).toBe('<redacted>');
-    expect((redacted as Record<string, unknown>)['Authorization']).toBe('<redacted>');
+    expect((redacted)['tokenPlaintext']).toBe('<redacted>');
+    expect((redacted)['passwordHash']).toBe('<redacted>');
+    expect((redacted)['Authorization']).toBe('<redacted>');
     const nested = (redacted as Record<string, Record<string, unknown>>)['nested']!;
     expect(nested['apiSecret']).toBe('<redacted>');
     expect(nested['ok']).toBe(1);

--- a/apps/core-api/test/photo-pipeline.test.ts
+++ b/apps/core-api/test/photo-pipeline.test.ts
@@ -246,7 +246,7 @@ describe('PhotoPipeline.process — metadata strip', () => {
 
   it('exiftool sees zero metadata across JPEG / PNG / WebP inputs', async () => {
     if (!exiftoolAvailable) {
-      // eslint-disable-next-line no-console
+       
       console.warn('skip: exiftool binary not on PATH — install libimage-exiftool-perl to enable');
       return;
     }

--- a/apps/core-api/test/reservation-basket-batch-exhaustion.e2e.test.ts
+++ b/apps/core-api/test/reservation-basket-batch-exhaustion.e2e.test.ts
@@ -45,7 +45,7 @@ describe('reservation basket batch exhaustion', () => {
   let url: string;
   let adminDb: PrismaClient;
   let tenantId: string;
-  let assetIds: string[] = [];
+  const assetIds: string[] = [];
 
   const admin = {
     email: 'admin@basket-exh.example',

--- a/apps/core-api/test/reservation-basket.e2e.test.ts
+++ b/apps/core-api/test/reservation-basket.e2e.test.ts
@@ -37,7 +37,7 @@ describe('reservation basket e2e', () => {
   let url: string;
   let adminDb: PrismaClient;
   let tenantId: string;
-  let assetIds: string[] = [];
+  const assetIds: string[] = [];
 
   const admin = {
     email: 'admin@basket-test.example',

--- a/apps/core-api/test/snipeit-compat-auth.e2e.test.ts
+++ b/apps/core-api/test/snipeit-compat-auth.e2e.test.ts
@@ -172,7 +172,8 @@ describe('snipeit compat — PatAuthGuard e2e', () => {
     expect(audit).toBeTruthy();
     const meta = (audit?.metadata ?? {}) as Record<string, unknown>;
     expect(meta['reason']).toBe('invalid_token');
-    expect(String(meta['tokenPrefix'] ?? '')).toMatch(/^pnrm_pat_/);
+    const prefix = meta['tokenPrefix'];
+    expect(typeof prefix === 'string' ? prefix : '').toMatch(/^pnrm_pat_/);
   });
 
   it('GET /api/v1/whoami with revoked token → 401 invalid_token', async () => {

--- a/apps/core-api/test/snipeit-compat-read.e2e.test.ts
+++ b/apps/core-api/test/snipeit-compat-read.e2e.test.ts
@@ -40,7 +40,7 @@ describe('snipeit compat read endpoints e2e', () => {
   let tenantId: string;
   let adminUserId: string;
   let otherTenantId: string;
-  let assetIds: string[] = [];
+  const assetIds: string[] = [];
   let categoryId: string;
   let modelId: string;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      '@eslint/js':
+        specifier: ^9
+        version: 9.39.4
       '@nestjs/cli':
         specifier: ^10.4.9
         version: 10.4.9(@swc/core@1.15.26)
@@ -159,6 +162,9 @@ importers:
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
+      typescript-eslint:
+        specifier: ^8.59.0
+        version: 8.59.0(eslint@9.39.4)(typescript@5.7.2)
       unplugin-swc:
         specifier: ^1.5.9
         version: 1.5.9(@swc/core@1.15.26)(rollup@4.60.1)
@@ -2049,6 +2055,65 @@ packages:
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
+  '@typescript-eslint/eslint-plugin@8.59.0':
+    resolution: {integrity: sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.59.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.59.0':
+    resolution: {integrity: sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.59.0':
+    resolution: {integrity: sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.59.0':
+    resolution: {integrity: sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.0':
+    resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.59.0':
+    resolution: {integrity: sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.59.0':
+    resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.0':
+    resolution: {integrity: sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.59.0':
+    resolution: {integrity: sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.0':
+    resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@ucast/core@1.10.2':
     resolution: {integrity: sha512-ons5CwXZ/51wrUPfoduC+cO7AS1/wRb0ybpQJ9RrssossDxVy4t49QxWoWgfBDvVKsz9VXzBk9z0wqTdZ+Cq8g==}
 
@@ -2342,6 +2407,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -2372,6 +2441,10 @@ packages:
 
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2748,6 +2821,10 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2837,6 +2914,15 @@ packages:
   fast-xml-parser@5.5.8:
     resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
     hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
@@ -3021,6 +3107,10 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   import-fresh@3.3.1:
@@ -3317,6 +3407,10 @@ packages:
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
@@ -4019,6 +4113,10 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4057,6 +4155,12 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   tsconfig-paths-webpack-plugin@4.2.0:
     resolution: {integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==}
     engines: {node: '>=10.13.0'}
@@ -4091,6 +4195,13 @@ packages:
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
+  typescript-eslint@8.59.0:
+    resolution: {integrity: sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.7.2:
     resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
@@ -6305,6 +6416,97 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
+  '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.7.2))(eslint@9.39.4)(typescript@5.7.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@5.7.2)
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/type-utils': 8.59.0(eslint@9.39.4)(typescript@5.7.2)
+      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4)(typescript@5.7.2)
+      '@typescript-eslint/visitor-keys': 8.59.0
+      eslint: 9.39.4
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.7.2)
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.7.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.2)
+      '@typescript-eslint/visitor-keys': 8.59.0
+      debug: 4.4.3
+      eslint: 9.39.4
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.0(typescript@5.7.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.7.2)
+      '@typescript-eslint/types': 8.59.0
+      debug: 4.4.3
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.59.0':
+    dependencies:
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
+
+  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.7.2)':
+    dependencies:
+      typescript: 5.7.2
+
+  '@typescript-eslint/type-utils@8.59.0(eslint@9.39.4)(typescript@5.7.2)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.2)
+      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4)(typescript@5.7.2)
+      debug: 4.4.3
+      eslint: 9.39.4
+      ts-api-utils: 2.5.0(typescript@5.7.2)
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.59.0': {}
+
+  '@typescript-eslint/typescript-estree@8.59.0(typescript@5.7.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.0(typescript@5.7.2)
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@5.7.2)
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.7.2)
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.59.0(eslint@9.39.4)(typescript@5.7.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.2)
+      eslint: 9.39.4
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.59.0':
+    dependencies:
+      '@typescript-eslint/types': 8.59.0
+      eslint-visitor-keys: 5.0.1
+
   '@ucast/core@1.10.2': {}
 
   '@ucast/js@3.1.0':
@@ -6656,6 +6858,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.19: {}
@@ -6697,6 +6901,10 @@ snapshots:
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -7078,6 +7286,8 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
+  eslint-visitor-keys@5.0.1: {}
+
   eslint@9.39.4:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4)
@@ -7214,6 +7424,10 @@ snapshots:
       fast-xml-builder: 1.1.5
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fflate@0.8.2: {}
 
@@ -7435,6 +7649,8 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -7736,6 +7952,10 @@ snapshots:
   mime@1.6.0: {}
 
   mimic-fn@2.1.0: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
 
   minimatch@3.1.5:
     dependencies:
@@ -8468,6 +8688,11 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@1.1.1: {}
 
   tinyrainbow@1.2.0: {}
@@ -8495,6 +8720,10 @@ snapshots:
   tree-kill@1.2.2: {}
 
   trim-lines@3.0.1: {}
+
+  ts-api-utils@2.5.0(typescript@5.7.2):
+    dependencies:
+      typescript: 5.7.2
 
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
@@ -8539,6 +8768,17 @@ snapshots:
       mime-types: 2.1.35
 
   typedarray@0.0.6: {}
+
+  typescript-eslint@8.59.0(eslint@9.39.4)(typescript@5.7.2):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.7.2))(eslint@9.39.4)(typescript@5.7.2)
+      '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@5.7.2)
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@5.7.2)
+      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4)(typescript@5.7.2)
+      eslint: 9.39.4
+      typescript: 5.7.2
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.7.2: {}
 


### PR DESCRIPTION
Closes #66 (Wave 2d.A, extends Wave 1 #39). Follow-up tracking issue #101 for the no-unsafe-* / no-unused-vars ratchet.

Real-bug rules as error, stylistic rules off (large pre-existing surface, ratchet per-module). Verified locally: `pnpm lint` 0/0, `pnpm typecheck` clean, full suite 308/308.

LOC delta: ~160 source; pnpm-lock auto-generated 240. See commit body for details.