### PR TITLE
fix(deps): nodemailer 6.10.1 → 8.0.6 + recipient shape gate (#80)

### DIFF
--- a/apps/core-api/package.json
+++ b/apps/core-api/package.json
@@ -45,7 +45,7 @@
     "ioredis": "^5.4.1",
     "iron-session": "^8.0.4",
     "nestjs-i18n": "^10.5.1",
-    "nodemailer": "^6.9.16",
+    "nodemailer": "^8.0.5",
     "openid-client": "^5.7.1",
     "pino": "^9.5.0",
     "prisma": "5.22.0",

--- a/apps/core-api/src/modules/email/email.service.ts
+++ b/apps/core-api/src/modules/email/email.service.ts
@@ -12,6 +12,18 @@ export interface SendEmailInput {
 }
 
 /**
+ * Recipient address shape gate (#80 / SUPPLY-02).
+ *
+ * Defends against malicious group-list shapes (`g0: g1: ... gN:`)
+ * that historically crashed nodemailer's address parser via
+ * unbounded recursion (CVE-2025-14874). Even after the upstream
+ * fix, the gate is a cheap belt-and-suspenders — colon and
+ * semicolon are not legal in the local-part or domain of any
+ * normal email anyway.
+ */
+const SAFE_RECIPIENT = /^[^:;]+@[^:;]+$/;
+
+/**
  * Minimal transactional email wrapper over nodemailer. In dev the SMTP
  * target is MailHog (`localhost:1025`); in prod swap envs to SES / a
  * provider with DKIM configured. Retries and bounce handling belong
@@ -25,6 +37,9 @@ export class EmailService implements OnModuleDestroy {
   constructor(private readonly cfg: EmailConfigService) {}
 
   async send(input: SendEmailInput): Promise<{ messageId: string }> {
+    if (!SAFE_RECIPIENT.test(input.to)) {
+      throw new Error(`email_recipient_rejected: malformed shape`);
+    }
     const transporter = this.transporter();
     const info = await transporter.sendMail({
       from: `"${this.cfg.config.fromName}" <${this.cfg.config.fromAddress}>`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ importers:
         specifier: ^10.5.1
         version: 10.6.5(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-validator@0.14.4)(rxjs@7.8.2)
       nodemailer:
-        specifier: ^6.9.16
-        version: 6.10.1
+        specifier: ^8.0.5
+        version: 8.0.6
       openid-client:
         specifier: ^5.7.1
         version: 5.7.1
@@ -4166,8 +4166,8 @@ packages:
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
-  nodemailer@6.10.1:
-    resolution: {integrity: sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==}
+  nodemailer@8.0.6:
+    resolution: {integrity: sha512-Nm2XeuDwwy2wi5A+8jPWwQwNzcjNjhWdE3pVLoXEusxJqCnAPAgnBGkSmiLknbnWuOF9qraRpYZjfxqtKZ4tPw==}
     engines: {node: '>=6.0.0'}
 
   normalize-path@3.0.0:
@@ -9805,7 +9805,7 @@ snapshots:
 
   node-releases@2.0.37: {}
 
-  nodemailer@6.10.1: {}
+  nodemailer@8.0.6: {}
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
Closes #80 (SUPPLY-02). 4 advisories — CVE-2025-14874 HIGH recursive DoS via malicious address being the load-bearing one. Bumped to 8.x (Dependabot PR #21 target, supersedes that PR) + defensive `^[^:;]+@[^:;]+$` recipient gate. Email + invitation tests green; supersedes Dependabot #21.