### PR TITLE
chore(ci): .trivyignore scaffold + flip Trivy gate to blocking (#83, #68)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,26 +159,45 @@ jobs:
   container-scan:
     name: Filesystem SCA (Trivy)
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     permissions:
       contents: read
       security-events: write
-    # Report-only during 0.x bootstrap. Dependabot's automated security
-    # fixes are chewing through transitive vulns one group at a time;
-    # blocking main on that queue would stall delivery. Flip exit-code
-    # back to '1' once the transitive queue is empty.
-    continue-on-error: true
+    # Wave 2d.C / #68 — two-pass pattern.
+    #
+    # 1. SARIF pass (exit-code: 0): always uploads to the Security tab
+    #    so the dashboard reflects current state regardless of whether
+    #    the PR fails the blocking gate. `if: always()` on the upload
+    #    keeps the SARIF current even if pass 2 errors.
+    # 2. Blocking pass (exit-code: 1, --severity HIGH,CRITICAL,
+    #    --ignore-unfixed): fails the build on real risk. Suppression
+    #    of unreachable advisories goes through .trivyignore at the
+    #    repo root (Wave 3b / #83) — every entry has a justification
+    #    header per the template; PRs adding bare CVE ids without
+    #    headers must be rejected.
+    #
+    # Pinned action version (was @master) per OSSF Scorecard
+    # pinned-deps. Bumps go through deliberate review.
     steps:
       - uses: actions/checkout@v4
-      - uses: aquasecurity/trivy-action@master
+      - name: Trivy report (SARIF, never blocks)
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           scan-type: fs
           severity: HIGH,CRITICAL
           exit-code: '0'
           format: sarif
           output: trivy-results.sarif
-      - uses: github/codeql-action/upload-sarif@v3
+      - name: Upload SARIF
         if: always()
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-results.sarif
           category: trivy
+      - name: Trivy gate (blocks on HIGH/CRITICAL)
+        uses: aquasecurity/trivy-action@0.36.0
+        with:
+          scan-type: fs
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          trivyignores: .trivyignore

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,63 @@
+# .trivyignore — Panorama supply-chain advisory triage
+# Generated: 2026-04-23, commit 33ef07a (Wave 3b audit)
+# Reviewer: security-reviewer subagent
+# Policy: re-triage on each quarterly dependency refresh or when
+#         a classified-unreachable advisory becomes reachable.
+#
+# Mandatory header per .trivyignore entry (Wave 2d CI-C / #68):
+#   # CVE-YYYY-NNNN  (package@version)
+#   # Classification: TRANSITIVE_UNREACHABLE | DIRECT_UNREACHABLE
+#   # Justification: why tolerated; blast radius; compensating control
+#   # (optional) Expiry: YYYY-MM-DD  ← forced re-triage at this date
+#
+# PRs adding entries without complete headers must be rejected.
+
+# ── lodash (transitive via @nestjs/config, @nestjs/swagger) ──────────
+# CVE-2025-13465 — prototype pollution in _.unset/_.omit
+# Classification: TRANSITIVE_UNREACHABLE
+# Justification: Panorama has zero direct lodash imports. NestJS
+# internals use _.get/_.set on developer-controlled config objects;
+# _.unset/_.omit with attacker-controlled paths is not called.
+CVE-2025-13465
+
+# CVE-2026-2950 — prototype pollution bypass in _.unset/_.omit (array path)
+# Classification: TRANSITIVE_UNREACHABLE
+# Justification: Same as CVE-2025-13465 — no attacker-reachable path.
+CVE-2026-2950
+
+# CVE-2026-4800 — lodash _.template code injection via imports keys
+# Classification: TRANSITIVE_UNREACHABLE (TEMPORARY — HIGH generic severity)
+# Justification: NestJS internals do not pass untrusted input to
+# _.template options.imports. No direct lodash usage in Panorama.
+# MANDATORY RE-TRIAGE: when @nestjs/config ships lodash >=4.18.0,
+# remove this entry and verify the transitive is resolved.
+# Expiry: 2026-07-23 (90 days)
+CVE-2026-4800
+
+# ── js-yaml (transitive via @nestjs/swagger) ─────────────────────────
+# CVE-2025-64718 — prototype pollution in yaml merge (<<)
+# Classification: TRANSITIVE_UNREACHABLE
+# Justification: @nestjs/swagger uses js-yaml to parse developer-
+# authored OpenAPI spec at build/boot time. No untrusted YAML.
+CVE-2025-64718
+
+# ── @nestjs/core ─────────────────────────────────────────────────────
+# CVE-2026-35515 — SSE stream injection via unsanitised type/id fields
+# Classification: DIRECT_UNREACHABLE
+# Justification: Panorama has zero @Sse decorators or SseStream usage.
+# If SSE is added, this must be re-triaged.
+CVE-2026-35515
+
+# ── fast-xml-parser (transitive via @aws-sdk/client-s3) ──────────────
+# CVE-2026-41650 — XML comment/CDATA injection in XMLBuilder
+# Classification: TRANSITIVE_UNREACHABLE
+# Justification: AWS SDK uses fast-xml-parser only to PARSE S3 XML
+# responses, not to build XML. XMLBuilder.buildTextValNode not called.
+CVE-2026-41650
+
+# ── uuid (transitive via bullmq) ─────────────────────────────────────
+# GHSA-w5hq-g745-h8pq — missing bounds check in v3/v5/v6 with buf arg
+# Classification: TRANSITIVE_UNREACHABLE
+# Justification: BullMQ uses uuid.v4() for job IDs. v3/v5/v6 with custom
+# buffer are not called.
+GHSA-w5hq-g745-h8pq


### PR DESCRIPTION
Closes #83 (Wave 3b SUPPLY-TRIVY) and #68 (Wave 2d CI-C). Bundle because they only make sense together. .trivyignore has 7 justified entries (one with 90-day expiry); CI Trivy step uses two-pass pattern (SARIF always-uploads + blocking gate on HIGH/CRITICAL with ignore-unfixed); action pinned @0.36.0 (was @master); runs on PRs now.