### PR TITLE
fix(core-api): migrate 4-service runAsSuperAdmin to runInTenant (#56)

### DIFF
--- a/apps/core-api/src/modules/auth/personal-access-token.service.ts
+++ b/apps/core-api/src/modules/auth/personal-access-token.service.ts
@@ -138,7 +138,8 @@ export class PersonalAccessTokenService {
     const tokenPrefix = `${PAT_PLAINTEXT_PREFIX}${secret.slice(0, 8)}`;
 
     try {
-      const token = await this.prisma.runAsSuperAdmin(
+      const token = await this.prisma.runInTenant(
+        params.actor.tenantId,
         async (tx) => {
           const created = await tx.personalAccessToken.create({
             data: {
@@ -170,7 +171,6 @@ export class PersonalAccessTokenService {
           });
           return created;
         },
-        { reason: `pat:mint:${params.actor.userId}` },
       );
       return { token, plaintext };
     } catch (err) {
@@ -187,7 +187,8 @@ export class PersonalAccessTokenService {
   // ---------------------------------------------------------------------
 
   async revoke(params: RevokePatParams): Promise<PersonalAccessToken> {
-    return this.prisma.runAsSuperAdmin(
+    return this.prisma.runInTenant(
+      params.actor.tenantId,
       async (tx) => {
         const existing = await tx.personalAccessToken.findUnique({
           where: { id: params.tokenId },
@@ -222,7 +223,6 @@ export class PersonalAccessTokenService {
         });
         return updated;
       },
-      { reason: `pat:revoke:${params.tokenId}` },
     );
   }
 
@@ -243,14 +243,14 @@ export class PersonalAccessTokenService {
     if (!params.includeRevoked) {
       where.revokedAt = null;
     }
-    return this.prisma.runAsSuperAdmin(
+    return this.prisma.runInTenant(
+      params.actor.tenantId,
       (tx) =>
         tx.personalAccessToken.findMany({
           where,
           orderBy: [{ createdAt: 'desc' }],
           take: params.limit ?? 50,
         }),
-      { reason: `pat:list:${params.actor.userId}` },
     );
   }
 

--- a/apps/core-api/src/modules/invitation/invitation.service.ts
+++ b/apps/core-api/src/modules/invitation/invitation.service.ts
@@ -190,7 +190,8 @@ export class InvitationService {
     const normalizedEmail = params.email.toLowerCase().trim();
 
     try {
-      const result = await this.prisma.runAsSuperAdmin(
+      const result = await this.prisma.runInTenant(
+        params.tenantId,
         async (tx) => {
           const tenant = await tx.tenant.findUnique({
             where: { id: params.tenantId },
@@ -210,6 +211,35 @@ export class InvitationService {
             );
           }
           const expiresAt = new Date(Date.now() + finalTtl * 1000);
+
+          // Open-invitation pre-check. The DB has a partial unique
+          // index `invitations_one_open_per_tenant_email` with the
+          // predicate `acceptedAt IS NULL AND revokedAt IS NULL`
+          // (no expiry clause — expired-but-not-swept rows still
+          // occupy the slot until the hourly sweep runs). Under
+          // runInTenant + FORCE RLS Prisma's P2002 error loses the
+          // constraint name (`meta.target = '(not available)'`),
+          // so the post-fail catch can't translate the violation
+          // to a clean 409. Explicit pre-check makes the conflict
+          // detection deterministic. The predicate must match the
+          // index EXACTLY — including the absence of the expiry
+          // clause — so an expired row also surfaces as 409, not 500.
+          // There remains a millisecond-race window where two
+          // concurrent creates both pass the pre-check and the
+          // second one's INSERT raises P2002 — that path is still
+          // translated by isOpenInvitationCollision.
+          const openMatch = await tx.invitation.findFirst({
+            where: {
+              tenantId: tenant.id,
+              email: normalizedEmail,
+              acceptedAt: null,
+              revokedAt: null,
+            },
+            select: { id: true },
+          });
+          if (openMatch) {
+            throw new ConflictException('open_invitation_exists');
+          }
 
           const targetUser = await tx.user.findUnique({
             where: { email: normalizedEmail },
@@ -250,7 +280,6 @@ export class InvitationService {
 
           return { created, plaintext, tenant };
         },
-        { reason: `invitation:create:${params.tenantId}` },
       );
 
       // Post-commit enqueue. Plaintext token travels in the payload —
@@ -293,7 +322,8 @@ export class InvitationService {
   // ---------------------------------------------------------------------
 
   async resend(params: ResendInvitationParams): Promise<InvitationCreatedView> {
-    const result = await this.prisma.runAsSuperAdmin(
+    const result = await this.prisma.runInTenant(
+      params.tenantId,
       async (tx) => {
         const existing = await tx.invitation.findUnique({
           where: { id: params.invitationId },
@@ -328,7 +358,6 @@ export class InvitationService {
 
         return { updated, plaintext };
       },
-      { reason: `invitation:resend:${params.invitationId}` },
     );
 
     this.queue
@@ -356,7 +385,8 @@ export class InvitationService {
   // ---------------------------------------------------------------------
 
   async revoke(params: RevokeInvitationParams): Promise<void> {
-    await this.prisma.runAsSuperAdmin(
+    await this.prisma.runInTenant(
+      params.tenantId,
       async (tx) => {
         const existing = await tx.invitation.findUnique({
           where: { id: params.invitationId },
@@ -380,7 +410,6 @@ export class InvitationService {
           metadata: { email: existing.email, role: existing.role },
         });
       },
-      { reason: `invitation:revoke:${params.invitationId}` },
     );
   }
 
@@ -544,14 +573,14 @@ export class InvitationService {
   // ---------------------------------------------------------------------
 
   async list(params: ListInvitationsParams): Promise<InvitationListItemView[]> {
-    const rows = await this.prisma.runAsSuperAdmin(
+    const rows = await this.prisma.runInTenant(
+      params.tenantId,
       (tx) =>
         tx.invitation.findMany({
           where: { tenantId: params.tenantId },
           orderBy: { createdAt: 'desc' },
           take: params.limit ?? 100,
         }),
-      { reason: `invitation:list:${params.tenantId}` },
     );
     const filtered = rows.filter((r) => this.matchStatus(r, params.status));
     return filtered.map((r) => this.toListItem(r));

--- a/apps/core-api/src/modules/reservation/blackout.service.ts
+++ b/apps/core-api/src/modules/reservation/blackout.service.ts
@@ -59,7 +59,8 @@ export class BlackoutService {
     if (params.startAt >= params.endAt) {
       throw new BadRequestException('start_must_be_before_end');
     }
-    return this.prisma.runAsSuperAdmin(
+    return this.prisma.runInTenant(
+      actor.tenantId,
       async (tx) => {
         if (params.assetId) {
           const asset = await tx.asset.findUnique({
@@ -96,7 +97,6 @@ export class BlackoutService {
         });
         return created;
       },
-      { reason: `blackout:create:${actor.tenantId}` },
     );
   }
 
@@ -106,20 +106,21 @@ export class BlackoutService {
     if (assetId) where.OR = [{ assetId }, { assetId: null }];
     if (to) where.startAt = { lte: to };
     if (from) where.endAt = { gte: from };
-    return this.prisma.runAsSuperAdmin(
+    return this.prisma.runInTenant(
+      actor.tenantId,
       (tx) =>
         tx.blackoutSlot.findMany({
           where,
           orderBy: { startAt: 'asc' },
           take: limit,
         }),
-      { reason: `blackout:list:${actor.tenantId}` },
     );
   }
 
   async delete(params: { actor: BlackoutContext; blackoutId: string }): Promise<void> {
     this.assertAdmin(params.actor);
-    await this.prisma.runAsSuperAdmin(
+    await this.prisma.runInTenant(
+      params.actor.tenantId,
       async (tx) => {
         const existing = await tx.blackoutSlot.findUnique({
           where: { id: params.blackoutId },
@@ -142,7 +143,6 @@ export class BlackoutService {
           },
         });
       },
-      { reason: `blackout:delete:${params.blackoutId}` },
     );
   }
 

--- a/apps/core-api/src/modules/snipeit-compat/pat-auth.guard.ts
+++ b/apps/core-api/src/modules/snipeit-compat/pat-auth.guard.ts
@@ -160,7 +160,8 @@ export class PatAuthGuard implements CanActivate {
     if (cached !== null) return cached;
 
     try {
-      const row = await this.prisma.runAsSuperAdmin(
+      const row = await this.prisma.runInTenant(
+        token.tenantId,
         (tx) =>
           tx.tenantMembership.findUnique({
             where: {
@@ -168,7 +169,6 @@ export class PatAuthGuard implements CanActivate {
             },
             select: { status: true },
           }),
-        { reason: `pat:membership_check:${token.userId}:${token.tenantId}` },
       );
       const status: 'active' | 'suspended' | 'not_a_member' = !row
         ? 'not_a_member'
@@ -231,7 +231,8 @@ export class PatAuthGuard implements CanActivate {
     if (isFirstUse || isDormantReuse) {
       // Synchronous write + audit so the admin-visible "first used"
       // / "woken up from dormant" signal is never lost on a crash.
-      await this.prisma.runAsSuperAdmin(
+      await this.prisma.runInTenant(
+        token.tenantId,
         async (tx) => {
           await tx.personalAccessToken.update({
             where: { id: token.id },
@@ -252,20 +253,17 @@ export class PatAuthGuard implements CanActivate {
             },
           });
         },
-        { reason: `pat:touch_first_or_dormant:${token.id}` },
       );
     } else {
       // Hot path — fire-and-forget timestamp refresh. A dropped
       // update just leaves lastUsedAt stale; rate-limiter metrics
       // are the audit source of truth per ADR-0010.
       this.prisma
-        .runAsSuperAdmin(
-          (tx) =>
-            tx.personalAccessToken.update({
-              where: { id: token.id },
-              data: { lastUsedAt: now },
-            }),
-          { reason: `pat:touch:${token.id}` },
+        .runInTenant(token.tenantId, (tx) =>
+          tx.personalAccessToken.update({
+            where: { id: token.id },
+            data: { lastUsedAt: now },
+          }),
         )
         .catch((err) =>
           this.log.warn({ err: String(err), tokenId: token.id }, 'pat_last_used_async_failed'),

--- a/apps/core-api/test/invitations.e2e.test.ts
+++ b/apps/core-api/test/invitations.e2e.test.ts
@@ -435,6 +435,30 @@ describe('invitation flow e2e', () => {
     expect(body.reason).toBe('expired');
   });
 
+  it('expired-but-not-swept invite → second create for same email returns 409 (not 500)', async () => {
+    // Regression for the runInTenant/RLS migration (#56): the partial
+    // unique index `invitations_one_open_per_tenant_email` is keyed
+    // on (tenantId, email) WHERE acceptedAt IS NULL AND revokedAt IS NULL,
+    // with no expiry clause. An expired-but-not-swept row still occupies
+    // the slot. The pre-check inside InvitationService.create must
+    // mirror the index predicate exactly so a duplicate-on-expired
+    // surfaces as 409, not as a 500 from a P2002 whose meta.target
+    // RLS strips to '(not available)'.
+    const adminCookie = await loginCookie(admin.email, admin.password);
+    const first = await createInvitation(adminCookie, 'collide@invitation-test.example');
+    if (!('token' in first.body)) throw new Error('expected first create to succeed');
+
+    const adminDb = new PrismaClient({ datasources: { db: { url: ADMIN_URL } } });
+    await adminDb.invitation.update({
+      where: { id: first.body.id },
+      data: { expiresAt: new Date(Date.now() - 1000) },
+    });
+    await adminDb.$disconnect();
+
+    const second = await createInvitation(adminCookie, 'collide@invitation-test.example');
+    expect(second.status).toBe(409);
+  });
+
   it('GET /invitations?tenantId= lists invitations for admin', async () => {
     const cookie = await loginCookie(admin.email, admin.password);
     const res = await fetch(`${url}/invitations?tenantId=${tenantAcme}&status=all&limit=50`, {


### PR DESCRIPTION
Closes #56 (RLS-02/03/05/06). 13 tenant-scoped sites across blackout, PAT service, PAT-guard, invitation migrated. 6 sites legitimately stay on runAsSuperAdmin (token-driven pre-tenant + worker callbacks + cross-tenant sweep).

Includes invitation-create collision pre-check fix — index-aligned predicate (no expiresAt clause) + regression test for expired-row case. security-reviewer round 1 BLOCK closed.

309/309 tests green. typecheck unchanged. Follow-up #115 for threading tenantId through invitation BullMQ payload.