### PR TITLE
chore(ci): runAsSuperAdmin allowlist gate (#58)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
       # must contain migration.sql + ROLLBACK.md + exactly one of
       # rls.sql / NO_RLS.md. Fails CI on any drift.
       - run: pnpm migrations:check
+      # Closes Wave 2 RLS-CI / #58 — every prisma.runAsSuperAdmin
+      # call site is budgeted in .runAsSuperAdmin.allowlist.json.
+      # Drift requires either migrating to runInTenant or raising
+      # the budget with security-reviewer sign-off.
+      - run: pnpm rls:allowlist-check
 
   test:
     name: Unit tests

--- a/.runAsSuperAdmin.allowlist.json
+++ b/.runAsSuperAdmin.allowlist.json
@@ -1,0 +1,47 @@
+{
+  "_doc": "Allowlist gate for prisma.runAsSuperAdmin call sites. Closes #58 (RLS-CI). Each entry is a file path + the count of CURRENTLY-JUSTIFIED runAsSuperAdmin calls in it + a one-line rationale. The CI script `scripts/check-runAsSuperAdmin-allowlist.ts` compares the actual count against the budget and fails if a file exceeds its budget. Lower the budget when a site migrates to runInTenant; raise only with reviewer sign-off documenting why a tenant-scoped op needs the privileged path.",
+  "_review_policy": "Any PR that raises a budget MUST be reviewed by security-reviewer. Lowering a budget is encouraged.",
+  "_last_audit": "2026-04-26 — post Bucket D (#55, #56, #57) RLS migration.",
+  "files": {
+    "apps/core-api/src/modules/audit/audit.service.ts": {
+      "budget": 1,
+      "rationale": "AuditService.record() opens its own tx via runAsSuperAdmin so the chain head read can see all tenants. Architectural escape per ADR-0011."
+    },
+    "apps/core-api/src/modules/auth/auth.service.ts": {
+      "budget": 6,
+      "rationale": "Login flows: identity lookup runs before tenant context exists (the credential IS what selects the tenant)."
+    },
+    "apps/core-api/src/modules/auth/discovery.service.ts": {
+      "budget": 1,
+      "rationale": "Email-domain → tenant discovery runs before any session, no tenant context."
+    },
+    "apps/core-api/src/modules/auth/personal-access-token.service.ts": {
+      "budget": 1,
+      "rationale": "findByPlaintext: the token IS what determines the tenant; lookup is pre-tenant-context."
+    },
+    "apps/core-api/src/modules/import/import.service.ts": {
+      "budget": 2,
+      "rationale": "Import flow runs as a privileged batch operation under operator credentials, not session-bound."
+    },
+    "apps/core-api/src/modules/inspection/inspection-maintenance.service.ts": {
+      "budget": 2,
+      "rationale": "Cross-tenant photo retention sweep + cluster-wide sweep candidates per ADR-0012 §11."
+    },
+    "apps/core-api/src/modules/invitation/invitation-email.queue.ts": {
+      "budget": 2,
+      "rationale": "BullMQ worker processes jobs whose payload only carries invitationId — pending #115 follow-up to thread tenantId through the payload."
+    },
+    "apps/core-api/src/modules/invitation/invitation.service.ts": {
+      "budget": 6,
+      "rationale": "Six legitimate cross-tenant / pre-tenant paths: previewAcceptance + finalizeAccept (token-driven, pre-tenant); markEmailSent + markEmailFailed + rotateTokenForRescue (worker callbacks; #115 to resolve); sweepExpired (cross-tenant background sweep)."
+    },
+    "apps/core-api/src/modules/notification/notification.dispatcher.ts": {
+      "budget": 5,
+      "rationale": "Notification dispatcher is by-design cross-tenant — claims jobs across tenants, dispatches, marks. ADR-0011 explicitly authorises."
+    },
+    "apps/core-api/src/modules/tenant/tenant-admin.service.ts": {
+      "budget": 2,
+      "rationale": "createTenantWithOwner (pre-tenant — birthing the row) + nominateOwner (admin tooling: lookup tenant by slug across cluster)."
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "license:check": "tsx scripts/license-check.ts",
     "migrations:check": "tsx scripts/check-migration-conventions.ts",
     "ensure:community-complete": "tsx scripts/ensure-community-complete.ts",
+    "rls:allowlist-check": "tsx scripts/check-runAsSuperAdmin-allowlist.ts",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",

--- a/scripts/check-runAsSuperAdmin-allowlist.ts
+++ b/scripts/check-runAsSuperAdmin-allowlist.ts
@@ -1,0 +1,149 @@
+/**
+ * RLS-CI allowlist gate (Wave 2 RLS-CI / #58).
+ *
+ * Counts `prisma.runAsSuperAdmin(` invocations per source file under
+ * `apps/core-api/src` and compares against the budget defined in
+ * `.runAsSuperAdmin.allowlist.json` at the repo root. Fails CI if:
+ *
+ *   - A file's actual count exceeds its allowlist budget (drift)
+ *   - A new file appears with non-zero count and is not in the allowlist
+ *
+ * Also flags (warning, not failing) when a file's actual count is BELOW
+ * its budget — that's an opportunity to lower the budget, encouraging
+ * the ratchet-down direction.
+ *
+ * Detection is regex-based on `\.runAsSuperAdmin\s*\(` against TS source.
+ * Comments and JSDoc references are filtered out by skipping lines that
+ * start with `*` or `//`.
+ *
+ * Exit codes:
+ *   0 — allowlist matches reality
+ *   1 — drift detected (PR must adjust the allowlist with reviewer
+ *       sign-off, OR migrate the new call to runInTenant)
+ *   2 — scan error
+ */
+
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = new URL('..', import.meta.url);
+const SCAN_DIR = 'apps/core-api/src';
+const ALLOWLIST_PATH = '.runAsSuperAdmin.allowlist.json';
+const CALL_REGEX = /\.runAsSuperAdmin\s*\(/;
+
+interface AllowlistEntry {
+  budget: number;
+  rationale: string;
+}
+
+interface Allowlist {
+  files: Record<string, AllowlistEntry>;
+}
+
+async function walkDirectory(dir: string, out: string[]): Promise<void> {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw err;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      await walkDirectory(join(dir, entry.name), out);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith('.ts') && !entry.name.endsWith('.tsx')) continue;
+    out.push(join(dir, entry.name));
+  }
+}
+
+async function countCallsInFile(path: string): Promise<number> {
+  const body = await fs.readFile(path, 'utf8');
+  let count = 0;
+  for (const raw of body.split('\n')) {
+    const trimmed = raw.trimStart();
+    if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue;
+    if (CALL_REGEX.test(raw)) count += 1;
+  }
+  return count;
+}
+
+async function main(): Promise<void> {
+  const repoRoot = ROOT.pathname.replace(/\/$/, '');
+  const allowlistRaw = await fs.readFile(join(repoRoot, ALLOWLIST_PATH), 'utf8');
+  const allowlist = JSON.parse(allowlistRaw) as Allowlist;
+
+  const files: string[] = [];
+  await walkDirectory(join(repoRoot, SCAN_DIR), files);
+
+  const actual = new Map<string, number>();
+  for (const path of files) {
+    const count = await countCallsInFile(path);
+    if (count > 0) {
+      const repoRel = path.slice(repoRoot.length + 1);
+      actual.set(repoRel, count);
+    }
+  }
+
+  const violations: string[] = [];
+  const warnings: string[] = [];
+
+  for (const [file, count] of actual) {
+    const entry = allowlist.files[file];
+    if (!entry) {
+      violations.push(
+        `  ${file}: ${count} unallowlisted call(s). ` +
+          `Either migrate to runInTenant or add an entry to .runAsSuperAdmin.allowlist.json with reviewer sign-off.`,
+      );
+      continue;
+    }
+    if (count > entry.budget) {
+      violations.push(
+        `  ${file}: ${count} calls (budget ${entry.budget}). ` +
+          `Drift requires either migrating new sites to runInTenant or raising the budget with security-reviewer approval.`,
+      );
+    } else if (count < entry.budget) {
+      warnings.push(
+        `  ${file}: ${count} calls (budget ${entry.budget}). ` +
+          `A site migrated; lower the budget in the allowlist to lock in the ratchet.`,
+      );
+    }
+  }
+
+  for (const file of Object.keys(allowlist.files)) {
+    if (!actual.has(file)) {
+      warnings.push(
+        `  ${file}: allowlist entry but zero calls in source. Remove the entry.`,
+      );
+    }
+  }
+
+  if (warnings.length > 0) {
+    console.log('runAsSuperAdmin allowlist — ratchet opportunities:');
+    for (const w of warnings) console.log(w);
+    console.log();
+  }
+
+  if (violations.length > 0) {
+    console.error('runAsSuperAdmin allowlist VIOLATIONS:');
+    for (const v of violations) console.error(v);
+    console.error(
+      `\n${violations.length} violation${violations.length === 1 ? '' : 's'}. ` +
+        'See ADR-0015 + .runAsSuperAdmin.allowlist.json for the policy.',
+    );
+    process.exit(1);
+  }
+
+  const total = [...actual.values()].reduce((a, b) => a + b, 0);
+  console.log(
+    `runAsSuperAdmin allowlist OK — ${total} calls across ${actual.size} files.`,
+  );
+}
+
+main().catch((err) => {
+  console.error('check-runAsSuperAdmin-allowlist failed unexpectedly:', err);
+  process.exit(2);
+});


### PR DESCRIPTION
Closes #58 (RLS-CI), final PR of Bucket D. .runAsSuperAdmin.allowlist.json snapshots the post-Bucket-D state (28 calls / 10 files, all justified). check-runAsSuperAdmin-allowlist.ts fails CI on drift, warns on ratchet opportunities. Bucket D total: 25 sites migrated across PRs #114, #116, #117, plus this CI gate.