### PR TITLE
chore(infra): pin Docker compose images (minio, mailhog, mc)

### DIFF
--- a/infra/docker/compose.dev.yml
+++ b/infra/docker/compose.dev.yml
@@ -33,7 +33,7 @@ services:
       retries: 10
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     restart: unless-stopped
     command: server /data --console-address ':9001'
     environment:
@@ -51,7 +51,7 @@ services:
       retries: 10
 
   mailhog:
-    image: mailhog/mailhog:latest
+    image: mailhog/mailhog:v1.0.1
     restart: unless-stopped
     ports:
       - '1025:1025'  # SMTP

--- a/infra/docker/compose.prod.yml
+++ b/infra/docker/compose.prod.yml
@@ -53,7 +53,7 @@ services:
       retries: 10
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     restart: unless-stopped
     command: server /data --console-address ':9001'
     environment:
@@ -74,7 +74,7 @@ services:
   # if bucket exists). Required so the core-api's bootstrap SSRF check can
   # succeed and so InspectionPhotoService.upload doesn't 503 on first call.
   minio-init:
-    image: minio/mc:latest
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
Replaces `:latest` floating tags in compose.dev/prod with specific releases. minio:latest → RELEASE.2025-09-07; mc:latest → RELEASE.2025-08-13; mailhog:latest → v1.0.1 (project dormant, permanent). OSSF Scorecard pinned-deps + dev reproducibility.