### PR TITLE
docs(governance): accept ADR-0017, MCP guidance, pilot scope lock (#85, #86, #87)

### DIFF
--- a/.claude/agents/ai-architect.md
+++ b/.claude/agents/ai-architect.md
@@ -60,6 +60,21 @@ now — don't invent work. But when an AI feature proposal appears
    (plan → act → observe) must have a hard step-count cap + a cost
    cap + a timeout. Runaway loops are a reliability + billing
    failure mode.
+7. **MCP / tool-server config files committed to the repo.** Per
+   ADR-0017 §"Configuration is execution surface" (accepted
+   2026-04-26 in response to the 2026-04-20 OX Security disclosure
+   of CVE-2025-49596 et al.), any MCP or tool-server connection
+   config that ships in git is treated as authorisation grant —
+   reviewer-required, allowlisted, and isolated. Default posture:
+   tool servers run in a sandbox with the absolute minimum
+   filesystem + network surface; STDIO-transport tool servers that
+   inherit parent-process credentials are forbidden without an ADR
+   amendment. Cross-link: `docs/runbooks/dev-environment-ai-tooling.md`
+   for the contributor-side allowlist + incident-response path.
+8. **AI-generated code without provenance.** When the LLM emits
+   code that lands in a PR, the commit body MUST carry the
+   `Assisted-By: <model> <provenance>` trailer per the user-level
+   CONTRIBUTING convention. NEVER `Co-Authored-By:`.
 
 ## Default lines you push
 

--- a/docs/adr/0017-ai-llm-integration-principles.md
+++ b/docs/adr/0017-ai-llm-integration-principles.md
@@ -1,9 +1,9 @@
 # ADR-0017: AI/LLM integration principles
 
-- Status: **Draft** (drafted 2026-04-23 from Wave 3b audit; pending maintainer acceptance)
-- Date: 2026-04-23
-- Deciders: TBD (maintainer + ai-architect + security-reviewer)
-- Related: ADR-0006 (plugin-sdk), `.claude/agents/ai-architect.md`
+- Status: **Accepted** (drafted 2026-04-23 from Wave 3b audit; accepted 2026-04-26 by maintainer — policy precedes first AI feature per the Wave 3 §"Decisions needing maintainer input" recommendation; zero AI features in production today, so accepting now lets every future AI ADR cite this ADR as the standing constraint)
+- Date: 2026-04-23 drafted; 2026-04-26 accepted
+- Deciders: Vitor Rodovalho (maintainer)
+- Related: ADR-0006 (plugin-sdk), `.claude/agents/ai-architect.md`, `docs/runbooks/dev-environment-ai-tooling.md`
 
 ## Context
 

--- a/docs/audits/PILOT-SCOPE-LOCK-2026-04-26.md
+++ b/docs/audits/PILOT-SCOPE-LOCK-2026-04-26.md
@@ -1,0 +1,45 @@
+# Pilot scope lock — 2026-04-26
+
+Maintainer commitment to the won't-ship-for-pilot list documented in
+`docs/audits/2026-04-23-wave-3.md` §"Explicit won't-ship-for-pilot"
+(line 93 of that file). Closes the §"Decisions needing maintainer
+input" item 3 from `HANDOFF-2026-04-23.md`.
+
+## Won't ship for pilot — committed
+
+Per Wave 3a Pilot readiness review:
+
+- CSV export
+- Stranded reservation flow
+- Auto-suggest maintenance from FAIL / damage flag (the Bucket B
+  manual maintenance UI ships; the auto-suggest path is 0.4)
+- Mileage / time-based PM alerts (cron + UI)
+- Training-expiry gating
+- Reservation notification emails (basic invitation email ships;
+  reservation lifecycle emails are 0.4)
+- Email-bounce webhook
+- JIT tenant membership (admin-via-UI invitation is the path)
+- Snipe-IT compat shim (PAT auth ships; shim adapter layer is 0.4)
+- Mobile-responsive tables (tablet/desktop during pilot is the
+  contract; mobile polish is 0.4)
+- Saved reports / dashboards
+- Plugin SDK (per ADR-0006 strip-back path #84 — Community SDK is
+  type re-exports only at 0.3; runtime + sandboxing is 0.4+)
+- SAML / LDAP / SCIM (OIDC + invitation-link is the pilot path)
+
+## Why this matters
+
+The 2026-09 pilot timeline (per HANDOFF-2026-04-23 §Sprint Split
+Scenario A — solo maintainer) holds **only if and only if scope is
+held to this MVP cut**. Any feature creep ("while we're at it") will
+push the pilot to Q4 2026 or later.
+
+Maintainer (Vitor Rodovalho, 2026-04-26): committed.
+
+## When this list changes
+
+Re-open via a wave-N audit doc when an explicit pilot-tenant
+requirement surfaces from a real user voice (Amtrak/FDT operator,
+SnipeScheduler-FleetManager community member, etc.). Don't extend
+this list because a contributor proposes a "small while-we're-here
+addition" — those go to 0.4+ by default.

--- a/docs/runbooks/dev-environment-ai-tooling.md
+++ b/docs/runbooks/dev-environment-ai-tooling.md
@@ -46,7 +46,7 @@ Use only MCP servers on the verified list. Current list (2026-04-23):
 
 | MCP server | Purpose | Verified version | Verified by / date |
 |---|---|---|---|
-| Supabase MCP | Schema management, migrations | `<pin the version>` | `<maintainer>` / `<date>` |
+| Supabase MCP (`@supabase/mcp-server-supabase`) | Schema management, migrations | `0.7.0` | Vitor Rodovalho / 2026-04-26 |
 | _Others_ | Require maintainer approval before use | — | — |
 
 The list is short on purpose. Any MCP server not on this list is **forbidden** until reviewed and added.


### PR DESCRIPTION
Governance batch closing 4 maintainer-decision items: ADR-0017 Draft→Accepted (#85), ai-architect MCP non-negotiables added (#86), Supabase MCP version pinned in runbook (#87 + scope-lock #5 from HANDOFF-2026-04-23), pilot won't-ship-for-pilot list committed via new PILOT-SCOPE-LOCK-2026-04-26.md doc.