### PR TITLE
chore(plugin-sdk): strip runtime, narrow ADR-0006 to event-type contract (#84)

### DIFF
--- a/docs/adr/0006-plugin-sdk.md
+++ b/docs/adr/0006-plugin-sdk.md
@@ -1,8 +1,11 @@
 # ADR-0006: Plugin / extension SDK boundary
 
-- Status: Draft
-- Date: 2026-04-17
+- Status: **Accepted** (narrow scope, 2026-04-26 — see "Scope at 0.3" below)
+- Date: 2026-04-17 drafted; 2026-04-26 narrowed + accepted
 - Deciders: Vitor Rodovalho
+- Related: #84 (strip-back), ADR-0017 (AI/LLM integration principles —
+  the isolation boundary required by Principle 2 is the same boundary
+  any future plugin runtime must satisfy)
 
 ## Context
 
@@ -22,9 +25,37 @@ We need an SDK boundary that lets partners and the community:
 
 …without a hard fork and without shipping C binaries.
 
-## Decision (draft)
+## Scope at 0.3 (the strip-back)
 
-Ship `@panorama/plugin-sdk` as:
+Per #84 (audit Wave-3a finding), the runtime portions of the original
+draft are **deferred to 0.4+**. The 0.3 community surface is:
+
+- `@panorama/plugin-sdk` exports **types only** —
+  `PanoramaEventName`, `PanoramaEvent<T>`, `PluginContext`,
+  `EventHandler<T>`. No runtime helpers (`onEvent`, `PluginModule.register`)
+  are exposed. This locks the *contract* (payload shapes, event names)
+  before any external author writes code against it, while keeping the
+  attack surface zero until the isolation work lands.
+
+- The well-known event catalog is the type union `PanoramaEventName`.
+  Adding an event is a typed, type-checked change.
+
+- `manifest.json` schema, plugin loader, capability model, UI extension
+  slots, and the NestJS dynamic-module integration all move to a
+  follow-up ADR alongside the isolation infrastructure required by
+  ADR-0017 Principle 2 (worker thread with `--experimental-permission`,
+  container, or Deno isolate — `vm.runInContext` is **not** an
+  acceptable boundary).
+
+- Why the strip-back: `PluginModule.register()` and `onEvent()` were
+  loaded primitives with no isolation, no signature verification, and
+  no allowlist gate. They predated ADR-0017 and would have given
+  third-party code in-process credentials by import. Better to have
+  no plugin runtime than a wrong one.
+
+## Decision (0.4+ — deferred)
+
+When the 0.4 plugin-runtime ADR lands it will specify:
 
 1. A set of **typed hook interfaces** (TypeScript) mirroring NestJS lifecycle
    events and domain events. Plugins register providers via NestJS dynamic
@@ -34,34 +65,54 @@ Ship `@panorama/plugin-sdk` as:
    `settings.panels`, `asset.profile.tabs`).
 3. A **manifest.json** per plugin declaring required permissions, required
    env vars, and the Panorama version range it's compatible with.
-4. A **plugin loader** that isolates plugin code in a separate Node VM
-   context, with a capability-based permission model (read-only, write-own,
-   write-all, invoke-webhook).
-5. A **well-known event catalog** that plugins can subscribe to without
-   reaching into internal classes — `panorama.asset.checked_out`,
-   `panorama.reservation.approved`, etc.
+4. A **plugin loader** that runs plugin code under a real isolation
+   boundary (worker thread with `--experimental-permission`, container,
+   or Deno isolate — per ADR-0017 Principle 2). Capability model:
+   read-only, write-own, write-all, invoke-webhook, all deny-by-default.
+5. A signed-allowlist check for marketplace-sourced plugins (per
+   ADR-0017 Principle 3).
+6. The **well-known event catalog** at 0.3 (the `PanoramaEventName`
+   union) is the seed; new events at 0.4 must be additions, not
+   removals or renames, until a major version of the SDK.
 
-Plugins run in-process in Community edition (simpler ops). Enterprise edition
-may run them in a sidecar for stricter isolation (deferred).
+Plugins were originally planned to run in-process in Community edition.
+ADR-0017 retires that posture: in-process untrusted code is forbidden.
+Community will run plugins under the same isolation boundary as
+Enterprise; the only difference is the management UI.
 
 ## Alternatives considered
 
 - **Webhooks only** — safe but too limited; partners can't render UI.
-- **Embed a JS runtime (V8 isolates)** — too complex for v1.
+- **Embed a JS runtime (V8 isolates)** — too complex for v1;
+  reconsidered for 0.4 in light of ADR-0017.
 - **Laravel-style service providers** — copy-paste from Snipe-IT's pattern.
   We're in Nest, so we use Nest's dynamic modules.
+- **Keep the original Draft runtime (`onEvent` + `PluginModule.register`)
+  for 0.3.** Rejected — see Scope at 0.3 above; no isolation, no allowlist,
+  no signature verification means any plugin import was an unaudited
+  credential grant. ADR-0017 makes this posture unshippable.
 
 ## Consequences
 
 ### Positive
-- Partners / customers can extend without forking
-- Clean lane for community-contributed integrations (Fleetio, Samsara, GeoTab)
+
+- Partners / customers can extend without forking (eventually — at 0.4)
+- The event-type contract is locked early, so 0.4 plugins can be written
+  against a stable type surface today
+- Strip-back removes a credential-grant footgun before it has any callers
+- ADR-0006 no longer contradicts ADR-0017 (the older draft did)
 
 ### Negative
-- We commit to maintaining plugin API stability; breaking changes need a
-  deprecation cycle
-- Security review for the capability model takes time
+
+- We commit to maintaining plugin API stability for the type contract;
+  breaking changes to `PanoramaEventName` need a deprecation cycle even
+  with no runtime
+- 0.4 plugin-runtime work is now blocked on isolation infrastructure
+  (acceptable — that infra is also required for any AI/LLM tool runtime
+  per ADR-0017, so the work is shared)
 
 ### Neutral
-- Status stays Draft until the first plugin ships (probably a Teams
-  connector in Community, since we already have FleetManager equivalent logic)
+
+- The `Status: Accepted (narrow scope)` framing is deliberate: future
+  ADRs will cover the runtime, manifest, capability model, and UI slot
+  layer as separate decisions. Each gets its own threat model.

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,26 +1,19 @@
 {
   "name": "@panorama/plugin-sdk",
   "version": "0.0.0",
-  "description": "Panorama plugin SDK — typed extension surface.",
+  "description": "Panorama plugin SDK — typed event contract (types-only at 0.3 per ADR-0006).",
   "license": "AGPL-3.0-or-later",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": ["dist"],
   "scripts": {
     "build": "tsc",
-    "test": "echo 'plugin-sdk — real tests land with first plugin in 0.4'",
+    "test": "echo 'plugin-sdk — runtime + tests land with first plugin in 0.4'",
     "lint": "echo 'plugin-sdk lint — no ESLint config yet, gated by typecheck'",
     "typecheck": "tsc --noEmit",
     "clean": "rimraf dist"
   },
-  "peerDependencies": {
-    "@nestjs/common": "^10",
-    "react": "^18"
-  },
   "devDependencies": {
-    "@nestjs/common": "^10.4.15",
-    "react": "^18.3.1",
-    "typescript": "^5.6.3",
-    "vitest": "^2.1.8"
+    "typescript": "^5.6.3"
   }
 }

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -1,7 +1,13 @@
 /**
- * Public plugin SDK surface.
- * Stable contract: breaking changes follow a deprecation cycle per
- * semantic versioning of @panorama/plugin-sdk.
+ * Public plugin SDK surface — types only at 0.3.
+ *
+ * Per ADR-0006 (Accepted 2026-04-26, narrow scope per #84): this package
+ * exposes the plugin event-type contract only. The runtime loader, NestJS
+ * dynamic-module helper, and React UI-slot surface are deferred to 0.4+
+ * and will land alongside the isolation boundary required by ADR-0017.
+ *
+ * Stable contract: breaking changes to the exported types follow a
+ * deprecation cycle per semantic versioning of @panorama/plugin-sdk.
  */
 
 export type PanoramaEventName =
@@ -44,17 +50,3 @@ export type EventHandler<T = unknown> = (
   ctx: PluginContext,
   evt: PanoramaEvent<T>,
 ) => Promise<void> | void;
-
-export function onEvent<T = unknown>(
-  name: PanoramaEventName,
-  handler: EventHandler<T>,
-): { __panorama_handler: true; name: PanoramaEventName; handler: EventHandler<T> } {
-  return { __panorama_handler: true, name, handler };
-}
-
-// Re-exported by plugin authors in their server.ts:
-export const PluginModule = {
-  register<T>(cls: T): { provide: 'PANORAMA_PLUGIN_MODULE'; useValue: T } {
-    return { provide: 'PANORAMA_PLUGIN_MODULE', useValue: cls };
-  },
-};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,18 +260,9 @@ importers:
 
   packages/plugin-sdk:
     devDependencies:
-      '@nestjs/common':
-        specifier: ^10.4.15
-        version: 10.4.22(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      react:
-        specifier: ^18.3.1
-        version: 18.3.1
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
-      vitest:
-        specifier: ^2.1.8
-        version: 2.1.9(@types/node@25.6.0)(terser@5.46.1)
 
   packages/shared:
     dependencies:
@@ -9119,8 +9110,8 @@ snapshots:
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@5.9.3)
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4)
       eslint-plugin-react: 7.37.5(eslint@9.39.4)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4)
@@ -9139,7 +9130,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9150,22 +9141,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@5.9.3)
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9176,7 +9167,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
- Removes `onEvent()` and `PluginModule.register()` from `@panorama/plugin-sdk` — they predated ADR-0017 (Accepted 2026-04-26) and would have given third-party code in-process credentials by import. Zero internal or external callers, so the strip is risk-free.
- Drops `@nestjs/common` + `react` peerDeps (no longer needed for a types-only package).
- Keeps the typed event contract (`PanoramaEventName`, `PanoramaEvent<T>`, `PluginContext`, `EventHandler<T>`) so 0.4+ plugin authors can write against a stable shape.
- Flips ADR-0006 `Status: Draft → Accepted (narrow scope)`, documents the strip-back rationale, and cross-links ADR-0017 Principle 2 (real isolation boundary) as the gate for the deferred runtime.

Closes #84. Aligns ADR-0006 with ADR-0017. Aligns the community surface with the pilot-scope-lock commitment in `docs/audits/PILOT-SCOPE-LOCK-2026-04-26.md`.

## Test plan
- [x] `pnpm --filter @panorama/plugin-sdk typecheck` — clean
- [x] `pnpm --filter @panorama/plugin-sdk build` — clean
- [x] `pnpm --filter @panorama/web typecheck` — clean
- [x] `pnpm --filter @panorama/core-api typecheck` — same 3 pre-existing CJS/ESM errors as `main`, unchanged
- [x] `grep -rn "from '@panorama/plugin-sdk'"` — no consumers anywhere; strip is safe