### PR TITLE
fix(docs): wrap unfenced /maintenance/<id> in backticks (ADR-0016)

### DIFF
--- a/docs/adr/0016-asset-maintenance-flow.md
+++ b/docs/adr/0016-asset-maintenance-flow.md
@@ -839,7 +839,7 @@ back to who triggered it.
 ### Notification email
 
 The existing ADR-0012 step 6 inspection-outcome email gets a new
-line: "A draft maintenance ticket has been opened: /maintenance/<id>"
+line: `"A draft maintenance ticket has been opened: /maintenance/<id>"`
 when the subscriber fired. No extra email; the existing recipients
 learn about the ticket via the same notification.
 


### PR DESCRIPTION
## Summary
- Docs site workflow has been red on \`main\` since ADR-0016 landed (2026-04-22). VitePress wraps each markdown file as a Vue SFC; the unfenced literal \`/maintenance/<id>\` in prose was parsed as an opening HTML tag with no closer.
- Fix: wrap the example string in backticks so markdown-it escapes \`<id>\` before Vue's compiler sees it. Identical placeholders inside fenced code blocks elsewhere in the file are already safe — only line 842 was the trigger.
- Local \`pnpm docs:build\` now passes.

## Test plan
- [x] \`pnpm docs:build\` — clean
- [x] CI Docs site workflow — should go green for the first time in 4 days