### PR TITLE
fix(reservations): require mileage at checkout/checkin + write Asset.lastReadMileage (#32, #31)

### DIFF
--- a/apps/core-api/src/modules/reservation/reservation.controller.ts
+++ b/apps/core-api/src/modules/reservation/reservation.controller.ts
@@ -238,12 +238,15 @@ export class ReservationController {
   ): Promise<unknown> {
     const actor = this.actorFromSession(req);
     const parsed = CheckoutSchema.safeParse(body ?? {});
-    if (!parsed.success) throw new BadRequestException('invalid_body');
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? 'invalid_body';
+      throw new BadRequestException(message);
+    }
     const checkoutParams: Parameters<ReservationService['checkOut']>[0] = {
       actor,
       reservationId: id,
+      mileage: parsed.data.mileage,
     };
-    if (parsed.data.mileage !== undefined) checkoutParams.mileage = parsed.data.mileage;
     if (parsed.data.condition !== undefined) checkoutParams.condition = parsed.data.condition;
     const updated = await this.reservations.checkOut(checkoutParams);
     return this.shape(updated);
@@ -258,12 +261,15 @@ export class ReservationController {
   ): Promise<unknown> {
     const actor = this.actorFromSession(req);
     const parsed = CheckinSchema.safeParse(body ?? {});
-    if (!parsed.success) throw new BadRequestException('invalid_body');
+    if (!parsed.success) {
+      const message = parsed.error.issues[0]?.message ?? 'invalid_body';
+      throw new BadRequestException(message);
+    }
     const checkinParams: Parameters<ReservationService['checkIn']>[0] = {
       actor,
       reservationId: id,
+      mileage: parsed.data.mileage,
     };
-    if (parsed.data.mileage !== undefined) checkinParams.mileage = parsed.data.mileage;
     if (parsed.data.condition !== undefined) checkinParams.condition = parsed.data.condition;
     if (parsed.data.damageFlag !== undefined) checkinParams.damageFlag = parsed.data.damageFlag;
     if (parsed.data.damageNote !== undefined) checkinParams.damageNote = parsed.data.damageNote;

--- a/apps/core-api/src/modules/reservation/reservation.dto.ts
+++ b/apps/core-api/src/modules/reservation/reservation.dto.ts
@@ -82,14 +82,28 @@ export const BasketBatchRejectionSchema = z.object({
     .max(500),
 });
 
+// Mileage is REQUIRED on checkout. OPS-02 (#32): DOT 49 CFR requires
+// odometer readings on every trip, and ADR-0016's PM-due cron depends
+// on Asset.lastReadMileage, which is populated from these fields. An
+// optional mileage column was the silent bug that broke the entire
+// maintenance scheduling chain.
 export const CheckoutSchema = z.object({
-  mileage: z.number().int().nonnegative().optional(),
+  mileage: z
+    .number({ required_error: 'mileage_required', invalid_type_error: 'mileage_required' })
+    .int()
+    .nonnegative('mileage_required'),
   condition: z.string().max(2000).optional(),
 });
 export type CheckoutInput = z.infer<typeof CheckoutSchema>;
 
+// Mileage is REQUIRED on check-in too. The check-in mileage is what
+// gets written to Asset.lastReadMileage (per OPS-02 / DATA-01) — the
+// PM-due cron depends on it being a real number, not NULL.
 export const CheckinSchema = z.object({
-  mileage: z.number().int().nonnegative().optional(),
+  mileage: z
+    .number({ required_error: 'mileage_required', invalid_type_error: 'mileage_required' })
+    .int()
+    .nonnegative('mileage_required'),
   condition: z.string().max(2000).optional(),
   damageFlag: z.boolean().optional(),
   damageNote: z.string().max(2000).optional(),

--- a/apps/core-api/src/modules/reservation/reservation.service.ts
+++ b/apps/core-api/src/modules/reservation/reservation.service.ts
@@ -98,14 +98,16 @@ export interface BasketBatchResult {
 export interface CheckoutParams {
   actor: ReservationContext;
   reservationId: string;
-  mileage?: number;
+  // Required at the API boundary (OPS-02 / #32) — DOT 49 CFR + ADR-0016
+  // PM-due cron both depend on real numbers.
+  mileage: number;
   condition?: string;
 }
 
 export interface CheckinParams {
   actor: ReservationContext;
   reservationId: string;
-  mileage?: number;
+  mileage: number;
   condition?: string;
   damageFlag?: boolean;
   damageNote?: string;
@@ -862,7 +864,7 @@ export class ReservationService {
             lifecycleStatus: 'CHECKED_OUT',
             checkedOutAt: now,
             checkedOutByUserId: actor.userId,
-            mileageOut: params.mileage ?? null,
+            mileageOut: params.mileage,
             conditionOut: params.condition ?? null,
           },
         });
@@ -878,7 +880,7 @@ export class ReservationService {
           actorUserId: actor.userId,
           metadata: {
             assetId: asset.id,
-            mileage: params.mileage ?? null,
+            mileage: params.mileage,
             condition: params.condition ?? null,
             ...(preCheckoutInspectionId
               ? { preCheckoutInspectionId }
@@ -980,7 +982,6 @@ export class ReservationService {
           throw new BadRequestException('no_asset_to_checkin');
         }
         if (
-          params.mileage !== undefined &&
           existing.mileageOut !== null &&
           existing.mileageOut !== undefined &&
           params.mileage < existing.mileageOut
@@ -992,13 +993,31 @@ export class ReservationService {
         const nextAssetStatus = damageFlag ? 'MAINTENANCE' : 'READY';
         const now = new Date();
 
+        // DATA-01 / ARCH-03 (#31): write Asset.lastReadMileage so the
+        // ADR-0016 §9 PM-due cron has a real number to compare against
+        // nextServiceMileage. Monotonic guard so a stale check-in (or
+        // an out-of-order admin correction) doesn't move the column
+        // backwards. The reservation-level monotonic check above
+        // already guarantees `params.mileage >= mileageOut`, but we
+        // re-check against the asset row separately because two
+        // concurrent reservations on the same asset could race —
+        // we want the higher reading to win.
+        const existingAsset = await tx.asset.findUnique({
+          where: { id: existing.assetId },
+          select: { lastReadMileage: true },
+        });
+        const shouldUpdateMileage =
+          existingAsset === null ||
+          existingAsset.lastReadMileage === null ||
+          params.mileage > existingAsset.lastReadMileage;
+
         const updated = await tx.reservation.update({
           where: { id: reservationId },
           data: {
             lifecycleStatus: 'RETURNED',
             checkedInAt: now,
             checkedInByUserId: actor.userId,
-            mileageIn: params.mileage ?? null,
+            mileageIn: params.mileage,
             conditionIn: params.condition ?? null,
             damageFlag,
             damageNote: params.damageNote ?? null,
@@ -1006,7 +1025,10 @@ export class ReservationService {
         });
         await tx.asset.update({
           where: { id: existing.assetId },
-          data: { status: nextAssetStatus },
+          data: {
+            status: nextAssetStatus,
+            ...(shouldUpdateMileage ? { lastReadMileage: params.mileage } : {}),
+          },
         });
         await this.audit.recordWithin(tx, {
           action: 'panorama.reservation.checked_in',
@@ -1016,11 +1038,12 @@ export class ReservationService {
           actorUserId: actor.userId,
           metadata: {
             assetId: existing.assetId,
-            mileage: params.mileage ?? null,
+            mileage: params.mileage,
             condition: params.condition ?? null,
             damageFlag,
             damageNote: params.damageNote ?? null,
             assetNextStatus: nextAssetStatus,
+            lastReadMileageUpdated: shouldUpdateMileage,
           },
         });
         return updated;

--- a/apps/core-api/test/reservation-checkout.e2e.test.ts
+++ b/apps/core-api/test/reservation-checkout.e2e.test.ts
@@ -223,6 +223,117 @@ describe('reservation check-out / check-in e2e', () => {
 
     const assetAfter = await adminDb.asset.findUnique({ where: { id: assetId } });
     expect(assetAfter?.status).toBe('READY');
+    // DATA-01 / ARCH-03 (#31): the asset's lastReadMileage must track the
+    // most recent check-in mileage so the ADR-0016 PM-due cron has real
+    // data to compare. Pre-fix the column was frozen at the migration
+    // backfill value.
+    expect(assetAfter?.lastReadMileage).toBe(12_400);
+  });
+
+  // OPS-02 (#32): mileage is REQUIRED on both checkout and checkin —
+  // DOT 49 CFR + ADR-0016 PM-due cron both depend on it. Pre-fix the
+  // DTO had `optional()` and the column stayed NULL silently.
+  it('checkout without mileage → 400 mileage_required', async () => {
+    const adminCookie = await loginCookie(admin.email, admin.password);
+    const id = await createApproved({
+      cookie: adminCookie,
+      assetId: otherAssetId,
+      startHours: 700,
+      endHours: 702,
+    });
+    const noBody = await fetch(`${url}/reservations/${id}/checkout`, {
+      method: 'POST',
+      headers: { cookie: adminCookie, 'content-type': 'application/json' },
+      body: '{}',
+    });
+    expect(noBody.status).toBe(400);
+    expect(((await noBody.json()) as { message: string }).message).toContain('mileage_required');
+  });
+
+  it('checkin without mileage → 400 mileage_required', async () => {
+    const adminCookie = await loginCookie(admin.email, admin.password);
+    const id = await createApproved({
+      cookie: adminCookie,
+      assetId: otherAssetId,
+      startHours: 720,
+      endHours: 722,
+    });
+    const out = await fetch(`${url}/reservations/${id}/checkout`, {
+      method: 'POST',
+      headers: { cookie: adminCookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ mileage: 30_000 }),
+    });
+    expect(out.status).toBe(200);
+    const noBody = await fetch(`${url}/reservations/${id}/checkin`, {
+      method: 'POST',
+      headers: { cookie: adminCookie, 'content-type': 'application/json' },
+      body: '{}',
+    });
+    expect(noBody.status).toBe(400);
+    expect(((await noBody.json()) as { message: string }).message).toContain('mileage_required');
+
+    // Leave the asset in READY for the next test — without this, the
+    // subsequent createApproved on otherAssetId can race against a
+    // still-CHECKED_OUT lifecycle.
+    const recover = await fetch(`${url}/reservations/${id}/checkin`, {
+      method: 'POST',
+      headers: { cookie: adminCookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ mileage: 30_010 }),
+    });
+    expect(recover.status).toBe(200);
+  });
+
+  // DATA-01 / ARCH-03 (#31): the asset's lastReadMileage must move
+  // forward with check-ins, but never backward — a stale check-in or
+  // an out-of-order admin correction shouldn't move the column down.
+  it('check-in updates Asset.lastReadMileage forward but never backward', async () => {
+    const adminCookie = await loginCookie(admin.email, admin.password);
+
+    const id1 = await createApproved({
+      cookie: adminCookie,
+      assetId: otherAssetId,
+      startHours: 740,
+      endHours: 742,
+    });
+    const out1 = await fetch(`${url}/reservations/${id1}/checkout`, {
+      method: 'POST',
+      headers: { cookie: adminCookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ mileage: 50_000 }),
+    });
+    expect(out1.status).toBe(200);
+    const in1 = await fetch(`${url}/reservations/${id1}/checkin`, {
+      method: 'POST',
+      headers: { cookie: adminCookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ mileage: 50_120 }),
+    });
+    expect(in1.status).toBe(200);
+    const a1 = await adminDb.asset.findUnique({ where: { id: otherAssetId } });
+    expect(a1?.lastReadMileage).toBe(50_120);
+
+    // A second reservation lands on the same asset with the *same*
+    // reading (no further travel) — lastReadMileage must not regress
+    // and must not move sideways pointlessly. Reservation-level
+    // monotonic check still passes since 50_120 == 50_120.
+    const id2 = await createApproved({
+      cookie: adminCookie,
+      assetId: otherAssetId,
+      startHours: 760,
+      endHours: 762,
+    });
+    const out2 = await fetch(`${url}/reservations/${id2}/checkout`, {
+      method: 'POST',
+      headers: { cookie: adminCookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ mileage: 50_120 }),
+    });
+    expect(out2.status).toBe(200);
+    const in2 = await fetch(`${url}/reservations/${id2}/checkin`, {
+      method: 'POST',
+      headers: { cookie: adminCookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ mileage: 50_120 }),
+    });
+    expect(in2.status).toBe(200);
+    const a2 = await adminDb.asset.findUnique({ where: { id: otherAssetId } });
+    expect(a2?.lastReadMileage).toBe(50_120); // unchanged, not regressed
   });
 
   it('damageFlag on checkin routes asset → MAINTENANCE', async () => {
@@ -281,7 +392,7 @@ describe('reservation check-out / check-in e2e', () => {
     const out = await fetch(`${url}/reservations/${id}/checkout`, {
       method: 'POST',
       headers: { cookie: driverCookie, 'content-type': 'application/json' },
-      body: '{}',
+      body: JSON.stringify({ mileage: 100 }),
     });
     expect(out.status).toBe(400);
     const body = (await out.json()) as { message: string };
@@ -302,7 +413,7 @@ describe('reservation check-out / check-in e2e', () => {
     const out = await fetch(`${url}/reservations/${id}/checkout`, {
       method: 'POST',
       headers: { cookie: adminCookie, 'content-type': 'application/json' },
-      body: '{}',
+      body: JSON.stringify({ mileage: 100 }),
     });
     expect(out.status).toBe(409);
     expect(((await out.json()) as { message: string }).message).toContain('asset_not_ready');

--- a/apps/core-api/test/reservation-inspection-tether.e2e.test.ts
+++ b/apps/core-api/test/reservation-inspection-tether.e2e.test.ts
@@ -194,7 +194,7 @@ describe('reservation inspection tether e2e', () => {
     const co = await fetch(`${url}/reservations/${reservation.id}/checkout`, {
       method: 'POST',
       headers: { cookie: driverCookie, 'content-type': 'application/json' },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ mileage: 1000 }),
     });
     expect(co.status).toBe(200);
   });
@@ -216,7 +216,7 @@ describe('reservation inspection tether e2e', () => {
     const co = await fetch(`${url}/reservations/${reservation.id}/checkout`, {
       method: 'POST',
       headers: { cookie: driverCookie, 'content-type': 'application/json' },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ mileage: 1000 }),
     });
     expect(co.status).toBe(409);
     const body = (await co.json()) as { message?: string };
@@ -251,7 +251,7 @@ describe('reservation inspection tether e2e', () => {
     const co = await fetch(`${url}/reservations/${reservation.id}/checkout`, {
       method: 'POST',
       headers: { cookie: driverCookie, 'content-type': 'application/json' },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ mileage: 1000 }),
     });
     expect(co.status).toBe(200);
 
@@ -281,7 +281,7 @@ describe('reservation inspection tether e2e', () => {
     const co = await fetch(`${url}/reservations/${reservation.id}/checkout`, {
       method: 'POST',
       headers: { cookie: driverCookie, 'content-type': 'application/json' },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ mileage: 1000 }),
     });
     expect(co.status).toBe(409);
   });
@@ -306,7 +306,7 @@ describe('reservation inspection tether e2e', () => {
     const co = await fetch(`${url}/reservations/${reservation.id}/checkout`, {
       method: 'POST',
       headers: { cookie: driverCookie, 'content-type': 'application/json' },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ mileage: 1000 }),
     });
     expect(co.status).toBe(409);
   });
@@ -325,7 +325,7 @@ describe('reservation inspection tether e2e', () => {
     const co1 = await fetch(`${url}/reservations/${reservation.id}/checkout`, {
       method: 'POST',
       headers: { cookie: driverCookie, 'content-type': 'application/json' },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ mileage: 1000 }),
     });
     expect(co1.status).toBe(200);
 
@@ -341,7 +341,7 @@ describe('reservation inspection tether e2e', () => {
     const ci = await fetch(`${url}/reservations/${reservation.id}/checkin`, {
       method: 'POST',
       headers: { cookie: driverCookie, 'content-type': 'application/json' },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ mileage: 1000 }),
     });
     expect(ci.status).toBe(200);
   });
@@ -365,7 +365,7 @@ describe('reservation inspection tether e2e', () => {
     const co = await fetch(`${url}/reservations/${reservation.id}/checkout`, {
       method: 'POST',
       headers: { cookie: driverCookie, 'content-type': 'application/json' },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ mileage: 1000 }),
     });
     expect(co.status).toBe(409);
   });
@@ -431,7 +431,7 @@ describe('reservation inspection tether e2e', () => {
       const ap = await fetch(`${baseUrl}/reservations/${created.id}/approve`, {
         method: 'POST',
         headers: { cookie: ownerCookie, 'content-type': 'application/json' },
-        body: JSON.stringify({}),
+        body: JSON.stringify({ mileage: 1000 }),
       });
       if (ap.status !== 200) {
         throw new Error(`approve failed: ${ap.status} ${await ap.text()}`);

--- a/apps/web/src/app/reservations/actions.ts
+++ b/apps/web/src/app/reservations/actions.ts
@@ -28,6 +28,7 @@ function fmtError(raw: string): string {
   if (e.includes('cannot_checkout_when_lifecycle')) return 'Reservation is not in a bookable state.';
   if (e.includes('asset_not_ready')) return "Asset isn't ready (in use, maintenance, or retired).";
   if (e.includes('cannot_checkin_when_lifecycle')) return 'Reservation must be checked-out before check-in.';
+  if (e.includes('mileage_required')) return 'Mileage is required (DOT 49 CFR + maintenance scheduling).';
   if (e.includes('mileage_not_monotonic')) return 'Check-in mileage must be ≥ check-out mileage.';
   if (e.includes('not_allowed')) return "You aren't allowed to perform this action.";
   if (e.includes('basket_not_found')) return 'Basket not found (it may have been fully cancelled or deleted).';

--- a/apps/web/src/app/reservations/page.tsx
+++ b/apps/web/src/app/reservations/page.tsx
@@ -610,7 +610,14 @@ export default async function ReservationsPage({
                           </summary>
                           <form action={checkoutReservationAction} className="panorama-inline-form">
                             <input type="hidden" name="id" value={r.id} />
-                            <input type="number" name="mileage" placeholder="Mileage out" min={0} />
+                            <input
+                              type="number"
+                              name="mileage"
+                              placeholder="Mileage out"
+                              min={0}
+                              required
+                              aria-required="true"
+                            />
                             <input type="text" name="condition" placeholder="Condition" maxLength={200} />
                             <button type="submit" className="panorama-button">
                               Confirm
@@ -630,6 +637,8 @@ export default async function ReservationsPage({
                               name="mileage"
                               placeholder="Mileage in"
                               min={r.mileageOut ?? 0}
+                              required
+                              aria-required="true"
                             />
                             <input type="text" name="condition" placeholder="Condition" maxLength={200} />
                             <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>


### PR DESCRIPTION
## Summary
Closes **#32 [OPS-02]** and **#31 [DATA-01/ARCH-03]** — two audit findings, one surgical bundle. #31 explicitly depends on #32 being fixed first per its issue body.

**OPS-02 (#32)** — DTOs had \`mileage: optional()\` so DOT 49 CFR-required odometer readings could be silently skipped, and \`Asset.lastReadMileage\` (which the ADR-0016 §9 PM-due cron compares to \`nextServiceMileage\`) stayed NULL — every mileage-based maintenance trigger was dead on arrival.
- \`CheckoutSchema\` / \`CheckinSchema\` mileage now required, with explicit \`required_error\` / \`invalid_type_error\` so missing/wrong-type returns 400 \`mileage_required\`.
- Controller surfaces the schema error message.
- \`CheckoutParams\` / \`CheckinParams\` types tightened to \`mileage: number\`.
- Web \`<input>\` on both forms gets \`required\` + \`aria-required="true"\`. Server error mapped to a user-facing string in \`fmtError\`.

**DATA-01 / ARCH-03 (#31)** — \`checkIn()\` now writes \`lastReadMileage\` on the asset row, monotonic-guarded against the existing column so concurrent reservations or out-of-order admin corrections don't move it backwards. Audit row gains \`lastReadMileageUpdated: boolean\` so the guard decision is observable.

**Tests:**
- 3 new e2e (mileage_required on checkout, on checkin; lastReadMileage forward-only across two reservations).
- Happy-path test extended to assert \`lastReadMileage\` is written.
- Tether-test empty-body calls migrated to \`{ mileage: 1000 }\`.
- **314/314** backend pass (was 311; +3 new).

## Test plan
- [x] \`pnpm --filter @panorama/core-api test\` — 314/314 pass
- [x] \`pnpm --filter @panorama/web typecheck\` / \`lint\` / \`build\` — clean
- [ ] CI green