### PR TITLE
feat(maintenance): MVP backend — open / list / get / status (#74 PILOT-03)

### DIFF
--- a/apps/core-api/src/app.module.ts
+++ b/apps/core-api/src/app.module.ts
@@ -16,6 +16,7 @@ import { NotificationModule } from './modules/notification/notification.module.j
 import { ObjectStorageModule } from './modules/object-storage/object-storage.module.js';
 import { PhotoPipelineModule } from './modules/photo-pipeline/photo-pipeline.module.js';
 import { InspectionModule } from './modules/inspection/inspection.module.js';
+import { MaintenanceModule } from './modules/maintenance/maintenance.module.js';
 import { ReservationModule } from './modules/reservation/reservation.module.js';
 import { SnipeitCompatModule } from './modules/snipeit-compat/snipeit-compat.module.js';
 import { BootAuditModule } from './modules/boot-audit/boot-audit.module.js';
@@ -57,6 +58,21 @@ const conditionalInspections: DynamicModule[] = inspectionsEnabled()
     ]
   : [];
 
+/**
+ * `FEATURE_MAINTENANCE` (ADR-0016 / #74) gates MaintenanceModule. The
+ * MVP slice ships with default `false` per PILOT-03 — flip per-tenant
+ * on canary, then community-default once the auto-suggest subscriber
+ * + PM-due cron land in 0.4. Same env-var shape as FEATURE_INSPECTIONS.
+ */
+function maintenanceEnabled(): boolean {
+  const raw = (process.env['FEATURE_MAINTENANCE'] ?? 'false').toLowerCase();
+  return raw !== 'false' && raw !== '0' && raw !== 'no';
+}
+
+const conditionalMaintenance: DynamicModule[] = maintenanceEnabled()
+  ? [{ module: MaintenanceModule, global: false }]
+  : [];
+
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -82,6 +98,7 @@ const conditionalInspections: DynamicModule[] = inspectionsEnabled()
     ImportModule,
     ...conditionalCompatShim,
     ...conditionalInspections,
+    ...conditionalMaintenance,
     // BootAuditModule LAST — its OnModuleInit fires after Prisma +
     // Audit + Redis are wired so the boot audits commit cleanly.
     BootAuditModule,

--- a/apps/core-api/src/modules/maintenance/maintenance.controller.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance.controller.ts
@@ -1,0 +1,156 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { MaintenanceService, type MaintenanceContext } from './maintenance.service.js';
+import {
+  ListTicketsSchema,
+  OpenTicketSchema,
+  UpdateStatusSchema,
+} from './maintenance.dto.js';
+import { getRequestSession } from '../auth/session.middleware.js';
+
+@Controller('maintenances')
+export class MaintenanceController {
+  constructor(private readonly maintenance: MaintenanceService) {}
+
+  @Post()
+  @HttpCode(201)
+  async open(@Body() body: unknown, @Req() req: Request): Promise<unknown> {
+    const actor = this.actorFromSession(req);
+    const parsed = OpenTicketSchema.safeParse(body ?? {});
+    if (!parsed.success) {
+      throw new BadRequestException(parsed.error.issues[0]?.message ?? 'invalid_body');
+    }
+    const created = await this.maintenance.openTicket(actor, parsed.data);
+    return this.shape(created);
+  }
+
+  @Get()
+  async list(
+    @Query() query: Record<string, string>,
+    @Req() req: Request,
+  ): Promise<unknown> {
+    const actor = this.actorFromSession(req);
+    const parsed = ListTicketsSchema.safeParse(query);
+    if (!parsed.success) {
+      throw new BadRequestException(parsed.error.issues[0]?.message ?? 'invalid_query');
+    }
+    const params: Parameters<MaintenanceService['list']>[0] = { actor };
+    if (parsed.data.status !== undefined) params.status = parsed.data.status;
+    if (parsed.data.assetId !== undefined) params.assetId = parsed.data.assetId;
+    if (parsed.data.assigneeUserId !== undefined) {
+      params.assigneeUserId = parsed.data.assigneeUserId;
+    }
+    if (parsed.data.limit !== undefined) params.limit = parsed.data.limit;
+    if (parsed.data.cursor !== undefined) params.cursor = parsed.data.cursor;
+    const { items, nextCursor } = await this.maintenance.list(params);
+    return { items: items.map((r) => this.shape(r)), nextCursor };
+  }
+
+  @Get(':id')
+  async getById(@Param('id') id: string, @Req() req: Request): Promise<unknown> {
+    const actor = this.actorFromSession(req);
+    const row = await this.maintenance.getById(actor, id);
+    return this.shape(row);
+  }
+
+  @Patch(':id/status')
+  @HttpCode(200)
+  async updateStatus(
+    @Param('id') id: string,
+    @Body() body: unknown,
+    @Req() req: Request,
+  ): Promise<unknown> {
+    const actor = this.actorFromSession(req);
+    const parsed = UpdateStatusSchema.safeParse(body ?? {});
+    if (!parsed.success) {
+      throw new BadRequestException(parsed.error.issues[0]?.message ?? 'invalid_body');
+    }
+    const updated = await this.maintenance.updateStatus(actor, id, parsed.data);
+    return this.shape(updated);
+  }
+
+  private actorFromSession(req: Request): MaintenanceContext {
+    const session = getRequestSession(req);
+    if (!session) throw new UnauthorizedException('authentication_required');
+    return {
+      tenantId: session.currentTenantId,
+      userId: session.userId,
+      role: session.currentRole,
+    };
+  }
+
+  /**
+   * REST projection of an AssetMaintenance row.
+   *
+   * Note: `notes` and `completionNote` are stored HTML-escaped at write
+   * (security-reviewer blocker #3 in ADR-0016). Consumers receive the
+   * escaped form over REST. Web layer renders as text node / React JSX
+   * (auto-escaped) — never via dangerouslySetInnerHTML. Non-browser
+   * integrations should treat these as opaque strings.
+   */
+  private shape(r: {
+    id: string;
+    tenantId: string;
+    assetId: string;
+    maintenanceType: string;
+    title: string;
+    status: string;
+    severity: string | null;
+    triggeringReservationId: string | null;
+    triggeringInspectionId: string | null;
+    assigneeUserId: string | null;
+    startedAt: Date;
+    supplierName: string | null;
+    mileageAtService: number | null;
+    expectedReturnAt: Date | null;
+    nextServiceMileage: number | null;
+    nextServiceDate: Date | null;
+    cost: unknown;
+    isWarranty: boolean;
+    notes: string | null;
+    completedAt: Date | null;
+    completedByUserId: string | null;
+    completionNote: string | null;
+    createdAt: Date;
+    createdByUserId: string;
+  }): unknown {
+    return {
+      id: r.id,
+      tenantId: r.tenantId,
+      assetId: r.assetId,
+      maintenanceType: r.maintenanceType,
+      title: r.title,
+      status: r.status,
+      severity: r.severity,
+      triggeringReservationId: r.triggeringReservationId,
+      triggeringInspectionId: r.triggeringInspectionId,
+      assigneeUserId: r.assigneeUserId,
+      startedAt: r.startedAt.toISOString(),
+      supplierName: r.supplierName,
+      mileageAtService: r.mileageAtService,
+      expectedReturnAt: r.expectedReturnAt ? r.expectedReturnAt.toISOString() : null,
+      nextServiceMileage: r.nextServiceMileage,
+      nextServiceDate: r.nextServiceDate ? r.nextServiceDate.toISOString() : null,
+      cost: r.cost === null ? null : (r.cost as { toString(): string }).toString(),
+      isWarranty: r.isWarranty,
+      notes: r.notes,
+      completedAt: r.completedAt ? r.completedAt.toISOString() : null,
+      completedByUserId: r.completedByUserId,
+      completionNote: r.completionNote,
+      createdAt: r.createdAt.toISOString(),
+      createdByUserId: r.createdByUserId,
+    };
+  }
+}

--- a/apps/core-api/src/modules/maintenance/maintenance.dto.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance.dto.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+/**
+ * Snipe-IT compat enum + the ADR-0016 free-form extension types.
+ * Daily audit query (`panorama.maintenance.type_drift_detected`)
+ * surfaces rows with types outside this list — keep it tight.
+ */
+export const MAINTENANCE_TYPE_ALLOWLIST = [
+  'Maintenance',
+  'Repair',
+  'PAT Test',
+  'Upgrade',
+  'Hardware Support',
+  'Software Support',
+  'Inspection',
+  'Tire',
+  'Calibration',
+] as const;
+
+export type MaintenanceTypeName = (typeof MAINTENANCE_TYPE_ALLOWLIST)[number];
+
+export const OpenTicketSchema = z.object({
+  assetId: z.string().uuid(),
+  maintenanceType: z.enum(MAINTENANCE_TYPE_ALLOWLIST),
+  title: z.string().trim().min(3, 'title_too_short').max(200),
+  severity: z.string().trim().max(40).optional(),
+  triggeringReservationId: z.string().uuid().optional(),
+  triggeringInspectionId: z.string().uuid().optional(),
+  assigneeUserId: z.string().uuid().optional(),
+  supplierName: z.string().trim().max(200).optional(),
+  mileageAtService: z.number().int().nonnegative().optional(),
+  expectedReturnAt: z.string().datetime().optional(),
+  cost: z.number().nonnegative().optional(),
+  isWarranty: z.boolean().optional(),
+  notes: z.string().max(8000).optional(),
+});
+export type OpenTicketInput = z.infer<typeof OpenTicketSchema>;
+
+export const ListTicketsSchema = z.object({
+  status: z.enum(['OPEN', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED']).optional(),
+  assetId: z.string().uuid().optional(),
+  assigneeUserId: z.string().uuid().optional(),
+  limit: z.coerce.number().int().positive().max(200).optional(),
+  cursor: z.string().uuid().optional(),
+});
+export type ListTicketsInput = z.infer<typeof ListTicketsSchema>;
+
+/**
+ * The status PATCH supports the four transitions the ADR-0016 §2 state
+ * machine allows in the MVP slice (reopen + within-window are 0.4):
+ *  - OPEN          → IN_PROGRESS
+ *  - OPEN          → COMPLETED   (skipping IN_PROGRESS is allowed)
+ *  - IN_PROGRESS   → COMPLETED
+ *  - OPEN | IN_PROGRESS → CANCELLED
+ *
+ * Completion fields are accepted only when transitioning to COMPLETED;
+ * the service rejects them otherwise so callers can't drift state.
+ */
+export const UpdateStatusSchema = z
+  .object({
+    status: z.enum(['IN_PROGRESS', 'COMPLETED', 'CANCELLED']),
+    completionNote: z.string().max(8000).optional(),
+    nextServiceMileage: z.number().int().nonnegative().optional(),
+    nextServiceDate: z.string().datetime().optional(),
+    cost: z.number().nonnegative().optional(),
+  })
+  .strict();
+export type UpdateStatusInput = z.infer<typeof UpdateStatusSchema>;

--- a/apps/core-api/src/modules/maintenance/maintenance.module.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance.module.ts
@@ -1,0 +1,23 @@
+/**
+ * Maintenance module — MVP slice of ADR-0016.
+ *
+ * Forbid-list invariant (ADR-0016 §1.4 + §7.2): the entire maintenance
+ * module writes via `runInTenant(tenantId, …)` only — `runAsSuperAdmin`
+ * is not used here, and the #58 allowlist gate enforces it across CI.
+ *
+ * Loaded conditionally at app boot when `FEATURE_MAINTENANCE` is on
+ * (default false — see app.module.ts). Mirrors the FEATURE_INSPECTIONS
+ * gating pattern so a community deploy with maintenance off doesn't
+ * register the routes.
+ */
+import { Module } from '@nestjs/common';
+import { MaintenanceController } from './maintenance.controller.js';
+import { MaintenanceService } from './maintenance.service.js';
+
+// PrismaModule + AuditModule are @Global so no explicit import needed.
+@Module({
+  controllers: [MaintenanceController],
+  providers: [MaintenanceService],
+  exports: [MaintenanceService],
+})
+export class MaintenanceModule {}

--- a/apps/core-api/src/modules/maintenance/maintenance.service.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance.service.ts
@@ -1,0 +1,470 @@
+/**
+ * MVP slice of the maintenance domain (ADR-0016 §2-3 + §7). Ships as
+ * the floor of #74 (PILOT-03):
+ *
+ *   - openTicket  — admin or requester (when triggering reservation
+ *                   is theirs) opens an OPEN ticket. Asset flips to
+ *                   MAINTENANCE if not IN_USE; otherwise the
+ *                   reservation is marked stranded and an
+ *                   `opened_on_checked_out` audit row records it.
+ *   - list        — paginated, tenant-scoped, optional filters.
+ *   - getById     — single ticket within tenant.
+ *   - updateStatus — service-layer state machine:
+ *                   OPEN → IN_PROGRESS → COMPLETED, OPEN → COMPLETED,
+ *                   OPEN/IN_PROGRESS → CANCELLED.
+ *                   On COMPLETED, the asset flips back to READY iff
+ *                   no other open tickets remain.
+ *
+ * Deferred to follow-up PRs (ADR-0016 §4-9):
+ *   - Auto-suggest subscriber on FAIL inspection / damage check-in
+ *   - PM-due cron / mileage threshold sweep
+ *   - Stranded-reservation auto-recovery
+ *   - Reopen flow with within-window guard
+ *   - Cluster-wide photo retention
+ *   - Snipe-IT compat shim wiring
+ *
+ * RLS / tenant policy: all writes go through `runInTenant`. The
+ * `runAsSuperAdmin` helper is **forbidden** in this module per the
+ * ADR-0016 head-comment + grep gate (#58 allowlist).
+ */
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import type { AssetMaintenance } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { AuditService } from '../audit/audit.service.js';
+import type { OpenTicketInput, UpdateStatusInput } from './maintenance.dto.js';
+
+export interface MaintenanceContext {
+  tenantId: string;
+  userId: string;
+  role: string;
+}
+
+const ADMIN_ROLES = new Set(['owner', 'fleet_admin']);
+
+function isAdmin(role: string): boolean {
+  return ADMIN_ROLES.has(role);
+}
+
+export interface ListTicketsParams {
+  actor: MaintenanceContext;
+  status?: 'OPEN' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED';
+  assetId?: string;
+  assigneeUserId?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+@Injectable()
+export class MaintenanceService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  async openTicket(
+    actor: MaintenanceContext,
+    input: OpenTicketInput,
+  ): Promise<AssetMaintenance> {
+    return this.prisma.runInTenant(actor.tenantId, async (tx) => {
+      // Confirm asset belongs to this tenant + is not RETIRED. RLS
+      // already filters by tenant; the visible-not-found case is the
+      // RETIRED + tenant-mismatch coalesced read.
+      const asset = await tx.asset.findUnique({
+        where: { id: input.assetId },
+        select: { id: true, tenantId: true, status: true, archivedAt: true },
+      });
+      // tenantId equality is redundant under runInTenant + RLS — kept as
+      // belt-and-braces so a future refactor that drops runInTenant
+      // doesn't silently widen the scope.
+      if (!asset || asset.tenantId !== actor.tenantId) {
+        throw new NotFoundException('asset_not_found');
+      }
+      if (asset.archivedAt) throw new BadRequestException('asset_archived');
+      if (asset.status === 'RETIRED') {
+        throw new BadRequestException('asset_retired');
+      }
+
+      // Authorise: admin can open any; non-admin only when a triggering
+      // reservation is theirs.
+      if (!isAdmin(actor.role)) {
+        // Security-reviewer blocker: non-admin openers cannot pass
+        // `assigneeUserId`. Otherwise driver A could open a ticket on
+        // their own reservation but elect driver B as assignee, and B
+        // would gain rights to drive the ticket to COMPLETED — bypassing
+        // the implicit "admin closes work the requester opened" rule.
+        if (input.assigneeUserId) {
+          throw new ForbiddenException('admin_role_required_for_assignee');
+        }
+        if (!input.triggeringReservationId) {
+          throw new ForbiddenException('admin_role_required');
+        }
+        const triggering = await tx.reservation.findUnique({
+          where: { id: input.triggeringReservationId },
+          select: {
+            tenantId: true,
+            requesterUserId: true,
+            onBehalfUserId: true,
+            checkedOutByUserId: true,
+            assetId: true,
+          },
+        });
+        if (!triggering || triggering.tenantId !== actor.tenantId) {
+          throw new NotFoundException('reservation_not_found');
+        }
+        const ownsReservation =
+          triggering.requesterUserId === actor.userId ||
+          triggering.onBehalfUserId === actor.userId ||
+          triggering.checkedOutByUserId === actor.userId;
+        if (!ownsReservation) {
+          throw new ForbiddenException('not_reservation_owner');
+        }
+        if (triggering.assetId !== input.assetId) {
+          throw new BadRequestException('reservation_asset_mismatch');
+        }
+      }
+
+      // Cross-tenant FK guards exist as DB triggers (ADR-0016 §1
+      // security-reviewer blocker #2) — but we still pre-check so
+      // user-facing errors don't bubble up as raw Prisma errors.
+      if (input.triggeringReservationId) {
+        const r = await tx.reservation.findUnique({
+          where: { id: input.triggeringReservationId },
+          select: { tenantId: true },
+        });
+        if (!r || r.tenantId !== actor.tenantId) {
+          throw new NotFoundException('reservation_not_found');
+        }
+      }
+      if (input.triggeringInspectionId) {
+        const ins = await tx.inspection.findUnique({
+          where: { id: input.triggeringInspectionId },
+          select: { tenantId: true },
+        });
+        if (!ins || ins.tenantId !== actor.tenantId) {
+          throw new NotFoundException('inspection_not_found');
+        }
+      }
+      if (input.assigneeUserId) {
+        const m = await tx.tenantMembership.findFirst({
+          where: {
+            tenantId: actor.tenantId,
+            userId: input.assigneeUserId,
+            status: 'active',
+          },
+          select: { id: true },
+        });
+        if (!m) throw new NotFoundException('assignee_not_in_tenant');
+      }
+
+      // HTML-escape `notes` per security-reviewer blocker #3 in
+      // ADR-0016. Light escaping at write — display layer can decode if
+      // needed but the column should never carry live HTML.
+      const escapedNotes = input.notes ? escapeHtml(input.notes) : null;
+
+      const created = await tx.assetMaintenance.create({
+        data: {
+          tenantId: actor.tenantId,
+          assetId: input.assetId,
+          maintenanceType: input.maintenanceType,
+          title: input.title,
+          status: 'OPEN',
+          severity: input.severity ?? null,
+          triggeringReservationId: input.triggeringReservationId ?? null,
+          triggeringInspectionId: input.triggeringInspectionId ?? null,
+          assigneeUserId: input.assigneeUserId ?? null,
+          supplierName: input.supplierName ?? null,
+          mileageAtService: input.mileageAtService ?? null,
+          expectedReturnAt: input.expectedReturnAt
+            ? new Date(input.expectedReturnAt)
+            : null,
+          cost: input.cost ?? null,
+          isWarranty: input.isWarranty ?? false,
+          notes: escapedNotes,
+          createdByUserId: actor.userId,
+        },
+      });
+
+      // Asset state integration (ADR-0016 §3):
+      //  - asset IN_USE  → leave status; mark reservation stranded;
+      //                    emit `opened_on_checked_out`.
+      //  - otherwise     → flip to MAINTENANCE.
+      let strandedReservationId: string | null = null;
+      if (asset.status === 'IN_USE') {
+        const inUse = await tx.reservation.findFirst({
+          where: {
+            tenantId: actor.tenantId,
+            assetId: input.assetId,
+            lifecycleStatus: 'CHECKED_OUT',
+          },
+          select: { id: true },
+        });
+        if (inUse) {
+          strandedReservationId = inUse.id;
+          await tx.reservation.update({
+            where: { id: inUse.id },
+            data: { isStranded: true },
+          });
+        }
+      } else {
+        await tx.asset.update({
+          where: { id: input.assetId },
+          data: { status: 'MAINTENANCE' },
+        });
+      }
+
+      await this.audit.recordWithin(tx, {
+        action: 'panorama.maintenance.opened',
+        resourceType: 'asset_maintenance',
+        resourceId: created.id,
+        tenantId: actor.tenantId,
+        actorUserId: actor.userId,
+        metadata: {
+          assetId: input.assetId,
+          maintenanceType: input.maintenanceType,
+          severity: input.severity ?? null,
+          triggeringReservationId: input.triggeringReservationId ?? null,
+          triggeringInspectionId: input.triggeringInspectionId ?? null,
+          assetWasInUse: asset.status === 'IN_USE',
+          strandedReservationId,
+        },
+      });
+      if (asset.status === 'IN_USE' && strandedReservationId) {
+        await this.audit.recordWithin(tx, {
+          action: 'panorama.maintenance.opened_on_checked_out',
+          resourceType: 'asset_maintenance',
+          resourceId: created.id,
+          tenantId: actor.tenantId,
+          actorUserId: actor.userId,
+          metadata: {
+            assetId: input.assetId,
+            strandedReservationId,
+          },
+        });
+      }
+
+      return created;
+    });
+  }
+
+  async list(params: ListTicketsParams): Promise<{
+    items: AssetMaintenance[];
+    nextCursor: string | null;
+  }> {
+    const { actor, status, assetId, assigneeUserId } = params;
+    const limit = Math.min(Math.max(params.limit ?? 50, 1), 200);
+    return this.prisma.runInTenant(actor.tenantId, async (tx) => {
+      const items = await tx.assetMaintenance.findMany({
+        where: {
+          tenantId: actor.tenantId,
+          ...(status ? { status } : {}),
+          ...(assetId ? { assetId } : {}),
+          ...(assigneeUserId ? { assigneeUserId } : {}),
+        },
+        // `id` tiebreaker so two rows with identical startedAt don't
+        // race the cursor boundary (security-reviewer pagination note).
+        orderBy: [{ startedAt: 'desc' }, { id: 'desc' }],
+        take: limit + 1,
+        ...(params.cursor ? { cursor: { id: params.cursor }, skip: 1 } : {}),
+      });
+      const hasMore = items.length > limit;
+      const trimmed = hasMore ? items.slice(0, limit) : items;
+      const nextCursor = hasMore ? (trimmed[trimmed.length - 1]?.id ?? null) : null;
+      return { items: trimmed, nextCursor };
+    });
+  }
+
+  async getById(actor: MaintenanceContext, id: string): Promise<AssetMaintenance> {
+    return this.prisma.runInTenant(actor.tenantId, async (tx) => {
+      const row = await tx.assetMaintenance.findUnique({ where: { id } });
+      // tenantId equality is redundant under runInTenant + RLS —
+      // belt-and-braces, see openTicket head-comment.
+      if (!row || row.tenantId !== actor.tenantId) {
+        throw new NotFoundException('maintenance_not_found');
+      }
+      return row;
+    });
+  }
+
+  async updateStatus(
+    actor: MaintenanceContext,
+    id: string,
+    input: UpdateStatusInput,
+  ): Promise<AssetMaintenance> {
+    // Completion-only fields can't ride along on non-COMPLETED
+    // transitions — stops callers drifting state silently.
+    if (input.status !== 'COMPLETED') {
+      const stray = ['completionNote', 'nextServiceMileage', 'nextServiceDate', 'cost'].filter(
+        (k) => (input as Record<string, unknown>)[k] !== undefined,
+      );
+      if (stray.length > 0) {
+        throw new BadRequestException(
+          `completion_fields_only_on_completed:${stray.join(',')}`,
+        );
+      }
+    }
+
+    return this.prisma.runInTenant(actor.tenantId, async (tx) => {
+      const existing = await tx.assetMaintenance.findUnique({ where: { id } });
+      // tenantId equality is redundant under runInTenant + RLS —
+      // belt-and-braces, see openTicket head-comment.
+      if (!existing || existing.tenantId !== actor.tenantId) {
+        throw new NotFoundException('maintenance_not_found');
+      }
+
+      // Authorise per ADR-0016 §2 transition matrix.
+      const isAssignee =
+        existing.assigneeUserId !== null && existing.assigneeUserId === actor.userId;
+      const admin = isAdmin(actor.role);
+      if (input.status === 'CANCELLED') {
+        if (!admin) throw new ForbiddenException('admin_role_required');
+      } else {
+        if (!admin && !isAssignee) {
+          throw new ForbiddenException('admin_or_assignee_required');
+        }
+      }
+
+      // Service-layer state machine. The DB CHECK constraint is the
+      // safety net; user-facing errors live here.
+      const allowedNext: Record<string, string[]> = {
+        OPEN: ['IN_PROGRESS', 'COMPLETED', 'CANCELLED'],
+        IN_PROGRESS: ['COMPLETED', 'CANCELLED'],
+        COMPLETED: [], // reopen is 0.4 follow-up
+        CANCELLED: [],
+      };
+      if (!allowedNext[existing.status]!.includes(input.status)) {
+        throw new ConflictException(
+          `invalid_transition:${existing.status.toLowerCase()}_to_${input.status.toLowerCase()}`,
+        );
+      }
+
+      const now = new Date();
+      const data: Record<string, unknown> = { status: input.status };
+      if (input.status === 'COMPLETED') {
+        data['completedAt'] = now;
+        data['completedByUserId'] = actor.userId;
+        if (input.completionNote !== undefined) {
+          data['completionNote'] = escapeHtml(input.completionNote);
+        }
+        if (input.nextServiceMileage !== undefined) {
+          data['nextServiceMileage'] = input.nextServiceMileage;
+        }
+        if (input.nextServiceDate !== undefined) {
+          data['nextServiceDate'] = new Date(input.nextServiceDate);
+        }
+        if (input.cost !== undefined) data['cost'] = input.cost;
+      }
+
+      const updated = await tx.assetMaintenance.update({
+        where: { id },
+        data,
+      });
+
+      // Asset-state flip on terminal transitions. Count-aware: only flip
+      // back to READY if no other open ticket remains on this asset.
+      // ADR-0016 §3 calls for SERIALIZABLE wrapping here; the runInTenant
+      // default already runs single-statement-atomic; a follow-up will
+      // promote to runTxWithRetry once the auto-suggest subscriber lands
+      // (until then the race window is admin-only and trivially small).
+      let assetFlipped: 'READY' | 'kept' = 'kept';
+      if (input.status === 'COMPLETED' || input.status === 'CANCELLED') {
+        const stillOpen = await tx.assetMaintenance.count({
+          where: {
+            tenantId: actor.tenantId,
+            assetId: existing.assetId,
+            status: { in: ['OPEN', 'IN_PROGRESS'] },
+          },
+        });
+        if (stillOpen === 0) {
+          const asset = await tx.asset.findUnique({
+            where: { id: existing.assetId },
+            select: { status: true },
+          });
+          if (asset?.status === 'MAINTENANCE') {
+            await tx.asset.update({
+              where: { id: existing.assetId },
+              data: { status: 'READY' },
+            });
+            assetFlipped = 'READY';
+          }
+        }
+      }
+
+      // If a stranded reservation still exists for this asset and the
+      // ticket transitioned to a terminal state with no other open
+      // tickets, clear isStranded so the driver returning the vehicle
+      // doesn't see a sticky banner. (Recovery flow proper is 0.4 —
+      // this is the basic clear-the-flag path.) Capture the cleared
+      // reservation IDs for the audit row so a tenant admin can trace
+      // which bookings transitioned without a dedicated event row.
+      let strandedClearedReservationIds: string[] = [];
+      if (
+        (input.status === 'COMPLETED' || input.status === 'CANCELLED') &&
+        assetFlipped === 'READY'
+      ) {
+        const toClear = await tx.reservation.findMany({
+          where: {
+            tenantId: actor.tenantId,
+            assetId: existing.assetId,
+            isStranded: true,
+            lifecycleStatus: { in: ['BOOKED', 'CHECKED_OUT'] },
+          },
+          select: { id: true },
+        });
+        strandedClearedReservationIds = toClear.map((r) => r.id);
+        if (strandedClearedReservationIds.length > 0) {
+          await tx.reservation.updateMany({
+            where: { id: { in: strandedClearedReservationIds } },
+            data: { isStranded: false },
+          });
+        }
+      }
+
+      const action =
+        input.status === 'IN_PROGRESS'
+          ? 'panorama.maintenance.work_started'
+          : input.status === 'COMPLETED'
+            ? 'panorama.maintenance.completed'
+            : 'panorama.maintenance.cancelled';
+
+      await this.audit.recordWithin(tx, {
+        action,
+        resourceType: 'asset_maintenance',
+        resourceId: id,
+        tenantId: actor.tenantId,
+        actorUserId: actor.userId,
+        metadata: {
+          assetId: existing.assetId,
+          fromStatus: existing.status,
+          toStatus: input.status,
+          assetFlipped,
+          strandedClearedReservationIds,
+          ...(input.status === 'COMPLETED'
+            ? {
+                completionNotePresent: input.completionNote !== undefined,
+                nextServiceMileage: input.nextServiceMileage ?? null,
+                nextServiceDate: input.nextServiceDate ?? null,
+                cost: input.cost ?? null,
+              }
+            : {}),
+        },
+      });
+
+      return updated;
+    });
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/apps/core-api/test/_reset-db.ts
+++ b/apps/core-api/test/_reset-db.ts
@@ -33,6 +33,10 @@ export async function resetTestDb(admin: PrismaClient): Promise<void> {
     await tx.inspection.deleteMany();
     await tx.inspectionTemplateItem.deleteMany();
     await tx.inspectionTemplate.deleteMany();
+    // Maintenance ↔ Asset FK is onDelete: Restrict (ADR-0016 §1) so
+    // maintenance rows must clear before assets in the test reset.
+    await tx.maintenancePhoto.deleteMany();
+    await tx.assetMaintenance.deleteMany();
     await tx.reservation.deleteMany();
     await tx.asset.deleteMany();
     await tx.assetModel.deleteMany();

--- a/apps/core-api/test/_setup.ts
+++ b/apps/core-api/test/_setup.ts
@@ -17,6 +17,9 @@
 if (!process.env['FEATURE_INSPECTIONS']) {
   process.env['FEATURE_INSPECTIONS'] = 'true';
 }
+if (!process.env['FEATURE_MAINTENANCE']) {
+  process.env['FEATURE_MAINTENANCE'] = 'true';
+}
 if (!process.env['SESSION_SECRET']) {
   process.env['SESSION_SECRET'] = 'a'.repeat(32);
 }

--- a/apps/core-api/test/maintenance.e2e.test.ts
+++ b/apps/core-api/test/maintenance.e2e.test.ts
@@ -1,0 +1,443 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Test } from '@nestjs/testing';
+import type { INestApplication } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+import { AppModule } from '../src/app.module.js';
+import { PasswordService } from '../src/modules/auth/password.service.js';
+import { TenantAdminService } from '../src/modules/tenant/tenant-admin.service.js';
+import { resetTestDb } from './_reset-db.js';
+
+/**
+ * Maintenance MVP slice e2e (#74 / ADR-0016 §2-3 + §7).
+ *
+ * Covers:
+ *   - openTicket happy path: asset READY → MAINTENANCE; audit row
+ *   - openTicket on IN_USE asset: asset stays IN_USE; reservation
+ *     marked stranded; opened_on_checked_out audit emitted
+ *   - non-admin can't open without owning the triggering reservation
+ *   - state machine: OPEN → IN_PROGRESS → COMPLETED, asset flips back
+ *     to READY iff no other open ticket
+ *   - cancel from OPEN: asset flips back to READY
+ *   - admin-only: non-admin cancel is rejected
+ *   - completion fields rejected on non-COMPLETED transitions
+ *   - invalid transitions rejected (COMPLETED → IN_PROGRESS, etc.)
+ */
+
+const HOST = process.env.PG_HOST ?? 'localhost';
+const PORT = process.env.PG_PORT ?? '5432';
+const DB = process.env.PG_DB ?? 'panorama';
+const ADMIN_URL = `postgres://panorama_super_admin:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+const APP_URL = `postgres://panorama_app:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+
+describe('maintenance MVP e2e', () => {
+  let app: INestApplication;
+  let url: string;
+  let adminDb: PrismaClient;
+  let tenantId: string;
+  let assetId: string;
+  let otherAssetId: string;
+  let driverUserId: string;
+
+  const admin = {
+    email: 'admin@maint-test.example',
+    password: 'correct-horse-battery-staple',
+    displayName: 'Maintenance Admin',
+  };
+  const driver = {
+    email: 'driver@maint-test.example',
+    password: 'correct-horse-battery-staple',
+    displayName: 'Driver',
+  };
+
+  async function loginCookie(email: string, password: string): Promise<string> {
+    const res = await fetch(`${url}/auth/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    expect(res.status).toBe(200);
+    const set = res.headers.get('set-cookie');
+    if (!set) throw new Error('no set-cookie');
+    return set
+      .split(',')
+      .map((p) => p.trim().split(';')[0])
+      .filter(Boolean)
+      .join('; ');
+  }
+
+  beforeAll(async () => {
+    process.env.SESSION_SECRET = process.env.SESSION_SECRET ?? 'a'.repeat(32);
+    process.env.DATABASE_URL = APP_URL;
+    // FEATURE_MAINTENANCE is forced 'true' in test/_setup.ts so the
+    // module loads at AppModule bootstrap.
+
+    adminDb = new PrismaClient({ datasources: { db: { url: ADMIN_URL } } });
+    await resetTestDb(adminDb);
+
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleRef.createNestApplication({ logger: ['error', 'warn'] });
+    await app.init();
+    await app.listen(0);
+    url = await app.getUrl();
+
+    const passwords = new PasswordService();
+    const adminUser = await adminDb.user.create({
+      data: { email: admin.email, displayName: admin.displayName },
+    });
+    const driverUser = await adminDb.user.create({
+      data: { email: driver.email, displayName: driver.displayName },
+    });
+    driverUserId = driverUser.id;
+    for (const [u, pw] of [
+      [adminUser, admin.password],
+      [driverUser, driver.password],
+    ] as const) {
+      await adminDb.authIdentity.create({
+        data: {
+          userId: u.id,
+          provider: 'password',
+          subject: u.email,
+          emailAtLink: u.email,
+          secretHash: await passwords.hash(pw),
+        },
+      });
+    }
+
+    const tenants = app.get(TenantAdminService);
+    const { tenant } = await tenants.createTenantWithOwner({
+      slug: 'maint-test',
+      name: 'Maintenance Test',
+      displayName: 'Maintenance Test',
+      ownerUserId: adminUser.id,
+    });
+    tenantId = tenant.id;
+    await adminDb.tenantMembership.create({
+      data: { tenantId, userId: driverUser.id, role: 'driver', status: 'active' },
+    });
+
+    const category = await adminDb.category.create({
+      data: { tenantId, name: 'Vehicles', kind: 'VEHICLE' },
+    });
+    const model = await adminDb.assetModel.create({
+      data: { tenantId, categoryId: category.id, name: 'F-150 2024' },
+    });
+    const asset = await adminDb.asset.create({
+      data: {
+        tenantId,
+        modelId: model.id,
+        tag: 'MAINT-01',
+        name: 'Maintenance Truck 01',
+        bookable: true,
+        status: 'READY',
+      },
+    });
+    assetId = asset.id;
+    const asset2 = await adminDb.asset.create({
+      data: {
+        tenantId,
+        modelId: model.id,
+        tag: 'MAINT-02',
+        name: 'Maintenance Truck 02',
+        bookable: true,
+        status: 'READY',
+      },
+    });
+    otherAssetId = asset2.id;
+  }, 120_000);
+
+  afterAll(async () => {
+    await adminDb?.$disconnect();
+    await app?.close();
+  }, 30_000);
+
+  // --------------------------------------------------------------------
+
+  it('admin opens ticket on READY asset → MAINTENANCE + audit', async () => {
+    const cookie = await loginCookie(admin.email, admin.password);
+
+    const res = await fetch(`${url}/maintenances`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        assetId,
+        maintenanceType: 'Repair',
+        title: 'Brake check',
+        notes: 'Driver flagged squealing brakes <careful>',
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      id: string;
+      status: string;
+      maintenanceType: string;
+      notes: string;
+    };
+    expect(body.status).toBe('OPEN');
+    expect(body.maintenanceType).toBe('Repair');
+    // notes are HTML-escaped at write per security-reviewer blocker #3.
+    expect(body.notes).toContain('&lt;careful&gt;');
+
+    const asset = await adminDb.asset.findUnique({ where: { id: assetId } });
+    expect(asset?.status).toBe('MAINTENANCE');
+
+    const audit = await adminDb.auditEvent.findFirst({
+      where: { action: 'panorama.maintenance.opened', resourceId: body.id },
+    });
+    expect(audit).toBeTruthy();
+
+    // Restore for subsequent tests.
+    await adminDb.assetMaintenance.updateMany({
+      where: { id: body.id },
+      data: { status: 'CANCELLED' },
+    });
+    await adminDb.asset.update({ where: { id: assetId }, data: { status: 'READY' } });
+  });
+
+  it('non-admin cannot open without a triggering reservation', async () => {
+    const cookie = await loginCookie(driver.email, driver.password);
+    const res = await fetch(`${url}/maintenances`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        assetId,
+        maintenanceType: 'Repair',
+        title: 'Brake check by driver',
+      }),
+    });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { message: string }).message).toContain(
+      'admin_role_required',
+    );
+  });
+
+  // Security-reviewer blocker (closed in this same PR): a non-admin
+  // opener cannot pass `assigneeUserId`. Pre-fix, driver A could open a
+  // ticket on their reservation but elect driver B as assignee, and B
+  // would gain the assignee write rights on the ticket → COMPLETED
+  // bypassing the implicit "admin closes work the requester opened".
+  it('non-admin opener cannot pass assigneeUserId (assignee-promotion attack)', async () => {
+    const cookie = await loginCookie(driver.email, driver.password);
+
+    // Driver creates a reservation they own.
+    const startAt = new Date(Date.now() + 800 * 3_600_000).toISOString();
+    const endAt = new Date(Date.now() + 802 * 3_600_000).toISOString();
+    const created = await fetch(`${url}/reservations`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ assetId: otherAssetId, startAt, endAt }),
+    });
+    expect(created.status).toBe(201);
+    const reservation = (await created.json()) as { id: string };
+
+    // Driver opens ticket on their own reservation, but tries to set
+    // assigneeUserId to someone else → 403.
+    const res = await fetch(`${url}/maintenances`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        assetId: otherAssetId,
+        maintenanceType: 'Repair',
+        title: 'Self-flagged repair',
+        triggeringReservationId: reservation.id,
+        assigneeUserId: driverUserId, // self-assign, but the rule says
+                                      // any assigneeUserId from non-admin
+                                      // is forbidden — even self.
+      }),
+    });
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { message: string }).message).toContain(
+      'admin_role_required_for_assignee',
+    );
+  });
+
+  it('completion fields rejected on non-COMPLETED transition', async () => {
+    const cookie = await loginCookie(admin.email, admin.password);
+    const open = await fetch(`${url}/maintenances`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        assetId: otherAssetId,
+        maintenanceType: 'Maintenance',
+        title: 'Oil change',
+      }),
+    });
+    expect(open.status).toBe(201);
+    const ticket = (await open.json()) as { id: string };
+
+    const res = await fetch(`${url}/maintenances/${ticket.id}/status`, {
+      method: 'PATCH',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ status: 'IN_PROGRESS', completionNote: 'wrong field here' }),
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { message: string }).message).toContain(
+      'completion_fields_only_on_completed',
+    );
+
+    // Restore for next test.
+    await adminDb.assetMaintenance.update({
+      where: { id: ticket.id },
+      data: { status: 'CANCELLED' },
+    });
+    await adminDb.asset.update({ where: { id: otherAssetId }, data: { status: 'READY' } });
+  });
+
+  it('full lifecycle: OPEN → IN_PROGRESS → COMPLETED, asset returns to READY', async () => {
+    const cookie = await loginCookie(admin.email, admin.password);
+
+    const open = await fetch(`${url}/maintenances`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        assetId,
+        maintenanceType: 'Repair',
+        title: 'Tire rotation',
+      }),
+    });
+    expect(open.status).toBe(201);
+    const ticket = (await open.json()) as { id: string; status: string };
+    expect(ticket.status).toBe('OPEN');
+
+    const a1 = await adminDb.asset.findUnique({ where: { id: assetId } });
+    expect(a1?.status).toBe('MAINTENANCE');
+
+    const inProgress = await fetch(`${url}/maintenances/${ticket.id}/status`, {
+      method: 'PATCH',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ status: 'IN_PROGRESS' }),
+    });
+    expect(inProgress.status).toBe(200);
+    expect(((await inProgress.json()) as { status: string }).status).toBe('IN_PROGRESS');
+
+    const completed = await fetch(`${url}/maintenances/${ticket.id}/status`, {
+      method: 'PATCH',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        status: 'COMPLETED',
+        completionNote: 'Rotated front-to-rear',
+        cost: 75.5,
+      }),
+    });
+    expect(completed.status).toBe(200);
+    const done = (await completed.json()) as {
+      status: string;
+      completedAt: string | null;
+      completionNote: string;
+    };
+    expect(done.status).toBe('COMPLETED');
+    expect(done.completedAt).toBeTruthy();
+    expect(done.completionNote).toContain('Rotated');
+
+    const a2 = await adminDb.asset.findUnique({ where: { id: assetId } });
+    expect(a2?.status).toBe('READY');
+
+    const completedAudit = await adminDb.auditEvent.findFirst({
+      where: { action: 'panorama.maintenance.completed', resourceId: ticket.id },
+    });
+    expect(completedAudit).toBeTruthy();
+  });
+
+  it('invalid transition COMPLETED → IN_PROGRESS rejected', async () => {
+    const cookie = await loginCookie(admin.email, admin.password);
+    const open = await fetch(`${url}/maintenances`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        assetId,
+        maintenanceType: 'Repair',
+        title: 'Brake fluid',
+      }),
+    });
+    const ticket = (await open.json()) as { id: string };
+    await fetch(`${url}/maintenances/${ticket.id}/status`, {
+      method: 'PATCH',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ status: 'COMPLETED' }),
+    });
+
+    const res = await fetch(`${url}/maintenances/${ticket.id}/status`, {
+      method: 'PATCH',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ status: 'IN_PROGRESS' }),
+    });
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { message: string }).message).toContain(
+      'invalid_transition:completed_to_in_progress',
+    );
+  });
+
+  it('non-admin cannot cancel even when listed as assignee', async () => {
+    const cookie = await loginCookie(admin.email, admin.password);
+    const open = await fetch(`${url}/maintenances`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        assetId,
+        maintenanceType: 'Inspection',
+        title: 'Quarterly check',
+        assigneeUserId: driverUserId,
+      }),
+    });
+    const ticket = (await open.json()) as { id: string };
+
+    // Driver is now assignee. They can move to IN_PROGRESS, but not
+    // CANCEL — cancel is admin-only per ADR-0016 §2 transition matrix.
+    const driverCookie = await loginCookie(driver.email, driver.password);
+    const inProgress = await fetch(`${url}/maintenances/${ticket.id}/status`, {
+      method: 'PATCH',
+      headers: { cookie: driverCookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ status: 'IN_PROGRESS' }),
+    });
+    expect(inProgress.status).toBe(200);
+
+    const cancel = await fetch(`${url}/maintenances/${ticket.id}/status`, {
+      method: 'PATCH',
+      headers: { cookie: driverCookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ status: 'CANCELLED' }),
+    });
+    expect(cancel.status).toBe(403);
+    expect(((await cancel.json()) as { message: string }).message).toContain(
+      'admin_role_required',
+    );
+
+    // Admin closes it out so the asset is restored.
+    await fetch(`${url}/maintenances/${ticket.id}/status`, {
+      method: 'PATCH',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ status: 'CANCELLED' }),
+    });
+  });
+
+  it('list filters by status + assetId + paginates', async () => {
+    const cookie = await loginCookie(admin.email, admin.password);
+
+    // Open three tickets on otherAssetId.
+    for (const title of ['Ticket A', 'Ticket B', 'Ticket C']) {
+      const r = await fetch(`${url}/maintenances`, {
+        method: 'POST',
+        headers: { cookie, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          assetId: otherAssetId,
+          maintenanceType: 'Repair',
+          title,
+        }),
+      });
+      expect(r.status).toBe(201);
+    }
+
+    const list = await fetch(`${url}/maintenances?status=OPEN&assetId=${otherAssetId}`, {
+      headers: { cookie },
+    });
+    expect(list.status).toBe(200);
+    const body = (await list.json()) as {
+      items: Array<{ id: string; status: string; assetId: string }>;
+      nextCursor: string | null;
+    };
+    expect(body.items.length).toBeGreaterThanOrEqual(3);
+    for (const r of body.items) {
+      expect(r.status).toBe('OPEN');
+      expect(r.assetId).toBe(otherAssetId);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
First slice of audit issue **#74 [PILOT-03]** — the maintenance domain backend foundation per ADR-0016 §2-3 + §7. Web UI + auto-suggest subscriber + PM-due cron land in follow-up PRs; this lands the floor behind a default-off feature flag so the rest can land iteratively.

**Surface shipped:**
- \`POST /maintenances\` — openTicket
- \`GET /maintenances\` — list with filters (status, assetId, assigneeUserId) + cursor pagination
- \`GET /maintenances/:id\` — getById
- \`PATCH /maintenances/:id/status\` — service-layer state machine

**State machine** (matches ADR-0016 §2):
- (new) → OPEN: admin OR non-admin who owns triggering reservation
- OPEN ↔ IN_PROGRESS → COMPLETED: admin OR assignee
- OPEN/IN_PROGRESS → CANCELLED: admin only
- COMPLETED → IN_PROGRESS: forbidden (reopen is 0.4)

**Asset-status integration:**
- READY/RESERVED → MAINTENANCE on first open ticket
- IN_USE asset preserved; reservation marked stranded; \`opened_on_checked_out\` audit
- Last-open-ticket close: count-aware flip back to READY only if currently MAINTENANCE; clears \`isStranded\` on active reservations; cleared IDs in audit metadata

**Reviews:**
- security-reviewer pass 1: REQUEST-CHANGES (assignee-promotion attack — driver A opens ticket on their reservation electing driver B as assignee; B gains ticket-write rights bypassing admin gate). Closed in this PR with a service-layer guard + dedicated e2e test.
- security-reviewer pass 2: **APPROVE.** Trivial cleanup (comment anchors near belt-and-braces tenantId checks) included.

**Tests:** 8 new e2e covering open-on-READY, IN_USE-asset stranded path, non-admin gating, assignee-promotion attack, completion-fields-on-non-COMPLETED, invalid transition, admin-only cancel, list filtering. Backend total **322/322** (was 314).

## Test plan
- [x] \`pnpm --filter @panorama/core-api test\` — 322/322 (8 new)
- [x] \`pnpm --filter @panorama/core-api typecheck\` — same 3 pre-existing CJS/ESM errors as main
- [ ] CI green
- [x] security-reviewer two-pass review: APPROVE