### PR TITLE
chore(invitation): thread tenantId through BullMQ payload, migrate worker callbacks to runInTenant (#115)

### DIFF
--- a/.runAsSuperAdmin.allowlist.json
+++ b/.runAsSuperAdmin.allowlist.json
@@ -29,11 +29,11 @@
     },
     "apps/core-api/src/modules/invitation/invitation-email.queue.ts": {
       "budget": 2,
-      "rationale": "BullMQ worker processes jobs whose payload only carries invitationId — pending #115 follow-up to thread tenantId through the payload."
+      "rationale": "Two cross-tenant paths: rescue-query (cluster-wide scan for stuck invitations) + lookupTenantId (legacy-payload fallback for pre-#115 BullMQ jobs). Per-row writes that follow run under runInTenant."
     },
     "apps/core-api/src/modules/invitation/invitation.service.ts": {
-      "budget": 6,
-      "rationale": "Six legitimate cross-tenant / pre-tenant paths: previewAcceptance + finalizeAccept (token-driven, pre-tenant); markEmailSent + markEmailFailed + rotateTokenForRescue (worker callbacks; #115 to resolve); sweepExpired (cross-tenant background sweep)."
+      "budget": 3,
+      "rationale": "Three legitimate cross-tenant / pre-tenant paths: previewAcceptance + finalizeAccept (token-driven, pre-tenant); sweepExpired (cross-tenant background sweep). markEmailSent / markEmailFailed / rotateTokenForRescue migrated to runInTenant once tenantId was threaded through the BullMQ payload (#115 closed 2026-04-26)."
     },
     "apps/core-api/src/modules/notification/notification.dispatcher.ts": {
       "budget": 5,

--- a/apps/core-api/src/modules/invitation/invitation-email.queue.ts
+++ b/apps/core-api/src/modules/invitation/invitation-email.queue.ts
@@ -37,6 +37,19 @@ const MAINTENANCE_JOB = 'sweep';
 
 interface InvitationEmailJobData {
   invitationId: string;
+  /**
+   * Tenant the invitation belongs to. Threaded through the payload so
+   * the worker callbacks (`markEmailSent`, `markEmailFailed`,
+   * `rotateTokenForRescue`) can run under `runInTenant` instead of
+   * `runAsSuperAdmin` — closes a #56 follow-up (issue #115).
+   *
+   * Old-shape jobs queued before this field landed are tolerated:
+   * `runEmailJob` falls back to a privileged read for tenantId
+   * resolution when this field is absent. Pre-pilot we have no
+   * persistent queue volume; this fallback exists so a rolling deploy
+   * doesn't drop in-flight jobs.
+   */
+  tenantId?: string;
   /** Plaintext token — present only for the duration of the job. */
   plaintextToken: string;
 }
@@ -62,10 +75,14 @@ export class BullMqInvitationQueue
 
   // --- InvitationQueuePort -------------------------------------------
 
-  async enqueueDelivery(invitationId: string, plaintextToken: string): Promise<void> {
+  async enqueueDelivery(
+    invitationId: string,
+    tenantId: string,
+    plaintextToken: string,
+  ): Promise<void> {
     await this.emailQueue.add(
       'send',
-      { invitationId, plaintextToken },
+      { invitationId, tenantId, plaintextToken },
       {
         attempts: 5,
         backoff: { type: 'exponential', delay: 60_000 }, // 1m, 2m, 4m, 8m, 16m
@@ -95,9 +112,28 @@ export class BullMqInvitationQueue
       const attemptsAllowed = job?.opts?.attempts ?? 5;
       const terminal = attemptsMade >= attemptsAllowed;
       const invitationId = (job?.data)?.invitationId;
+      const tenantId = (job?.data)?.tenantId;
       if (!invitationId) return;
-      this.invitations
-        .markEmailFailed(invitationId, String(err?.message ?? err ?? 'unknown_error'), terminal)
+      // Resolve a tenantId for old-shape jobs that landed before #115.
+      const resolveTenantId = tenantId
+        ? Promise.resolve(tenantId)
+        : this.lookupTenantId(invitationId);
+      resolveTenantId
+        .then((tid) => {
+          if (!tid) {
+            this.log.warn(
+              { invitationId },
+              'markEmailFailed_skipped_missing_tenantid',
+            );
+            return undefined;
+          }
+          return this.invitations.markEmailFailed(
+            invitationId,
+            tid,
+            String(err?.message ?? err ?? 'unknown_error'),
+            terminal,
+          );
+        })
         .catch((markErr: unknown) =>
           this.log.warn({ invitationId, err: String(markErr) }, 'markEmailFailed_error'),
         );
@@ -139,19 +175,35 @@ export class BullMqInvitationQueue
 
   private async runEmailJob(job: Job<InvitationEmailJobData>): Promise<void> {
     const { invitationId, plaintextToken } = job.data;
-    const invitation = await this.prisma.runAsSuperAdmin(
-      (tx) =>
-        tx.invitation.findUnique({
-          where: { id: invitationId },
-          include: {
-            tenant: { select: { displayName: true, locale: true } },
-            invitedBy: { select: { displayName: true, email: true } },
-          },
-        }),
-      { reason: `invitation-email:load:${invitationId}` },
+
+    // tenantId rides in the payload now (#115). For backward compat
+    // with jobs queued by the prior shape (no rolling-deploy job loss),
+    // resolve it from the row when missing.
+    let tenantId = job.data.tenantId;
+    if (!tenantId) {
+      const fallback = await this.lookupTenantId(invitationId);
+      if (!fallback) {
+        this.log.warn({ invitationId }, 'invitation_missing_skipping');
+        return;
+      }
+      tenantId = fallback;
+      this.log.warn(
+        { invitationId, tenantId },
+        'invitation_email_legacy_payload_shape_resolved_tenantid',
+      );
+    }
+
+    const invitation = await this.prisma.runInTenant(tenantId, (tx) =>
+      tx.invitation.findUnique({
+        where: { id: invitationId },
+        include: {
+          tenant: { select: { displayName: true, locale: true } },
+          invitedBy: { select: { displayName: true, email: true } },
+        },
+      }),
     );
     if (!invitation) {
-      this.log.warn({ invitationId }, 'invitation_missing_skipping');
+      this.log.warn({ invitationId, tenantId }, 'invitation_missing_skipping');
       return;
     }
     if (invitation.revokedAt || invitation.acceptedAt) {
@@ -185,7 +237,27 @@ export class BullMqInvitationQueue
       html: rendered.html,
     });
 
-    await this.invitations.markEmailSent(invitation.id);
+    await this.invitations.markEmailSent(invitation.id, tenantId);
+  }
+
+  /**
+   * Cluster-wide invitation -> tenantId lookup. Used only as a fallback
+   * for legacy-shape BullMQ jobs that landed before #115 wired tenantId
+   * into the payload. The cross-tenant read justifies `runAsSuperAdmin`
+   * — same architectural escape pattern the inspection-maintenance
+   * sweep uses.
+   */
+  private async lookupTenantId(invitationId: string): Promise<string | null> {
+    return this.prisma.runAsSuperAdmin(
+      async (tx) => {
+        const row = await tx.invitation.findUnique({
+          where: { id: invitationId },
+          select: { tenantId: true },
+        });
+        return row?.tenantId ?? null;
+      },
+      { reason: `invitation-email:lookup-tenantid:${invitationId}` },
+    );
   }
 
   private async runMaintenance(): Promise<void> {
@@ -196,6 +268,10 @@ export class BullMqInvitationQueue
     // initial `queue.add` never landed (crash between tx commit and
     // enqueue). Only pick rows created more than 60s ago so we don't
     // race the happy-path enqueue in-flight.
+    // Cluster-wide rescue scan — legitimate cross-tenant read for the
+    // maintenance sweep, same architectural escape pattern as
+    // inspection-maintenance. Per-row rescue work below runs under
+    // `runInTenant` with the tenantId pulled out of this query.
     const stuck = await this.prisma.runAsSuperAdmin(
       (tx) =>
         tx.invitation.findMany({
@@ -207,7 +283,7 @@ export class BullMqInvitationQueue
             emailAttempts: 0,
             createdAt: { lt: new Date(Date.now() - 60_000) },
           },
-          select: { id: true },
+          select: { id: true, tenantId: true },
           take: 100,
         }),
       { reason: 'invitation-email:rescue-query' },
@@ -215,9 +291,9 @@ export class BullMqInvitationQueue
     let rescued = 0;
     for (const row of stuck) {
       try {
-        const rotated = await this.invitations.rotateTokenForRescue(row.id);
+        const rotated = await this.invitations.rotateTokenForRescue(row.id, row.tenantId);
         if (rotated) {
-          await this.enqueueDelivery(row.id, rotated.plaintext);
+          await this.enqueueDelivery(row.id, row.tenantId, rotated.plaintext);
           rescued++;
         }
       } catch (err) {

--- a/apps/core-api/src/modules/invitation/invitation.queue.ts
+++ b/apps/core-api/src/modules/invitation/invitation.queue.ts
@@ -18,7 +18,16 @@ import { Injectable, Logger } from '@nestjs/common';
  * is removed from Redis on completion (see `removeOnComplete`).
  */
 export interface InvitationQueuePort {
-  enqueueDelivery(invitationId: string, plaintextToken: string): Promise<void>;
+  /**
+   * Queue an invitation email for delivery. `tenantId` rides in the
+   * payload so the worker can run callbacks under `runInTenant` instead
+   * of escalating to `runAsSuperAdmin` (#115 / closes a #56 follow-up).
+   */
+  enqueueDelivery(
+    invitationId: string,
+    tenantId: string,
+    plaintextToken: string,
+  ): Promise<void>;
 }
 
 export const INVITATION_QUEUE = Symbol('INVITATION_QUEUE');
@@ -32,7 +41,11 @@ export const INVITATION_QUEUE = Symbol('INVITATION_QUEUE');
 export class NoopInvitationQueue implements InvitationQueuePort {
   private readonly log = new Logger('NoopInvitationQueue');
 
-  async enqueueDelivery(invitationId: string, _plaintextToken: string): Promise<void> {
-    this.log.debug({ invitationId }, 'noop_enqueue');
+  async enqueueDelivery(
+    invitationId: string,
+    tenantId: string,
+    _plaintextToken: string,
+  ): Promise<void> {
+    this.log.debug({ invitationId, tenantId }, 'noop_enqueue');
   }
 }

--- a/apps/core-api/src/modules/invitation/invitation.service.ts
+++ b/apps/core-api/src/modules/invitation/invitation.service.ts
@@ -288,7 +288,7 @@ export class InvitationService {
       // where emailQueuedAt is set but the email was never sent by
       // rotating the token + re-enqueuing.
       this.queue
-        .enqueueDelivery(result.created.id, result.plaintext)
+        .enqueueDelivery(result.created.id, result.created.tenantId, result.plaintext)
         .catch((err: unknown) => {
           this.log.warn(
             { invitationId: result.created.id, err: String(err) },
@@ -361,7 +361,7 @@ export class InvitationService {
     );
 
     this.queue
-      .enqueueDelivery(result.updated.id, result.plaintext)
+      .enqueueDelivery(result.updated.id, result.updated.tenantId, result.plaintext)
       .catch((err: unknown) => {
         this.log.warn(
           { invitationId: result.updated.id, err: String(err) },
@@ -590,56 +590,57 @@ export class InvitationService {
   // Post-email-send callbacks (used by the BullMQ worker)
   // ---------------------------------------------------------------------
 
-  async markEmailSent(invitationId: string): Promise<void> {
-    await this.prisma.runAsSuperAdmin(
-      async (tx) => {
-        const existing = await tx.invitation.findUnique({ where: { id: invitationId } });
-        if (!existing) return;
-        await tx.invitation.update({
-          where: { id: invitationId },
-          data: { emailSentAt: new Date(), emailLastError: null },
-        });
-        await this.audit.recordWithin(tx, {
-          action: 'panorama.invitation.email_sent',
-          resourceType: 'invitation',
-          resourceId: invitationId,
-          tenantId: existing.tenantId,
-          metadata: { email: existing.email },
-        });
-      },
-      { reason: `invitation:markEmailSent:${invitationId}` },
-    );
+  /**
+   * Worker callback. `tenantId` is threaded through the BullMQ payload
+   * (#115) so this runs under `runInTenant` instead of an unscoped
+   * privileged write.
+   */
+  async markEmailSent(invitationId: string, tenantId: string): Promise<void> {
+    await this.prisma.runInTenant(tenantId, async (tx) => {
+      const existing = await tx.invitation.findUnique({ where: { id: invitationId } });
+      if (!existing || existing.tenantId !== tenantId) return;
+      await tx.invitation.update({
+        where: { id: invitationId },
+        data: { emailSentAt: new Date(), emailLastError: null },
+      });
+      await this.audit.recordWithin(tx, {
+        action: 'panorama.invitation.email_sent',
+        resourceType: 'invitation',
+        resourceId: invitationId,
+        tenantId,
+        metadata: { email: existing.email },
+      });
+    });
   }
 
+  /** Worker callback — see markEmailSent re: tenantId threading. */
   async markEmailFailed(
     invitationId: string,
+    tenantId: string,
     error: string,
     terminal: boolean,
   ): Promise<void> {
-    await this.prisma.runAsSuperAdmin(
-      async (tx) => {
-        const existing = await tx.invitation.findUnique({ where: { id: invitationId } });
-        if (!existing) return;
-        await tx.invitation.update({
-          where: { id: invitationId },
-          data: {
-            emailAttempts: { increment: 1 },
-            emailLastError: error.slice(0, 500),
-            ...(terminal ? { emailBouncedAt: new Date() } : {}),
-          },
-        });
-        await this.audit.recordWithin(tx, {
-          action: terminal
-            ? 'panorama.invitation.email_bounced'
-            : 'panorama.invitation.email_failed',
-          resourceType: 'invitation',
-          resourceId: invitationId,
-          tenantId: existing.tenantId,
-          metadata: { email: existing.email, error: error.slice(0, 500) },
-        });
-      },
-      { reason: `invitation:markEmailFailed:${invitationId}` },
-    );
+    await this.prisma.runInTenant(tenantId, async (tx) => {
+      const existing = await tx.invitation.findUnique({ where: { id: invitationId } });
+      if (!existing || existing.tenantId !== tenantId) return;
+      await tx.invitation.update({
+        where: { id: invitationId },
+        data: {
+          emailAttempts: { increment: 1 },
+          emailLastError: error.slice(0, 500),
+          ...(terminal ? { emailBouncedAt: new Date() } : {}),
+        },
+      });
+      await this.audit.recordWithin(tx, {
+        action: terminal
+          ? 'panorama.invitation.email_bounced'
+          : 'panorama.invitation.email_failed',
+        resourceType: 'invitation',
+        resourceId: invitationId,
+        tenantId,
+        metadata: { email: existing.email, error: error.slice(0, 500) },
+      });
+    });
   }
 
   /**
@@ -651,39 +652,42 @@ export class InvitationService {
    * Unlike `resend`, this is system-initiated — no admin actor exists.
    * The audit row uses `actorUserId=null` and `action=resent` with
    * metadata reason=`rescue`.
+   *
+   * `tenantId` comes from the rescue scan (cluster-wide read) so the
+   * write itself runs under `runInTenant` (#115).
    */
-  async rotateTokenForRescue(invitationId: string): Promise<{ plaintext: string } | null> {
-    return this.prisma.runAsSuperAdmin(
-      async (tx) => {
-        const existing = await tx.invitation.findUnique({ where: { id: invitationId } });
-        if (!existing) return null;
-        if (existing.acceptedAt || existing.revokedAt) return null;
-        if (existing.expiresAt.getTime() <= Date.now()) return null;
+  async rotateTokenForRescue(
+    invitationId: string,
+    tenantId: string,
+  ): Promise<{ plaintext: string } | null> {
+    return this.prisma.runInTenant(tenantId, async (tx) => {
+      const existing = await tx.invitation.findUnique({ where: { id: invitationId } });
+      if (!existing || existing.tenantId !== tenantId) return null;
+      if (existing.acceptedAt || existing.revokedAt) return null;
+      if (existing.expiresAt.getTime() <= Date.now()) return null;
 
-        const { plaintext, tokenHash } = this.generateToken();
-        await tx.invitation.update({
-          where: { id: invitationId },
-          data: {
-            tokenHash,
-            emailQueuedAt: new Date(),
-            emailSentAt: null,
-            emailBouncedAt: null,
-            emailAttempts: 0,
-            emailLastError: null,
-          },
-        });
-        await this.audit.recordWithin(tx, {
-          action: 'panorama.invitation.resent',
-          resourceType: 'invitation',
-          resourceId: invitationId,
-          tenantId: existing.tenantId,
-          actorUserId: null,
-          metadata: { email: existing.email, reason: 'rescue' },
-        });
-        return { plaintext };
-      },
-      { reason: `invitation:rotateTokenForRescue:${invitationId}` },
-    );
+      const { plaintext, tokenHash } = this.generateToken();
+      await tx.invitation.update({
+        where: { id: invitationId },
+        data: {
+          tokenHash,
+          emailQueuedAt: new Date(),
+          emailSentAt: null,
+          emailBouncedAt: null,
+          emailAttempts: 0,
+          emailLastError: null,
+        },
+      });
+      await this.audit.recordWithin(tx, {
+        action: 'panorama.invitation.resent',
+        resourceType: 'invitation',
+        resourceId: invitationId,
+        tenantId,
+        actorUserId: null,
+        metadata: { email: existing.email, reason: 'rescue' },
+      });
+      return { plaintext };
+    });
   }
 
   async sweepExpired(): Promise<number> {


### PR DESCRIPTION
## Summary
Closes **#115** (a #56 follow-up). Three invitation worker callbacks previously stayed on \`runAsSuperAdmin\` because the BullMQ job payload only carried \`invitationId + plaintext\`. Widens the payload at enqueue time to include \`tenantId\` (already known to the caller) so the worker runs under \`runInTenant\` — defense-in-depth, not a real bypass, but it removes three privileged-write sites and tightens the allowlist budget.

**Migrated from runAsSuperAdmin → runInTenant:**
- \`InvitationService.markEmailSent\`
- \`InvitationService.markEmailFailed\`
- \`InvitationService.rotateTokenForRescue\`
- \`runEmailJob\`'s invitation load

**Stays on runAsSuperAdmin** (legitimate cluster-wide / pre-tenant-context reads):
- \`runMaintenance\` rescue-query (scans across tenants)
- New \`lookupTenantId\` fallback for legacy-shape jobs queued before this PR — warns + resolves so a rolling deploy doesn't drop in-flight work

**Allowlist budgets** (#58 gate):
- \`invitation.service.ts\`: 6 → 3
- \`invitation-email.queue.ts\`: 2 → 2 (rescue scan still cluster-wide; lookupTenantId replaces the prior runAsSuperAdmin slot)

## Test plan
- [x] \`pnpm --filter @panorama/core-api test\` — 322/322 (invitation suite 14/14, no behavioural changes — refactor only)
- [x] \`pnpm tsx scripts/check-runAsSuperAdmin-allowlist.ts\` — passes (25 calls across 10 files)
- [ ] CI green