### PR TITLE
perf(inspection): batch respond into single INSERT … ON CONFLICT DO UPDATE (#62 PERF-03)

### DIFF
--- a/apps/core-api/src/modules/inspection/inspection.service.ts
+++ b/apps/core-api/src/modules/inspection/inspection.service.ts
@@ -18,11 +18,10 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import type {
-  Inspection,
-  InspectionOutcome,
-  Prisma,
-} from '@prisma/client';
+import type { Inspection, InspectionOutcome } from '@prisma/client';
+// `Prisma.sql` + `Prisma.join` build parameterised raw SQL — needed
+// for the respond batch-upsert hot path (#62 / PERF-03).
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { AuditService } from '../audit/audit.service.js';
 import { NotificationService } from '../notification/notification.service.js';
@@ -235,35 +234,52 @@ export class InspectionService {
         validateResponseShape(item, r);
       }
 
-      // Upsert each response against the unique (inspectionId, snapshotItemId).
-      let count = 0;
-      for (const r of input.responses) {
-        await tx.inspectionResponse.upsert({
-          where: {
-            inspectionId_snapshotItemId: {
-              inspectionId,
-              snapshotItemId: r.snapshotItemId,
-            },
-          },
-          create: {
-            tenantId: actor.tenantId,
-            inspectionId,
-            snapshotItemId: r.snapshotItemId,
-            booleanValue: r.booleanValue ?? null,
-            textValue: r.textValue ?? null,
-            numberValue: r.numberValue ?? null,
-            note: r.note ?? null,
-          },
-          update: {
-            booleanValue: r.booleanValue ?? null,
-            textValue: r.textValue ?? null,
-            numberValue: r.numberValue ?? null,
-            note: r.note ?? null,
-          },
-        });
-        count++;
-      }
-      return { count };
+      // PERF-03 (#62): batch upsert in a single round-trip. The prior
+      // for-loop did N upserts (≈100ms for 20 items on slow cellular).
+      // Single INSERT … ON CONFLICT DO UPDATE collapses N→1.
+      //
+      // Safety: `Prisma.sql` + `Prisma.join` keep every value
+      // parameterised. The `tx.$executeRaw` tagged-template form is
+      // allowed in this module (see head-comment); `$executeRawUnsafe`
+      // remains forbidden.
+      //
+      // Dedupe by snapshotItemId (last-write-wins). Postgres raises
+      // 21000 cardinality_violation if ON CONFLICT DO UPDATE sees the
+      // same conflict target twice in one statement. The prior loop
+      // tolerated duplicates as overwrite-in-order; we preserve that
+      // behaviour by keeping the last occurrence per snapshotItemId.
+      if (input.responses.length === 0) return { count: 0 };
+      const dedup = new Map<string, (typeof input.responses)[number]>();
+      for (const r of input.responses) dedup.set(r.snapshotItemId, r);
+      const rows = Array.from(dedup.values());
+      const valueRows = rows.map(
+        (r) => Prisma.sql`(
+          gen_random_uuid(),
+          ${actor.tenantId}::uuid,
+          ${inspectionId}::uuid,
+          ${r.snapshotItemId}::uuid,
+          ${r.booleanValue ?? null},
+          ${r.textValue ?? null},
+          ${r.numberValue ?? null},
+          ${r.note ?? null},
+          now(),
+          now()
+        )`,
+      );
+      await tx.$executeRaw`
+        INSERT INTO inspection_responses (
+          "id", "tenantId", "inspectionId", "snapshotItemId",
+          "booleanValue", "textValue", "numberValue", "note",
+          "createdAt", "updatedAt"
+        ) VALUES ${Prisma.join(valueRows, ', ')}
+        ON CONFLICT ("inspectionId", "snapshotItemId") DO UPDATE SET
+          "booleanValue" = EXCLUDED."booleanValue",
+          "textValue"    = EXCLUDED."textValue",
+          "numberValue"  = EXCLUDED."numberValue",
+          "note"         = EXCLUDED."note",
+          "updatedAt"    = now()
+      `;
+      return { count: rows.length };
     });
   }
 

--- a/apps/core-api/test/inspections-lifecycle.e2e.test.ts
+++ b/apps/core-api/test/inspections-lifecycle.e2e.test.ts
@@ -283,6 +283,98 @@ describe('inspections lifecycle e2e', () => {
     expect(payload['summaryNote']).toBe('all good');
   });
 
+  // PERF-03 (#62): respond is now a single INSERT … ON CONFLICT DO
+  // UPDATE round-trip. Smoke-test the batch + upsert (re-respond)
+  // semantics so the raw-SQL path matches the prior Prisma upsert
+  // behaviour on every shape.
+  it('respond batch upsert: multiple items in one call + re-respond replaces', async () => {
+    const cookie = await login(url, driverEmail, password);
+    const start = (await (
+      await fetch(`${url}/inspections`, {
+        method: 'POST',
+        headers: { cookie, 'content-type': 'application/json' },
+        body: JSON.stringify({ assetId: alphaAssetId }),
+      })
+    ).json()) as { id: string };
+
+    const insp = (await (
+      await fetch(`${url}/inspections/${start.id}`, { headers: { cookie } })
+    ).json()) as {
+      templateSnapshot: { items: Array<{ id: string; label: string; itemType: string }> };
+    };
+    const lights = insp.templateSnapshot.items.find((i) => i.label === 'Lights working?')!;
+    const mileage = insp.templateSnapshot.items.find((i) => i.label === 'Mileage')!;
+
+    // Batch of 2 different shapes (BOOLEAN + NUMBER) in one call.
+    const r1 = await fetch(`${url}/inspections/${start.id}/responses`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        responses: [
+          { snapshotItemId: lights.id, booleanValue: true },
+          { snapshotItemId: mileage.id, numberValue: 120_000 },
+        ],
+      }),
+    });
+    expect(r1.status).toBe(200);
+    expect(((await r1.json()) as { count: number }).count).toBe(2);
+
+    // Re-respond on the SAME item with a different value. ON CONFLICT
+    // DO UPDATE must replace the prior row (not insert a duplicate).
+    const r2 = await fetch(`${url}/inspections/${start.id}/responses`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        responses: [{ snapshotItemId: lights.id, booleanValue: false, note: 'left turn dim' }],
+      }),
+    });
+    expect(r2.status).toBe(200);
+
+    // Read-back via admin DB: still exactly two rows, lights row
+    // reflects the overwrite (booleanValue=false + note set).
+    const responses = await admin.inspectionResponse.findMany({
+      where: { inspectionId: start.id },
+    });
+    expect(responses).toHaveLength(2);
+    const lightsRow = responses.find((r) => r.snapshotItemId === lights.id)!;
+    expect(lightsRow.booleanValue).toBe(false);
+    expect(lightsRow.note).toBe('left turn dim');
+    const mileageRow = responses.find((r) => r.snapshotItemId === mileage.id)!;
+    expect(mileageRow.numberValue?.toString()).toBe('120000');
+
+    // Same snapshotItemId appearing twice in one batch — Postgres ON
+    // CONFLICT DO UPDATE raises 21000 if not deduped. The prior Prisma
+    // loop tolerated it as overwrite-in-order; the new SQL path
+    // dedupes by snapshotItemId keeping the last occurrence.
+    const r3 = await fetch(`${url}/inspections/${start.id}/responses`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        responses: [
+          { snapshotItemId: lights.id, booleanValue: true, note: 'first' },
+          { snapshotItemId: lights.id, booleanValue: false, note: 'last wins' },
+        ],
+      }),
+    });
+    expect(r3.status).toBe(200);
+    const r3Body = (await r3.json()) as { count: number };
+    expect(r3Body.count).toBe(1); // dedupe collapsed the pair
+    const reread = await admin.inspectionResponse.findMany({
+      where: { inspectionId: start.id, snapshotItemId: lights.id },
+    });
+    expect(reread).toHaveLength(1);
+    expect(reread[0]!.booleanValue).toBe(false);
+    expect(reread[0]!.note).toBe('last wins');
+
+    // Cleanup so subsequent tests don't trip on this in-progress row.
+    const cancelRes = await fetch(`${url}/inspections/${start.id}/cancel`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(cancelRes.status).toBe(200);
+  });
+
   it('complete fails 400 if a required item has no response', async () => {
     const cookie = await login(url, driverEmail, password);
     const start = (await (


### PR DESCRIPTION
## Summary
Closes **#62 [PERF-03]** (was Wave 1 DATA-10; reclassified critical in Wave 2c — driver cellular hot path).

\`InspectionService.respond()\` did N sequential Prisma upserts (~5ms/round-trip × 20 items = ~100ms; ~200ms at the 40-item template cap). Replaced with a single parameterised raw SQL \`INSERT … ON CONFLICT DO UPDATE\` built via \`Prisma.sql\` + \`Prisma.join\`. **N→1 round-trip collapse.**

**Safety:**
- \`tx.$executeRaw\` (parameterised tagged template) is the allowed form; \`$executeRawUnsafe\` remains forbidden in this module.
- \`Prisma\` is now a value import (was type-only).
- \`gen_random_uuid()\` server-side via pgcrypto (enabled in 0001).
- RLS: tenantId bound from the same actor that set the GUC; \`EXCLUDED.tenantId\` deliberately omitted from SET so existing-row tenantId never moves.
- Snapshot-validity trigger is FOR EACH ROW — fires N times, identical to prior loop.
- **Dedupe by snapshotItemId** before the SQL (last-write-wins) so the duplicate-in-batch case can't trigger Postgres 21000 cardinality_violation. Prior loop tolerated dupes as overwrite-in-order; this preserves that contract.

**Reviewed by data-architect:** APPROVE. Cardinality-violation dedupe was the one behavioural delta flagged — closed in this PR with a dedicated e2e ("same snapshotItemId twice → 200, count=1, last wins").

**Tests:** 1 new e2e covers BOOLEAN+NUMBER batch, idempotent re-respond, duplicate-in-batch dedupe. **323/323 backend pass** (was 322).

## Test plan
- [x] \`pnpm --filter @panorama/core-api test\` — 323/323
- [x] \`pnpm --filter @panorama/core-api typecheck\` — same 3 pre-existing CJS/ESM errors
- [x] data-architect review: APPROVE (after dedupe)
- [ ] CI green