### PR TITLE
feat(maintenance): auto-suggest tickets from damage + FAIL (#74 #40)

### DIFF
--- a/apps/core-api/prisma/migrations/20260426220000_0016_maintenance_open_per_trigger_unique/ROLLBACK.md
+++ b/apps/core-api/prisma/migrations/20260426220000_0016_maintenance_open_per_trigger_unique/ROLLBACK.md
@@ -1,0 +1,51 @@
+# Rollback — migration 0016 (per-trigger UNIQUE)
+
+Drops the two per-trigger UNIQUE partial indexes added by 0016.
+Safe in either direction. After rollback the auto-suggest retry
+race becomes possible again under multi-pod scaling — single-pod
+deploys today are unaffected because the dispatcher's claim
+mechanism + per-event runInTenant scoping keeps duplicate dispatch
+of a single event impossible inside one process.
+
+```sql
+BEGIN;
+
+DROP INDEX IF EXISTS "asset_maintenances_open_per_inspection_unique";
+DROP INDEX IF EXISTS "asset_maintenances_open_per_reservation_unique";
+
+COMMIT;
+```
+
+The `asset_maintenances_open_per_asset_partial` index from
+migration 0014 is unaffected — 0016 did not modify it. After
+rollback, the close-ticket / stale-sweep queries continue using
+that index.
+
+Code rollback (`git revert` of the implementation commit) is not
+required for the indexes alone. The `openTicketAuto` 23505 catch
+path becomes unreachable but compiles and is dormant — it returns
+`status: 'opened'` for new triggers and falls back to compare-
+then-act for existence checks, which is the v2 behaviour shipped
+in #132.
+
+## Pre-flight check (before re-applying after rollback)
+
+```sql
+SELECT "tenantId", "triggeringInspectionId", count(*)
+  FROM "asset_maintenances"
+ WHERE "triggeringInspectionId" IS NOT NULL
+   AND status IN ('OPEN', 'IN_PROGRESS')
+ GROUP BY "tenantId", "triggeringInspectionId"
+HAVING count(*) > 1;
+
+SELECT "tenantId", "triggeringReservationId", count(*)
+  FROM "asset_maintenances"
+ WHERE "triggeringReservationId" IS NOT NULL
+   AND status IN ('OPEN', 'IN_PROGRESS')
+ GROUP BY "tenantId", "triggeringReservationId"
+HAVING count(*) > 1;
+```
+
+Both empty = safe to re-apply 0016. Non-empty = manually resolve
+the duplicate-trigger tickets first (cancel the stale duplicate)
+before retrying.

--- a/apps/core-api/prisma/migrations/20260426220000_0016_maintenance_open_per_trigger_unique/migration.sql
+++ b/apps/core-api/prisma/migrations/20260426220000_0016_maintenance_open_per_trigger_unique/migration.sql
@@ -1,0 +1,74 @@
+-- Migration 0016 — Per-trigger UNIQUE partial indexes on
+-- `asset_maintenances` (closes the auto-suggest retry race).
+--
+-- Filed during the auto-suggest landing review (#74 PILOT-03 +
+-- #40 ARCH-15 PR), tech-lead + security-reviewer convergent BLOCKER
+-- on the "concurrent dispatcher" race.
+--
+-- The reviewers' first proposal was a UNIQUE partial on
+-- `(tenantId, assetId) WHERE status IN ('OPEN','IN_PROGRESS')` — a
+-- single-ticket-per-asset invariant. That conflicts with ADR-0016
+-- §3 "count-aware update" semantics + the manual `openTicket`
+-- path's multi-ticket capability + persona-fleet-ops's explicit
+-- ask for distinct tickets per distinct signal (a manual "rotate
+-- tires" plus an auto-suggested "cracked windshield" should both
+-- exist, not collapse).
+--
+-- The actual idempotency hole lives at the EVENT layer, not the
+-- ASSET layer: a single notification event being processed twice
+-- (multi-pod retry / dispatcher rescue) must produce one ticket,
+-- not two. The event's identity is its trigger ID — either
+-- `triggeringInspectionId` (FAIL inspection completion) or
+-- `triggeringReservationId` (damage check-in). Per-trigger UNIQUE
+-- partial indexes close the retry race exactly where it lives,
+-- without forbidding multi-ticket semantics.
+--
+-- ADR-0016 v3 §5 documents this design and supersedes v2's
+-- `DomainEventSubscriber` primitive proposal. The subscriber
+-- continues to do an application-level "any OPEN ticket on asset?"
+-- check first (friendly skip path, persona-acknowledged SHIPPABLE
+-- friction); the per-trigger UNIQUE catches retries that the check
+-- can't see.
+
+-- ---------------------------------------------------------------
+-- 1. UNIQUE partial: at most one OPEN/IN_PROGRESS ticket per
+--    triggering inspection.
+--
+--    Closes: same `panorama.inspection.completed` event re-fired
+--    by dispatcher rescue / multi-pod claim race produces the
+--    same ticket twice.
+-- ---------------------------------------------------------------
+
+CREATE UNIQUE INDEX "asset_maintenances_open_per_inspection_unique"
+    ON "asset_maintenances" ("tenantId", "triggeringInspectionId")
+    WHERE "triggeringInspectionId" IS NOT NULL
+      AND status IN ('OPEN', 'IN_PROGRESS');
+
+COMMENT ON INDEX "asset_maintenances_open_per_inspection_unique" IS
+    'ADR-0016 v3 §5 — at most one OPEN/IN_PROGRESS ticket per '
+    'triggering inspection. Catches the multi-pod auto-suggest '
+    'retry race; preserves multi-ticket-per-asset semantics.';
+
+-- ---------------------------------------------------------------
+-- 2. UNIQUE partial: at most one OPEN/IN_PROGRESS ticket per
+--    triggering reservation.
+--
+--    Closes: same `panorama.reservation.checked_in_with_damage`
+--    event re-fired produces the same ticket twice.
+-- ---------------------------------------------------------------
+
+CREATE UNIQUE INDEX "asset_maintenances_open_per_reservation_unique"
+    ON "asset_maintenances" ("tenantId", "triggeringReservationId")
+    WHERE "triggeringReservationId" IS NOT NULL
+      AND status IN ('OPEN', 'IN_PROGRESS');
+
+COMMENT ON INDEX "asset_maintenances_open_per_reservation_unique" IS
+    'ADR-0016 v3 §5 — at most one OPEN/IN_PROGRESS ticket per '
+    'triggering reservation. Catches the damage-check-in retry '
+    'race; preserves multi-ticket-per-asset semantics.';
+
+-- The existing `asset_maintenances_open_per_asset_partial`
+-- (tenantId, assetId, startedAt) WHERE OPEN/IN_PROGRESS index from
+-- migration 0014 is kept AS-IS (non-unique) — it serves the
+-- close-ticket "last open ticket on this asset" + hourly stale
+-- sweep queries, which need to count rather than dedup.

--- a/apps/core-api/prisma/migrations/20260426220000_0016_maintenance_open_per_trigger_unique/rls.sql
+++ b/apps/core-api/prisma/migrations/20260426220000_0016_maintenance_open_per_trigger_unique/rls.sql
@@ -1,0 +1,16 @@
+-- Migration 0016 — no RLS surface change.
+--
+-- This migration adds two partial UNIQUE indexes on
+-- `asset_maintenances` (per-trigger uniqueness — see migration.sql for
+-- the design rationale). Indexes do not interact with
+-- ENABLE/FORCE ROW LEVEL SECURITY policies; the existing tenant-scoped
+-- and privileged-bypass policies on `asset_maintenances` from
+-- migration 0014 continue to apply unchanged.
+--
+-- Placeholder kept for grep-greppability of the per-migration RLS
+-- audit pattern (project convention since migration 0012 — every
+-- migration on a tenant-scoped table either ships an `rls.sql` with
+-- the change OR a placeholder no-op so a reviewer can confirm at a
+-- glance that RLS was considered).
+
+SELECT 1;

--- a/apps/core-api/src/modules/maintenance/maintenance-ticket.subscriber.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance-ticket.subscriber.ts
@@ -53,6 +53,12 @@ import { MaintenanceService, type AutoOpenTicketParams } from './maintenance.ser
  * (tx-local) does not decide the contract — same defensive pattern
  * as `InspectionOutcomeEmailChannel`. `runAsSuperAdmin` is **forbidden**
  * in MaintenanceModule per ADR-0016 §1.4 / §7.2 + the #58 allowlist.
+ *
+ * XSS surface: `payload.summaryNote` and `payload.damageNote` are
+ * passed through to `params.notes` raw — the escape happens at write
+ * inside `MaintenanceService.openTicketAuto` via `escapeHtml(params.notes)`,
+ * matching the public `openTicket` path. Single chokepoint per ADR-0016
+ * security-reviewer blocker #3.
  */
 @Injectable()
 export class MaintenanceTicketSubscriber implements ChannelHandler {
@@ -139,9 +145,22 @@ export class MaintenanceTicketSubscriber implements ChannelHandler {
    *
    * Asset.tag is read here so the title carries a human-readable
    * vehicle identifier — same convention as the inspection-outcome
-   * email subject. A missing asset throws, since both events came
-   * from a publisher that already wrote a row keyed on assetId; an
-   * absence here means cross-tenant or schema corruption.
+   * email subject. A null `asset` here means **schema corruption**
+   * (assetId in the event payload no longer references a row): under
+   * `runInTenant(event.tenantId)`, RLS already filters out cross-
+   * tenant rows so the assetId-belongs-to-other-tenant case lands as
+   * null, indistinguishable from "row was deleted." The explicit
+   * `asset_cross_tenant` check below remains as belt-and-braces
+   * against an RLS-misconfiguration regression — under healthy RLS
+   * it is dead code.
+   *
+   * The interpolated `asset.tag` is NOT HTML-escaped. Title is
+   * plain-text-by-contract: REST consumers render via JSX (auto-
+   * escape) and the column carries the literal tag string. Notes
+   * by contrast carry user-typed multi-line content and ARE escaped
+   * at write inside `MaintenanceService.openTicketAuto`. The
+   * asymmetry is intentional — single chokepoint per
+   * security-reviewer blocker #3.
    */
   private async buildParams(
     tx: Prisma.TransactionClient,
@@ -170,11 +189,16 @@ export class MaintenanceTicketSubscriber implements ChannelHandler {
       });
       if (!asset) throw new Error('asset_not_found');
       if (asset.tenantId !== event.tenantId) throw new Error('asset_cross_tenant');
+      // persona-fleet-ops: prefix the title with the outcome so a
+      // coordinator scanning the maintenance dashboard can triage FAIL
+      // (vehicle won't pull out) vs NEEDS-MAINT (deferrable) at a
+      // glance — three characters of difference, big triage value.
+      const outcomeTag = payload.outcome === 'FAIL' ? 'FAIL' : 'NEEDS-MAINT';
       const params: AutoOpenTicketParams = {
         tenantId: event.tenantId,
         assetId: payload.assetId,
         maintenanceType: 'Repair',
-        title: `Inspection follow-up: ${asset.tag}`,
+        title: `Inspection ${outcomeTag}: ${asset.tag}`,
         notes: payload.summaryNote ?? null,
         triggeringInspectionId: payload.inspectionId,
         createdByUserId: systemActorUserId,

--- a/apps/core-api/src/modules/maintenance/maintenance-ticket.subscriber.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance-ticket.subscriber.ts
@@ -1,0 +1,220 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { NotificationEvent, Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+import type { ChannelHandler } from '../notification/channel-registry.js';
+import { MaintenanceService, type AutoOpenTicketParams } from './maintenance.service.js';
+
+/**
+ * MaintenanceTicketSubscriber — auto-suggest draft tickets from upstream
+ * domain signals (ADR-0016 §5).
+ *
+ * Subscribes to two events:
+ *
+ *   1. `panorama.reservation.checked_in_with_damage` — emitted by
+ *      ReservationService.checkIn when `damageFlag === true`. Closes the
+ *      dominant ~70% trigger path per persona-fleet-ops (driver returns
+ *      vehicle with damage → ticket auto-opens for ops).
+ *
+ *   2. `panorama.inspection.completed` with outcome IN ('FAIL',
+ *      'NEEDS_MAINTENANCE'). Closes the ADR-0012 §11 dead-end where
+ *      a FAIL inspection emits an email but never a ticket.
+ *
+ * Per-tenant gate: writes a ticket only when
+ * `tenant.autoOpenMaintenanceFromInspection = true` (default false).
+ * The flag default is conservative on purpose — flag-flip on a tenant
+ * with a backlog of historical FAIL signals would otherwise flood the
+ * dashboard. Pilot tenants opt in after their signal:noise calibration.
+ *
+ * --- Architectural note (ADR-0016 §5 v2 deviation) ---
+ *
+ * ADR-0016 §5 v2 sketched a new `DomainEventSubscriber` primitive that
+ * runs *inside the publisher's transaction*, coupling failure fates so
+ * a subscriber bug rolls the publisher back. v1's stated concern was
+ * "ChannelHandler silently drops the ticket creation on 40001."
+ *
+ * The current dispatcher does NOT silently drop — handler failures get
+ * retried with exponential backoff up to MAX_ATTEMPTS=5, then DEAD with
+ * an audit row. So the silent-drop concern is unfounded against the
+ * code as it stands.
+ *
+ * Coupled fate is also undesirable for this specific surface: a buggy
+ * MaintenanceTicketSubscriber would otherwise refuse driver check-ins
+ * (a primary user-facing flow) on every replay attempt. The outbox
+ * pattern keeps the user-facing flow committing successfully and
+ * surfaces subscriber failures via the dispatcher's retry/DEAD audit
+ * trail — operationally equivalent without the user-visible blast.
+ *
+ * Idempotency for the decoupled path lives in
+ * `MaintenanceService.openTicketAuto`: at most one OPEN/IN_PROGRESS
+ * ticket per asset, audited skip on duplicate.
+ *
+ * Tenant isolation: every Prisma read happens inside an explicit
+ * `runInTenant(event.tenantId)` so the dispatcher's outer GUC scope
+ * (tx-local) does not decide the contract — same defensive pattern
+ * as `InspectionOutcomeEmailChannel`. `runAsSuperAdmin` is **forbidden**
+ * in MaintenanceModule per ADR-0016 §1.4 / §7.2 + the #58 allowlist.
+ */
+@Injectable()
+export class MaintenanceTicketSubscriber implements ChannelHandler {
+  // Distinct name from other handlers — the registry rejects duplicates.
+  readonly name = 'maintenance-ticket';
+  private readonly log = new Logger('MaintenanceTicketSubscriber');
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly maintenance: MaintenanceService,
+  ) {}
+
+  supports(eventType: string): boolean {
+    return (
+      eventType === 'panorama.reservation.checked_in_with_damage' ||
+      eventType === 'panorama.inspection.completed'
+    );
+  }
+
+  async handle(event: NotificationEvent): Promise<void> {
+    if (!event.tenantId) {
+      // Auto-suggest is strictly tenant-scoped — refuse rather than fall
+      // through to runAsSuperAdmin and write under the wrong tenant.
+      throw new Error('missing_tenant_id');
+    }
+    const tenantId = event.tenantId;
+
+    await this.prisma.runInTenant(tenantId, async (tx) => {
+      const tenant = await tx.tenant.findUnique({
+        where: { id: tenantId },
+        select: {
+          autoOpenMaintenanceFromInspection: true,
+          systemActorUserId: true,
+        },
+      });
+      if (!tenant) {
+        // Stale event for a deleted tenant. Throwing would loop the
+        // dispatcher's retry path. Return cleanly so the row marks
+        // dispatched and the issue (deleted-tenant residual events)
+        // surfaces via the cleanup audit trail elsewhere.
+        this.log.warn(
+          { eventId: event.id, eventType: event.eventType, tenantId },
+          'auto_suggest_tenant_missing',
+        );
+        return;
+      }
+      if (!tenant.autoOpenMaintenanceFromInspection) {
+        // Per-tenant opt-in — log + return cleanly so the event marks
+        // dispatched on first attempt instead of accumulating retries.
+        this.log.log(
+          { eventId: event.id, eventType: event.eventType, tenantId },
+          'auto_suggest_skipped_flag_off',
+        );
+        return;
+      }
+
+      const params = await this.buildParams(tx, event, tenant.systemActorUserId);
+      if (!params) {
+        // PASS outcome on inspection.completed → no ticket. The event
+        // itself still dispatches successfully.
+        return;
+      }
+
+      const result = await this.maintenance.openTicketAuto(tx, params);
+      this.log.log(
+        {
+          eventId: event.id,
+          eventType: event.eventType,
+          tenantId,
+          source: params.source,
+          result: result.status,
+          ...(result.status === 'opened'
+            ? { ticketId: result.ticketId }
+            : { reason: result.reason, existingTicketId: result.existingTicketId }),
+        },
+        'auto_suggest_processed',
+      );
+    });
+  }
+
+  /**
+   * Translate the bus event into the `openTicketAuto` shape. Returns
+   * null when the event is a no-op (PASS outcome on inspection).
+   *
+   * Asset.tag is read here so the title carries a human-readable
+   * vehicle identifier — same convention as the inspection-outcome
+   * email subject. A missing asset throws, since both events came
+   * from a publisher that already wrote a row keyed on assetId; an
+   * absence here means cross-tenant or schema corruption.
+   */
+  private async buildParams(
+    tx: Prisma.TransactionClient,
+    event: NotificationEvent,
+    systemActorUserId: string,
+  ): Promise<AutoOpenTicketParams | null> {
+    if (event.eventType === 'panorama.inspection.completed') {
+      const payload = event.payload as {
+        inspectionId: string;
+        assetId: string;
+        reservationId: string | null;
+        startedByUserId: string;
+        outcome: 'PASS' | 'FAIL' | 'NEEDS_MAINTENANCE';
+        summaryNote?: string;
+      };
+      if (payload.outcome === 'PASS') {
+        this.log.log(
+          { eventId: event.id, outcome: 'PASS' },
+          'auto_suggest_skipped_pass_outcome',
+        );
+        return null;
+      }
+      const asset = await tx.asset.findUnique({
+        where: { id: payload.assetId },
+        select: { tag: true, tenantId: true },
+      });
+      if (!asset) throw new Error('asset_not_found');
+      if (asset.tenantId !== event.tenantId) throw new Error('asset_cross_tenant');
+      const params: AutoOpenTicketParams = {
+        tenantId: event.tenantId,
+        assetId: payload.assetId,
+        maintenanceType: 'Repair',
+        title: `Inspection follow-up: ${asset.tag}`,
+        notes: payload.summaryNote ?? null,
+        triggeringInspectionId: payload.inspectionId,
+        createdByUserId: systemActorUserId,
+        originalActorUserId: payload.startedByUserId,
+        source: 'inspection_subscriber',
+      };
+      if (payload.reservationId) params.triggeringReservationId = payload.reservationId;
+      return params;
+    }
+
+    if (event.eventType === 'panorama.reservation.checked_in_with_damage') {
+      const payload = event.payload as {
+        reservationId: string;
+        assetId: string;
+        requesterUserId: string;
+        checkedInByUserId: string;
+        checkedInAt: string;
+        mileageIn: number;
+        damageNote?: string;
+      };
+      const asset = await tx.asset.findUnique({
+        where: { id: payload.assetId },
+        select: { tag: true, tenantId: true },
+      });
+      if (!asset) throw new Error('asset_not_found');
+      if (asset.tenantId !== event.tenantId) throw new Error('asset_cross_tenant');
+      return {
+        tenantId: event.tenantId,
+        assetId: payload.assetId,
+        maintenanceType: 'Repair',
+        title: `Damage flagged at check-in: ${asset.tag}`,
+        notes: payload.damageNote ?? null,
+        triggeringReservationId: payload.reservationId,
+        createdByUserId: systemActorUserId,
+        originalActorUserId: payload.checkedInByUserId,
+        source: 'checkin_subscriber',
+      };
+    }
+
+    // supports() should have filtered these out, but defence-in-depth.
+    throw new Error(`unsupported_event_type:${event.eventType}`);
+  }
+}

--- a/apps/core-api/src/modules/maintenance/maintenance.module.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance.module.ts
@@ -1,5 +1,6 @@
 /**
- * Maintenance module — MVP slice of ADR-0016.
+ * Maintenance module — MVP slice of ADR-0016 + auto-suggest subscriber
+ * (#74 PILOT-03 + #40 ARCH-15).
  *
  * Forbid-list invariant (ADR-0016 §1.4 + §7.2): the entire maintenance
  * module writes via `runInTenant(tenantId, …)` only — `runAsSuperAdmin`
@@ -8,16 +9,36 @@
  * Loaded conditionally at app boot when `FEATURE_MAINTENANCE` is on
  * (default false — see app.module.ts). Mirrors the FEATURE_INSPECTIONS
  * gating pattern so a community deploy with maintenance off doesn't
- * register the routes.
+ * register the routes — and, by extension, doesn't register the
+ * MaintenanceTicketSubscriber on the notification bus, so damage
+ * check-in / FAIL inspection events flow through with no handler.
  */
-import { Module } from '@nestjs/common';
+import { Module, OnModuleInit } from '@nestjs/common';
+import { NotificationModule } from '../notification/notification.module.js';
+import { ChannelRegistry } from '../notification/channel-registry.js';
 import { MaintenanceController } from './maintenance.controller.js';
 import { MaintenanceService } from './maintenance.service.js';
+import { MaintenanceTicketSubscriber } from './maintenance-ticket.subscriber.js';
 
 // PrismaModule + AuditModule are @Global so no explicit import needed.
 @Module({
+  imports: [NotificationModule],
   controllers: [MaintenanceController],
-  providers: [MaintenanceService],
+  providers: [MaintenanceService, MaintenanceTicketSubscriber],
   exports: [MaintenanceService],
 })
-export class MaintenanceModule {}
+export class MaintenanceModule implements OnModuleInit {
+  constructor(
+    private readonly registry: ChannelRegistry,
+    private readonly subscriber: MaintenanceTicketSubscriber,
+  ) {}
+
+  onModuleInit(): void {
+    // ADR-0016 §5: register the auto-suggest subscriber on the bus. The
+    // ChannelRegistry rejects duplicates by name, so a second module
+    // load (HMR / test harness re-import) would fail loud. NotificationModule
+    // is loaded eagerly in app.module.ts and registers its own handlers
+    // before MaintenanceModule's onModuleInit runs.
+    this.registry.register(this.subscriber);
+  }
+}

--- a/apps/core-api/src/modules/maintenance/maintenance.service.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance.service.ts
@@ -38,6 +38,7 @@ import {
   ConflictException,
   ForbiddenException,
   Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import type { AssetMaintenance, Prisma } from '@prisma/client';
@@ -95,6 +96,8 @@ export type AutoOpenResult =
 
 @Injectable()
 export class MaintenanceService {
+  private readonly log = new Logger('MaintenanceService');
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly audit: AuditService,
@@ -649,23 +652,31 @@ export class MaintenanceService {
       // per-asset semantics) and convert to a `skipped` result so
       // the dispatcher marks the event DISPATCHED.
       if (isMaintenanceOpenUniqueViolation(err)) {
-        // Look up the conflicting ticket by trigger ID. Each event has
-        // exactly one of triggeringInspectionId / triggeringReservationId
-        // set per the publisher contracts (inspection.completed populates
-        // inspection; reservation.checked_in_with_damage populates
-        // reservation). At least one is non-null on every auto-suggest
-        // call site; this branch finds whichever the partial UNIQUE
-        // index actually rejected.
+        // Look up the conflicting ticket by trigger ID. The two
+        // partial UNIQUE indexes are independent: an event can populate
+        // both `triggeringInspectionId` and `triggeringReservationId`
+        // (the inspection subscriber sets both when the inspection is
+        // tied to a reservation), and Postgres surfaces only the FIRST
+        // unique violation it encounters. Use OR so the recovery
+        // findFirst matches the existing ticket whichever index
+        // rejected — including the cross-trigger collapse case where
+        // a second FAIL inspection on the same reservation conflicts
+        // on the per-reservation UNIQUE rather than the per-inspection
+        // one (ADR-0016 v3 §5: distinct triggers within the same
+        // reservation collapse to one ticket — same-root-cause ops
+        // semantics).
         const winner = await tx.assetMaintenance.findFirst({
           where: {
             tenantId: params.tenantId,
             status: { in: ['OPEN', 'IN_PROGRESS'] },
-            ...(params.triggeringInspectionId
-              ? { triggeringInspectionId: params.triggeringInspectionId }
-              : {}),
-            ...(params.triggeringReservationId
-              ? { triggeringReservationId: params.triggeringReservationId }
-              : {}),
+            OR: [
+              ...(params.triggeringInspectionId
+                ? [{ triggeringInspectionId: params.triggeringInspectionId }]
+                : []),
+              ...(params.triggeringReservationId
+                ? [{ triggeringReservationId: params.triggeringReservationId }]
+                : []),
+            ],
           },
           select: { id: true },
         });
@@ -674,8 +685,22 @@ export class MaintenanceService {
         // the original error if the committed snapshot somehow hides
         // the winner. (Could happen if the partial predicate excludes
         // the existing row — e.g. it transitioned to COMPLETED between
-        // the conflict and this lookup.)
-        if (!winner) throw err;
+        // the conflict and this lookup.) Log so an SRE seeing a raw
+        // 23505 in prod can correlate to which event payload tripped
+        // the unreachable branch.
+        if (!winner) {
+          this.log.warn(
+            {
+              tenantId: params.tenantId,
+              assetId: params.assetId,
+              triggeringInspectionId: params.triggeringInspectionId ?? null,
+              triggeringReservationId: params.triggeringReservationId ?? null,
+              source: params.source,
+            },
+            'maintenance_open_unique_violation_no_winner_found',
+          );
+          throw err;
+        }
         await this.audit.recordWithin(tx, {
           action: 'panorama.maintenance.auto_suggest_skipped',
           resourceType: 'asset_maintenance',
@@ -766,20 +791,23 @@ export class MaintenanceService {
 
 /**
  * Returns true iff `err` looks like a Postgres unique-violation that
- * would have come from `asset_maintenances_open_per_asset_unique`
- * (ADR-0016 v3 migration 0016). Used by both `openTicket` and
- * `openTicketAuto` to convert the multi-pod race into a controlled
- * skip / 409 instead of bubbling a Prisma error to the controller.
+ * would have come from one of the two per-trigger partial UNIQUE
+ * indexes shipped in ADR-0016 v3 migration 0016
+ * (`asset_maintenances_open_per_inspection_unique` /
+ * `asset_maintenances_open_per_reservation_unique`). Used by both
+ * `openTicket` and `openTicketAuto` to convert the multi-pod retry
+ * race into a controlled `skipped` / 409 instead of bubbling a
+ * Prisma error to the controller.
  *
  * Mirrors the helper in `notification.service.ts`: Prisma surfaces
  * unique violations as `P2002` on the typed error, and the underlying
  * Postgres `23505` is in `meta.code` for the raw-SQL paths.
  *
- * No constraint-name check: `asset_maintenances` has only one unique
- * index on this row shape (the photo unique lives on a separate
- * table), so any P2002 reaching this catch block came from the
- * open-per-asset rule. If a future migration adds a second unique
- * constraint to this table, narrow with `meta.target`.
+ * Both per-trigger UNIQUEs are handled identically by the catch path
+ * (the recovery `findFirst` filters by whichever trigger field this
+ * call site populated), so no constraint-name disambiguation is
+ * needed. If a future migration adds a per-asset or per-photo unique
+ * to this table, narrow with `meta.target`.
  */
 function isMaintenanceOpenUniqueViolation(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;

--- a/apps/core-api/src/modules/maintenance/maintenance.service.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance.service.ts
@@ -7,6 +7,13 @@
  *                   MAINTENANCE if not IN_USE; otherwise the
  *                   reservation is marked stranded and an
  *                   `opened_on_checked_out` audit row records it.
+ *   - openTicketAuto — system-attributed entry point for the
+ *                   MaintenanceTicketSubscriber (ADR-0016 §5). Same
+ *                   ticket-creation + asset-state semantics as
+ *                   openTicket, minus the user-authz checks. Idempotent
+ *                   via the `existing OPEN/IN_PROGRESS` skip rule so
+ *                   dispatcher retries cannot double-open. Caller passes
+ *                   a tx and `tenant.systemActorUserId`.
  *   - list        — paginated, tenant-scoped, optional filters.
  *   - getById     — single ticket within tenant.
  *   - updateStatus — service-layer state machine:
@@ -16,7 +23,6 @@
  *                   no other open tickets remain.
  *
  * Deferred to follow-up PRs (ADR-0016 §4-9):
- *   - Auto-suggest subscriber on FAIL inspection / damage check-in
  *   - PM-due cron / mileage threshold sweep
  *   - Stranded-reservation auto-recovery
  *   - Reopen flow with within-window guard
@@ -34,7 +40,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import type { AssetMaintenance } from '@prisma/client';
+import type { AssetMaintenance, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { AuditService } from '../audit/audit.service.js';
 import type { OpenTicketInput, UpdateStatusInput } from './maintenance.dto.js';
@@ -59,6 +65,33 @@ export interface ListTicketsParams {
   limit?: number;
   cursor?: string;
 }
+
+/**
+ * Input for the system-attributed auto-open path consumed by the
+ * MaintenanceTicketSubscriber. Mirrors `OpenTicketInput` but trims the
+ * fields the subscriber never sets (assignee, supplier, cost, …) and
+ * adds the audit-trail metadata required by ADR-0016 §5.
+ */
+export interface AutoOpenTicketParams {
+  tenantId: string;
+  assetId: string;
+  maintenanceType: 'Repair';
+  title: string;
+  notes: string | null;
+  triggeringReservationId?: string;
+  triggeringInspectionId?: string;
+  /** `tenant.systemActorUserId` — the audit row's `actorUserId` is null
+   *  (system-attributed), but the maintenance row needs a real FK. */
+  createdByUserId: string;
+  /** The human who triggered upstream — recorded in audit metadata so the
+   *  chain ties back. ADR-0016 §5 `originalActorUserId`. */
+  originalActorUserId: string;
+  source: 'inspection_subscriber' | 'checkin_subscriber';
+}
+
+export type AutoOpenResult =
+  | { status: 'opened'; ticketId: string }
+  | { status: 'skipped'; reason: 'existing_open_ticket' | 'asset_archived' | 'asset_retired'; existingTicketId: string | null };
 
 @Injectable()
 export class MaintenanceService {
@@ -457,6 +490,182 @@ export class MaintenanceService {
 
       return updated;
     });
+  }
+
+  /**
+   * System-attributed auto-open path (ADR-0016 §5). Called by
+   * `MaintenanceTicketSubscriber` from inside its `runInTenant` scope —
+   * caller supplies the `tx` so this nests, no separate transaction.
+   *
+   * Idempotency model: at most one OPEN/IN_PROGRESS ticket per asset.
+   * If one already exists, this returns `skipped` with the existing
+   * ticket id and audits `panorama.maintenance.auto_suggest_skipped`.
+   * That covers two scenarios:
+   *   1. Dispatcher retry of an event whose first invocation succeeded
+   *      but failed to mark dispatched.
+   *   2. A second upstream signal (e.g. damage check-in then FAIL
+   *      inspection on the same asset) where one ticket is enough —
+   *      ops can amend the existing ticket rather than juggle two.
+   *
+   * Asset-state flip and stranded-reservation marking match the public
+   * `openTicket` shape so auto-suggested and manually-opened tickets are
+   * indistinguishable to downstream consumers (banner UI, dashboards).
+   *
+   * The audit row carries `source` + `originalActorUserId` so the chain
+   * remains traceable — without those fields every auto-suggested ticket
+   * would attribute to "system" with no path back to the human signal.
+   */
+  async openTicketAuto(
+    tx: Prisma.TransactionClient,
+    params: AutoOpenTicketParams,
+  ): Promise<AutoOpenResult> {
+    const asset = await tx.asset.findUnique({
+      where: { id: params.assetId },
+      select: { id: true, tenantId: true, status: true, archivedAt: true },
+    });
+    // tenantId equality is redundant under the subscriber's runInTenant
+    // RLS scope — kept as belt-and-braces so a future refactor does not
+    // silently widen.
+    if (!asset || asset.tenantId !== params.tenantId) {
+      throw new NotFoundException('asset_not_found');
+    }
+    if (asset.archivedAt) {
+      await this.audit.recordWithin(tx, {
+        action: 'panorama.maintenance.auto_suggest_skipped',
+        resourceType: 'asset',
+        resourceId: params.assetId,
+        tenantId: params.tenantId,
+        actorUserId: null,
+        metadata: {
+          reason: 'asset_archived',
+          source: params.source,
+          triggeringInspectionId: params.triggeringInspectionId ?? null,
+          triggeringReservationId: params.triggeringReservationId ?? null,
+        },
+      });
+      return { status: 'skipped', reason: 'asset_archived', existingTicketId: null };
+    }
+    if (asset.status === 'RETIRED') {
+      await this.audit.recordWithin(tx, {
+        action: 'panorama.maintenance.auto_suggest_skipped',
+        resourceType: 'asset',
+        resourceId: params.assetId,
+        tenantId: params.tenantId,
+        actorUserId: null,
+        metadata: {
+          reason: 'asset_retired',
+          source: params.source,
+          triggeringInspectionId: params.triggeringInspectionId ?? null,
+          triggeringReservationId: params.triggeringReservationId ?? null,
+        },
+      });
+      return { status: 'skipped', reason: 'asset_retired', existingTicketId: null };
+    }
+
+    const existingOpen = await tx.assetMaintenance.findFirst({
+      where: {
+        tenantId: params.tenantId,
+        assetId: params.assetId,
+        status: { in: ['OPEN', 'IN_PROGRESS'] },
+      },
+      orderBy: { startedAt: 'desc' },
+      select: { id: true },
+    });
+    if (existingOpen) {
+      await this.audit.recordWithin(tx, {
+        action: 'panorama.maintenance.auto_suggest_skipped',
+        resourceType: 'asset_maintenance',
+        resourceId: existingOpen.id,
+        tenantId: params.tenantId,
+        actorUserId: null,
+        metadata: {
+          reason: 'existing_open_ticket',
+          assetId: params.assetId,
+          source: params.source,
+          triggeringInspectionId: params.triggeringInspectionId ?? null,
+          triggeringReservationId: params.triggeringReservationId ?? null,
+          originalActorUserId: params.originalActorUserId,
+        },
+      });
+      return { status: 'skipped', reason: 'existing_open_ticket', existingTicketId: existingOpen.id };
+    }
+
+    const escapedNotes = params.notes ? escapeHtml(params.notes) : null;
+    const created = await tx.assetMaintenance.create({
+      data: {
+        tenantId: params.tenantId,
+        assetId: params.assetId,
+        maintenanceType: params.maintenanceType,
+        title: params.title,
+        status: 'OPEN',
+        triggeringReservationId: params.triggeringReservationId ?? null,
+        triggeringInspectionId: params.triggeringInspectionId ?? null,
+        notes: escapedNotes,
+        createdByUserId: params.createdByUserId,
+      },
+    });
+
+    let strandedReservationId: string | null = null;
+    if (asset.status === 'IN_USE') {
+      const inUse = await tx.reservation.findFirst({
+        where: {
+          tenantId: params.tenantId,
+          assetId: params.assetId,
+          lifecycleStatus: 'CHECKED_OUT',
+        },
+        select: { id: true },
+      });
+      if (inUse) {
+        strandedReservationId = inUse.id;
+        await tx.reservation.update({
+          where: { id: inUse.id },
+          data: { isStranded: true },
+        });
+      }
+    } else {
+      await tx.asset.update({
+        where: { id: params.assetId },
+        data: { status: 'MAINTENANCE' },
+      });
+    }
+
+    await this.audit.recordWithin(tx, {
+      action: 'panorama.maintenance.opened',
+      resourceType: 'asset_maintenance',
+      resourceId: created.id,
+      tenantId: params.tenantId,
+      // System-attributed: actorUserId null. The human chain lives in
+      // `metadata.originalActorUserId` per ADR-0016 §5.
+      actorUserId: null,
+      metadata: {
+        assetId: params.assetId,
+        maintenanceType: params.maintenanceType,
+        severity: null,
+        triggeringReservationId: params.triggeringReservationId ?? null,
+        triggeringInspectionId: params.triggeringInspectionId ?? null,
+        assetWasInUse: asset.status === 'IN_USE',
+        strandedReservationId,
+        source: params.source,
+        originalActorUserId: params.originalActorUserId,
+      },
+    });
+    if (asset.status === 'IN_USE' && strandedReservationId) {
+      await this.audit.recordWithin(tx, {
+        action: 'panorama.maintenance.opened_on_checked_out',
+        resourceType: 'asset_maintenance',
+        resourceId: created.id,
+        tenantId: params.tenantId,
+        actorUserId: null,
+        metadata: {
+          assetId: params.assetId,
+          strandedReservationId,
+          source: params.source,
+          originalActorUserId: params.originalActorUserId,
+        },
+      });
+    }
+
+    return { status: 'opened', ticketId: created.id };
   }
 }
 

--- a/apps/core-api/src/modules/maintenance/maintenance.service.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance.service.ts
@@ -200,28 +200,47 @@ export class MaintenanceService {
       // needed but the column should never carry live HTML.
       const escapedNotes = input.notes ? escapeHtml(input.notes) : null;
 
-      const created = await tx.assetMaintenance.create({
-        data: {
-          tenantId: actor.tenantId,
-          assetId: input.assetId,
-          maintenanceType: input.maintenanceType,
-          title: input.title,
-          status: 'OPEN',
-          severity: input.severity ?? null,
-          triggeringReservationId: input.triggeringReservationId ?? null,
-          triggeringInspectionId: input.triggeringInspectionId ?? null,
-          assigneeUserId: input.assigneeUserId ?? null,
-          supplierName: input.supplierName ?? null,
-          mileageAtService: input.mileageAtService ?? null,
-          expectedReturnAt: input.expectedReturnAt
-            ? new Date(input.expectedReturnAt)
-            : null,
-          cost: input.cost ?? null,
-          isWarranty: input.isWarranty ?? false,
-          notes: escapedNotes,
-          createdByUserId: actor.userId,
-        },
-      });
+      // Per-trigger UNIQUE indexes (migration 0016) reject a manual
+      // open whose trigger matches an already-OPEN auto-suggested
+      // ticket. Convert to a 409 with a clear code so the UI can
+      // surface "ticket already exists for this inspection /
+      // reservation" instead of a generic Prisma error. Manual opens
+      // with null trigger fields never hit this branch — the partial
+      // predicate excludes them — so the existing multi-ticket-per-
+      // asset behaviour is unchanged.
+      let created;
+      try {
+        created = await tx.assetMaintenance.create({
+          data: {
+            tenantId: actor.tenantId,
+            assetId: input.assetId,
+            maintenanceType: input.maintenanceType,
+            title: input.title,
+            status: 'OPEN',
+            severity: input.severity ?? null,
+            triggeringReservationId: input.triggeringReservationId ?? null,
+            triggeringInspectionId: input.triggeringInspectionId ?? null,
+            assigneeUserId: input.assigneeUserId ?? null,
+            supplierName: input.supplierName ?? null,
+            mileageAtService: input.mileageAtService ?? null,
+            expectedReturnAt: input.expectedReturnAt
+              ? new Date(input.expectedReturnAt)
+              : null,
+            cost: input.cost ?? null,
+            isWarranty: input.isWarranty ?? false,
+            notes: escapedNotes,
+            createdByUserId: actor.userId,
+          },
+        });
+      } catch (err) {
+        if (
+          isMaintenanceOpenUniqueViolation(err) &&
+          (input.triggeringInspectionId || input.triggeringReservationId)
+        ) {
+          throw new ConflictException('open_ticket_for_trigger_exists');
+        }
+        throw err;
+      }
 
       // Asset state integration (ADR-0016 §3):
       //  - asset IN_USE  → leave status; mark reservation stranded;
@@ -591,19 +610,95 @@ export class MaintenanceService {
     }
 
     const escapedNotes = params.notes ? escapeHtml(params.notes) : null;
-    const created = await tx.assetMaintenance.create({
-      data: {
-        tenantId: params.tenantId,
-        assetId: params.assetId,
-        maintenanceType: params.maintenanceType,
-        title: params.title,
-        status: 'OPEN',
-        triggeringReservationId: params.triggeringReservationId ?? null,
-        triggeringInspectionId: params.triggeringInspectionId ?? null,
-        notes: escapedNotes,
-        createdByUserId: params.createdByUserId,
-      },
-    });
+    let created: AssetMaintenance;
+    // Wrap the create in a SAVEPOINT so a 23505 from the per-trigger
+    // UNIQUE indexes (migration 0016) doesn't poison the surrounding
+    // transaction. Without the SAVEPOINT, Postgres flips the tx into
+    // SQLSTATE 25P02 (current transaction is aborted) on the next
+    // command, and the recovery findFirst can't run. ROLLBACK TO
+    // SAVEPOINT brings the tx back to a runnable state with the
+    // failed insert effectively un-attempted.
+    await tx.$executeRawUnsafe('SAVEPOINT before_maintenance_create');
+    try {
+      created = await tx.assetMaintenance.create({
+        data: {
+          tenantId: params.tenantId,
+          assetId: params.assetId,
+          maintenanceType: params.maintenanceType,
+          title: params.title,
+          status: 'OPEN',
+          triggeringReservationId: params.triggeringReservationId ?? null,
+          triggeringInspectionId: params.triggeringInspectionId ?? null,
+          notes: escapedNotes,
+          createdByUserId: params.createdByUserId,
+        },
+      });
+      await tx.$executeRawUnsafe('RELEASE SAVEPOINT before_maintenance_create');
+    } catch (err) {
+      await tx.$executeRawUnsafe('ROLLBACK TO SAVEPOINT before_maintenance_create');
+      // Migration 0016 added per-trigger UNIQUE partial indexes on
+      // (tenantId, triggeringInspectionId) and (tenantId,
+      // triggeringReservationId) — both partial WHERE NOT NULL AND
+      // status IN ('OPEN','IN_PROGRESS'). The race that lands here
+      // is a dispatcher rescue / multi-pod retry of the same event:
+      // a successful first attempt committed the row, then the
+      // event was re-claimed and re-processed.
+      //
+      // Look up the existing ticket BY TRIGGER (not by asset — see
+      // ADR-0016 v3 §5 on why per-trigger preserves multi-ticket-
+      // per-asset semantics) and convert to a `skipped` result so
+      // the dispatcher marks the event DISPATCHED.
+      if (isMaintenanceOpenUniqueViolation(err)) {
+        // Look up the conflicting ticket by trigger ID. Each event has
+        // exactly one of triggeringInspectionId / triggeringReservationId
+        // set per the publisher contracts (inspection.completed populates
+        // inspection; reservation.checked_in_with_damage populates
+        // reservation). At least one is non-null on every auto-suggest
+        // call site; this branch finds whichever the partial UNIQUE
+        // index actually rejected.
+        const winner = await tx.assetMaintenance.findFirst({
+          where: {
+            tenantId: params.tenantId,
+            status: { in: ['OPEN', 'IN_PROGRESS'] },
+            ...(params.triggeringInspectionId
+              ? { triggeringInspectionId: params.triggeringInspectionId }
+              : {}),
+            ...(params.triggeringReservationId
+              ? { triggeringReservationId: params.triggeringReservationId }
+              : {}),
+          },
+          select: { id: true },
+        });
+        // Should be unreachable-empty when 23505 just fired against
+        // this row's partial predicate, but defence-in-depth: surface
+        // the original error if the committed snapshot somehow hides
+        // the winner. (Could happen if the partial predicate excludes
+        // the existing row — e.g. it transitioned to COMPLETED between
+        // the conflict and this lookup.)
+        if (!winner) throw err;
+        await this.audit.recordWithin(tx, {
+          action: 'panorama.maintenance.auto_suggest_skipped',
+          resourceType: 'asset_maintenance',
+          resourceId: winner.id,
+          tenantId: params.tenantId,
+          actorUserId: null,
+          metadata: {
+            reason: 'concurrent_open_race_lost',
+            assetId: params.assetId,
+            source: params.source,
+            triggeringInspectionId: params.triggeringInspectionId ?? null,
+            triggeringReservationId: params.triggeringReservationId ?? null,
+            originalActorUserId: params.originalActorUserId,
+          },
+        });
+        return {
+          status: 'skipped',
+          reason: 'existing_open_ticket',
+          existingTicketId: winner.id,
+        };
+      }
+      throw err;
+    }
 
     let strandedReservationId: string | null = null;
     if (asset.status === 'IN_USE') {
@@ -667,6 +762,29 @@ export class MaintenanceService {
 
     return { status: 'opened', ticketId: created.id };
   }
+}
+
+/**
+ * Returns true iff `err` looks like a Postgres unique-violation that
+ * would have come from `asset_maintenances_open_per_asset_unique`
+ * (ADR-0016 v3 migration 0016). Used by both `openTicket` and
+ * `openTicketAuto` to convert the multi-pod race into a controlled
+ * skip / 409 instead of bubbling a Prisma error to the controller.
+ *
+ * Mirrors the helper in `notification.service.ts`: Prisma surfaces
+ * unique violations as `P2002` on the typed error, and the underlying
+ * Postgres `23505` is in `meta.code` for the raw-SQL paths.
+ *
+ * No constraint-name check: `asset_maintenances` has only one unique
+ * index on this row shape (the photo unique lives on a separate
+ * table), so any P2002 reaching this catch block came from the
+ * open-per-asset rule. If a future migration adds a second unique
+ * constraint to this table, narrow with `meta.target`.
+ */
+function isMaintenanceOpenUniqueViolation(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { code?: unknown; meta?: { code?: unknown } };
+  return e.code === 'P2002' || e.meta?.code === '23505';
 }
 
 function escapeHtml(s: string): string {

--- a/apps/core-api/src/modules/notification/notification-events.schema.ts
+++ b/apps/core-api/src/modules/notification/notification-events.schema.ts
@@ -59,6 +59,27 @@ export const NOTIFICATION_PAYLOAD_SCHEMAS = {
       summaryNote: z.string().max(500).optional(),
     })
     .strict(),
+
+  // ADR-0016 §5 dominant trigger path (~70% of auto-suggested tickets per
+  // persona-fleet-ops analysis). Emitted by ReservationService.checkIn
+  // when `damageFlag === true`. The MaintenanceTicketSubscriber consumes
+  // it to open a draft ticket, gated by `tenant.autoOpenMaintenanceFromInspection`.
+  // Wave 1 ARCH-15 / #40: this event was specced in the ADR but never
+  // emitted until the auto-suggest slice landed.
+  'panorama.reservation.checked_in_with_damage': z
+    .object({
+      reservationId: z.string().uuid(),
+      assetId: z.string().uuid(),
+      requesterUserId: z.string().uuid(),
+      checkedInByUserId: z.string().uuid(),
+      checkedInAt: z.string().datetime(),
+      mileageIn: z.number().int().nonnegative(),
+      // Free-text driver note describing the damage — bounded so payload
+      // stays small + fits in the maintenance ticket's `notes` field
+      // when the subscriber HTML-escapes it at write.
+      damageNote: z.string().max(500).optional(),
+    })
+    .strict(),
 } as const;
 
 export type NotificationEventType = keyof typeof NOTIFICATION_PAYLOAD_SCHEMAS;

--- a/apps/core-api/src/modules/reservation/reservation.service.ts
+++ b/apps/core-api/src/modules/reservation/reservation.service.ts
@@ -1046,6 +1046,40 @@ export class ReservationService {
             lastReadMileageUpdated: shouldUpdateMileage,
           },
         });
+
+        // ADR-0016 §5 / #40 ARCH-15: emit the dominant auto-suggest
+        // trigger event when the driver flagged damage at check-in. The
+        // event flows through the same notification bus as
+        // `panorama.inspection.completed`; the MaintenanceTicketSubscriber
+        // (gated per-tenant by `autoOpenMaintenanceFromInspection`)
+        // decides whether to open a draft ticket.
+        //
+        // The event is emitted regardless of the per-tenant flag — the
+        // bus row is the audit-recoverable trail of "the driver reported
+        // damage on this reservation," letting a later flag-flip + manual
+        // backfill replay missed events. The subscriber's no-op-when-flag-
+        // off is logged + benign.
+        //
+        // dedupKey is keyed on the reservation so an idempotent retry of
+        // checkIn (a 5xx-after-commit + client retry, hypothetically)
+        // does not enqueue twice. The subscriber additionally guards via
+        // an existing-OPEN-ticket check so re-emission cannot double-open.
+        if (damageFlag) {
+          await this.notifications.enqueueWithin(tx, {
+            eventType: 'panorama.reservation.checked_in_with_damage',
+            tenantId: actor.tenantId,
+            payload: {
+              reservationId,
+              assetId: existing.assetId,
+              requesterUserId: existing.requesterUserId,
+              checkedInByUserId: actor.userId,
+              checkedInAt: now.toISOString(),
+              mileageIn: params.mileage,
+              ...(params.damageNote ? { damageNote: params.damageNote } : {}),
+            },
+            dedupKey: `checkin_damage:${reservationId}`,
+          });
+        }
         return updated;
       },
     );

--- a/apps/core-api/test/maintenance-tether.e2e.test.ts
+++ b/apps/core-api/test/maintenance-tether.e2e.test.ts
@@ -1,0 +1,551 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Test } from '@nestjs/testing';
+import type { INestApplication } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+import { AppModule } from '../src/app.module.js';
+import { PasswordService } from '../src/modules/auth/password.service.js';
+import { TenantAdminService } from '../src/modules/tenant/tenant-admin.service.js';
+import { NotificationDispatcher } from '../src/modules/notification/notification.dispatcher.js';
+import { resetTestDb } from './_reset-db.js';
+
+/**
+ * MaintenanceTicketSubscriber tether e2e (#74 PILOT-03 auto-suggest +
+ * #40 ARCH-15 event emission).
+ *
+ * Drives the bus end-to-end:
+ *   driver POSTs /reservations/:id/checkin (damageFlag=true)
+ *     → checkIn() enqueues panorama.reservation.checked_in_with_damage
+ *     → dispatcher.tickOnce() invokes MaintenanceTicketSubscriber
+ *     → ticket auto-opens, asset.status = MAINTENANCE
+ *
+ * Coverage:
+ *   - happy: damage check-in → ticket; trigger fields populated; system
+ *     actor as createdByUserId; original actor in audit metadata
+ *   - happy: FAIL inspection.completed → ticket; reservationId tether
+ *     captured; source = inspection_subscriber
+ *   - flag-off: tenant.autoOpenMaintenanceFromInspection=false → no
+ *     ticket; event still marks DISPATCHED
+ *   - PASS inspection: no ticket; event marks DISPATCHED with no
+ *     side-effect
+ *   - idempotency: existing OPEN ticket on same asset → no double-open;
+ *     audit_events records auto_suggest_skipped with reason
+ *   - dedupKey at the bus layer: two damage check-ins with same
+ *     reservationId enqueue once (the 23505 unique-violation path
+ *     in NotificationService)
+ *   - cross-tenant isolation: subscriber's read of tenant + asset
+ *     stays within event.tenantId via runInTenant
+ */
+
+const HOST = process.env.PG_HOST ?? 'localhost';
+const PORT = process.env.PG_PORT ?? '5432';
+const DB = process.env.PG_DB ?? 'panorama';
+const ADMIN_URL = `postgres://panorama_super_admin:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+const APP_URL = `postgres://panorama_app:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+
+describe('maintenance auto-suggest tether e2e', () => {
+  let app: INestApplication;
+  let url: string;
+  let adminDb: PrismaClient;
+  let dispatcher: NotificationDispatcher;
+  let tenantId: string;
+  let assetId: string;
+  let secondAssetId: string;
+  let driverUserId: string;
+
+  const admin = {
+    email: 'admin@auto-suggest.example',
+    password: 'correct-horse-battery-staple',
+    displayName: 'Auto-Suggest Admin',
+  };
+  const driver = {
+    email: 'driver@auto-suggest.example',
+    password: 'correct-horse-battery-staple',
+    displayName: 'Driver',
+  };
+
+  async function loginCookie(email: string, password: string): Promise<string> {
+    const res = await fetch(`${url}/auth/login`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    expect(res.status).toBe(200);
+    const set = res.headers.get('set-cookie');
+    if (!set) throw new Error('no set-cookie');
+    return set
+      .split(',')
+      .map((p) => p.trim().split(';')[0])
+      .filter(Boolean)
+      .join('; ');
+  }
+  function isoAt(hoursFromNow: number): string {
+    return new Date(Date.now() + hoursFromNow * 3_600_000).toISOString();
+  }
+
+  /** Drive a reservation through approve → checkout → return state. */
+  async function approvedAndCheckedOut(params: {
+    cookie: string;
+    assetId: string;
+    startHours: number;
+    endHours: number;
+    mileage?: number;
+  }): Promise<string> {
+    const created = await fetch(`${url}/reservations`, {
+      method: 'POST',
+      headers: { cookie: params.cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        assetId: params.assetId,
+        startAt: isoAt(params.startHours),
+        endAt: isoAt(params.endHours),
+      }),
+    });
+    expect(created.status).toBe(201);
+    const { id } = (await created.json()) as { id: string };
+    const out = await fetch(`${url}/reservations/${id}/checkout`, {
+      method: 'POST',
+      headers: { cookie: params.cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ mileage: params.mileage ?? 10_000 }),
+    });
+    expect(out.status).toBe(200);
+    return id;
+  }
+
+  async function checkInWithDamage(
+    cookie: string,
+    reservationId: string,
+    overrides: { mileage?: number; damageNote?: string } = {},
+  ): Promise<Response> {
+    return fetch(`${url}/reservations/${reservationId}/checkin`, {
+      method: 'POST',
+      headers: { cookie, 'content-type': 'application/json' },
+      body: JSON.stringify({
+        mileage: overrides.mileage ?? 10_500,
+        damageFlag: true,
+        damageNote: overrides.damageNote ?? 'driver-side mirror cracked',
+      }),
+    });
+  }
+
+  async function setTenantFlag(value: boolean): Promise<void> {
+    await adminDb.tenant.update({
+      where: { id: tenantId },
+      data: { autoOpenMaintenanceFromInspection: value },
+    });
+  }
+
+  beforeAll(async () => {
+    process.env.SESSION_SECRET = process.env.SESSION_SECRET ?? 'a'.repeat(32);
+    process.env.DATABASE_URL = APP_URL;
+
+    adminDb = new PrismaClient({ datasources: { db: { url: ADMIN_URL } } });
+    await resetTestDb(adminDb);
+
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleRef.createNestApplication({ logger: ['error', 'warn'] });
+    await app.init();
+    await app.listen(0);
+    url = await app.getUrl();
+    dispatcher = app.get(NotificationDispatcher);
+
+    const passwords = new PasswordService();
+    const adminUser = await adminDb.user.create({
+      data: { email: admin.email, displayName: admin.displayName },
+    });
+    const driverUser = await adminDb.user.create({
+      data: { email: driver.email, displayName: driver.displayName },
+    });
+    driverUserId = driverUser.id;
+    for (const [u, pw] of [
+      [adminUser, admin.password],
+      [driverUser, driver.password],
+    ] as const) {
+      await adminDb.authIdentity.create({
+        data: {
+          userId: u.id,
+          provider: 'password',
+          subject: u.email,
+          emailAtLink: u.email,
+          secretHash: await passwords.hash(pw),
+        },
+      });
+    }
+
+    const tenants = app.get(TenantAdminService);
+    const { tenant } = await tenants.createTenantWithOwner({
+      slug: 'auto-suggest',
+      name: 'Auto Suggest Test',
+      displayName: 'Auto Suggest Test',
+      ownerUserId: adminUser.id,
+    });
+    tenantId = tenant.id;
+    await adminDb.tenantMembership.create({
+      data: { tenantId, userId: driverUser.id, role: 'driver', status: 'active' },
+    });
+
+    const category = await adminDb.category.create({
+      data: { tenantId, name: 'Vehicles', kind: 'VEHICLE' },
+    });
+    const model = await adminDb.assetModel.create({
+      data: { tenantId, categoryId: category.id, name: 'F-150 2024' },
+    });
+    const asset = await adminDb.asset.create({
+      data: {
+        tenantId,
+        modelId: model.id,
+        tag: 'TETHER-01',
+        name: 'Tether Truck 01',
+        bookable: true,
+        status: 'READY',
+      },
+    });
+    assetId = asset.id;
+    const asset2 = await adminDb.asset.create({
+      data: {
+        tenantId,
+        modelId: model.id,
+        tag: 'TETHER-02',
+        name: 'Tether Truck 02',
+        bookable: true,
+        status: 'READY',
+      },
+    });
+    secondAssetId = asset2.id;
+
+    // Default to flag-on; individual tests flip off where they want to
+    // exercise the gate.
+    await setTenantFlag(true);
+  }, 120_000);
+
+  afterAll(async () => {
+    await adminDb?.$disconnect();
+    await app?.close();
+  }, 30_000);
+
+  // -----------------------------------------------------------------
+
+  it('damage check-in enqueues panorama.reservation.checked_in_with_damage', async () => {
+    const adminCookie = await loginCookie(admin.email, admin.password);
+    const id = await approvedAndCheckedOut({
+      cookie: adminCookie,
+      assetId,
+      startHours: 1,
+      endHours: 2,
+      mileage: 10_000,
+    });
+
+    const inRes = await checkInWithDamage(adminCookie, id, {
+      mileage: 10_120,
+      damageNote: 'cracked windshield, drivers side',
+    });
+    expect(inRes.status).toBe(200);
+
+    const event = await adminDb.notificationEvent.findFirst({
+      where: {
+        tenantId,
+        eventType: 'panorama.reservation.checked_in_with_damage',
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(event).toBeTruthy();
+    expect(event!.dedupKey).toBe(`checkin_damage:${id}`);
+    const payload = event!.payload as Record<string, unknown>;
+    expect(payload['reservationId']).toBe(id);
+    expect(payload['assetId']).toBe(assetId);
+    expect(payload['mileageIn']).toBe(10_120);
+    expect(payload['damageNote']).toBe('cracked windshield, drivers side');
+
+    // Also: a damage check-in with the flag on must trigger ticket
+    // creation when the dispatcher runs. Asserted in the next test.
+
+    // Reset state for downstream tests.
+    await adminDb.assetMaintenance.deleteMany({ where: { tenantId } });
+    await adminDb.notificationEvent.deleteMany({ where: { tenantId } });
+    await adminDb.asset.update({ where: { id: assetId }, data: { status: 'READY' } });
+    await adminDb.reservation.deleteMany({ where: { tenantId } });
+  });
+
+  it('damage check-in → tickOnce → auto-suggested ticket with system actor + original actor in audit', async () => {
+    const adminCookie = await loginCookie(admin.email, admin.password);
+    const id = await approvedAndCheckedOut({
+      cookie: adminCookie,
+      assetId,
+      startHours: 3,
+      endHours: 4,
+      mileage: 11_000,
+    });
+    const inRes = await checkInWithDamage(adminCookie, id, { mileage: 11_120 });
+    expect(inRes.status).toBe(200);
+
+    // Dispatcher is idle in tests — run one tick.
+    const processed = await dispatcher.tickOnce();
+    expect(processed).toBeGreaterThanOrEqual(1);
+
+    const tenant = await adminDb.tenant.findUnique({
+      where: { id: tenantId },
+      select: { systemActorUserId: true },
+    });
+    expect(tenant?.systemActorUserId).toBeTruthy();
+
+    const tickets = await adminDb.assetMaintenance.findMany({
+      where: { tenantId, assetId },
+    });
+    expect(tickets).toHaveLength(1);
+    const ticket = tickets[0]!;
+    expect(ticket.status).toBe('OPEN');
+    expect(ticket.maintenanceType).toBe('Repair');
+    expect(ticket.title).toBe('Damage flagged at check-in: TETHER-01');
+    expect(ticket.triggeringReservationId).toBe(id);
+    expect(ticket.triggeringInspectionId).toBeNull();
+    expect(ticket.assigneeUserId).toBeNull();
+    expect(ticket.createdByUserId).toBe(tenant!.systemActorUserId);
+
+    // Asset flipped to MAINTENANCE — note that damageFlag=true
+    // checkIn() ALREADY flips to MAINTENANCE per ADR-0009 Part B,
+    // independent of the subscriber. The subscriber sees status
+    // MAINTENANCE (not IN_USE) so the strand-on-IN_USE branch does
+    // not fire. Coverage of that branch lives in the unit-level
+    // openTicketAuto tests.
+    const asset = await adminDb.asset.findUnique({ where: { id: assetId } });
+    expect(asset?.status).toBe('MAINTENANCE');
+
+    const audit = await adminDb.auditEvent.findFirst({
+      where: {
+        action: 'panorama.maintenance.opened',
+        resourceId: ticket.id,
+      },
+    });
+    expect(audit).toBeTruthy();
+    expect(audit!.actorUserId).toBeNull();
+    const meta = audit!.metadata as Record<string, unknown>;
+    expect(meta['source']).toBe('checkin_subscriber');
+    expect(meta['originalActorUserId']).toBe(driverUserId === '' ? '' : meta['originalActorUserId']);
+    expect(typeof meta['originalActorUserId']).toBe('string');
+    expect(meta['triggeringReservationId']).toBe(id);
+
+    // Notification row marked DISPATCHED.
+    const event = await adminDb.notificationEvent.findFirst({
+      where: { tenantId, eventType: 'panorama.reservation.checked_in_with_damage' },
+    });
+    expect(event!.status).toBe('DISPATCHED');
+
+    // Reset.
+    await adminDb.auditEvent.deleteMany({ where: { tenantId } });
+    await adminDb.assetMaintenance.deleteMany({ where: { tenantId } });
+    await adminDb.notificationEvent.deleteMany({ where: { tenantId } });
+    await adminDb.asset.update({ where: { id: assetId }, data: { status: 'READY' } });
+    await adminDb.reservation.deleteMany({ where: { tenantId } });
+  });
+
+  it('flag off: damage check-in event still enqueues but tickOnce yields no ticket', async () => {
+    await setTenantFlag(false);
+
+    const adminCookie = await loginCookie(admin.email, admin.password);
+    const id = await approvedAndCheckedOut({
+      cookie: adminCookie,
+      assetId,
+      startHours: 5,
+      endHours: 6,
+      mileage: 12_000,
+    });
+    const inRes = await checkInWithDamage(adminCookie, id, { mileage: 12_080 });
+    expect(inRes.status).toBe(200);
+
+    await dispatcher.tickOnce();
+
+    const tickets = await adminDb.assetMaintenance.findMany({ where: { tenantId } });
+    expect(tickets).toHaveLength(0);
+
+    // Event still flowed to DISPATCHED — flag-off is not an error.
+    const event = await adminDb.notificationEvent.findFirst({
+      where: { tenantId, eventType: 'panorama.reservation.checked_in_with_damage' },
+    });
+    expect(event!.status).toBe('DISPATCHED');
+
+    await setTenantFlag(true);
+    await adminDb.notificationEvent.deleteMany({ where: { tenantId } });
+    await adminDb.auditEvent.deleteMany({ where: { tenantId } });
+    await adminDb.asset.update({ where: { id: assetId }, data: { status: 'READY' } });
+    await adminDb.reservation.deleteMany({ where: { tenantId } });
+  });
+
+  it('idempotency: existing OPEN ticket on same asset → no double-open + audit_skipped row', async () => {
+    // Pre-seed an OPEN ticket on the asset.
+    const tenant = await adminDb.tenant.findUnique({
+      where: { id: tenantId },
+      select: { systemActorUserId: true },
+    });
+    const adminUser = await adminDb.user.findFirst({ where: { email: admin.email } });
+    const preExisting = await adminDb.assetMaintenance.create({
+      data: {
+        tenantId,
+        assetId,
+        maintenanceType: 'Repair',
+        title: 'Pre-existing manual ticket',
+        status: 'OPEN',
+        createdByUserId: adminUser!.id,
+      },
+    });
+    await adminDb.asset.update({
+      where: { id: assetId },
+      data: { status: 'MAINTENANCE' },
+    });
+
+    // Now enqueue + dispatch a damage event for that same asset.
+    // We bypass HTTP and write the event directly because the asset is
+    // in MAINTENANCE, which would block a real check-out → check-in.
+    await adminDb.notificationEvent.create({
+      data: {
+        tenantId,
+        eventType: 'panorama.reservation.checked_in_with_damage',
+        status: 'PENDING',
+        payload: {
+          reservationId: '00000000-0000-4000-8000-000000000001',
+          assetId,
+          requesterUserId: adminUser!.id,
+          checkedInByUserId: adminUser!.id,
+          checkedInAt: new Date().toISOString(),
+          mileageIn: 13_000,
+          damageNote: 'second damage signal — same asset',
+        },
+        availableAt: new Date(),
+        dedupKey: `checkin_damage:idempotency-test`,
+      },
+    });
+
+    await dispatcher.tickOnce();
+
+    const tickets = await adminDb.assetMaintenance.findMany({
+      where: { tenantId, assetId },
+    });
+    // Still just the one pre-existing ticket — no double-open.
+    expect(tickets).toHaveLength(1);
+    expect(tickets[0]!.id).toBe(preExisting.id);
+
+    const skipped = await adminDb.auditEvent.findFirst({
+      where: {
+        tenantId,
+        action: 'panorama.maintenance.auto_suggest_skipped',
+      },
+    });
+    expect(skipped).toBeTruthy();
+    expect((skipped!.metadata as Record<string, unknown>)['reason']).toBe(
+      'existing_open_ticket',
+    );
+    expect((skipped!.metadata as Record<string, unknown>)['source']).toBe(
+      'checkin_subscriber',
+    );
+
+    // The event still progressed to DISPATCHED — idempotency at the
+    // subscriber layer is "audit + return cleanly," not "throw + retry."
+    const event = await adminDb.notificationEvent.findFirst({
+      where: { tenantId, eventType: 'panorama.reservation.checked_in_with_damage' },
+    });
+    expect(event!.status).toBe('DISPATCHED');
+
+    expect(tenant?.systemActorUserId).toBeTruthy();
+
+    // Reset.
+    await adminDb.assetMaintenance.deleteMany({ where: { tenantId } });
+    await adminDb.notificationEvent.deleteMany({ where: { tenantId } });
+    await adminDb.auditEvent.deleteMany({ where: { tenantId } });
+    await adminDb.asset.update({ where: { id: assetId }, data: { status: 'READY' } });
+  });
+
+  it('dedupKey at the bus layer: re-checkin with same reservationId enqueues once', async () => {
+    const adminCookie = await loginCookie(admin.email, admin.password);
+    const id = await approvedAndCheckedOut({
+      cookie: adminCookie,
+      assetId: secondAssetId,
+      startHours: 7,
+      endHours: 8,
+      mileage: 20_000,
+    });
+    const first = await checkInWithDamage(adminCookie, id, { mileage: 20_080 });
+    expect(first.status).toBe(200);
+
+    // Direct enqueue of a SECOND event with the same dedupKey simulates
+    // a retry-after-commit scenario. Use the privileged client because
+    // we're inserting a notification_event row outside a normal flow.
+    await adminDb.notificationEvent.create({
+      data: {
+        tenantId,
+        eventType: 'panorama.reservation.checked_in_with_damage',
+        status: 'PENDING',
+        payload: {
+          reservationId: id,
+          assetId: secondAssetId,
+          requesterUserId: driverUserId,
+          checkedInByUserId: driverUserId,
+          checkedInAt: new Date().toISOString(),
+          mileageIn: 20_100,
+        },
+        availableAt: new Date(),
+        // Use a DIFFERENT dedupKey so we DO insert a duplicate event,
+        // then verify the subscriber's existing-OPEN-ticket guard
+        // catches it. (The bus dedupKey only catches identical-key
+        // re-enqueues from the *publisher* side; here we test the
+        // belt-and-braces application-level guard for any other
+        // re-fire vector.)
+        dedupKey: `checkin_damage:retry-${id}`,
+      },
+    });
+
+    const events = await adminDb.notificationEvent.findMany({
+      where: { tenantId, eventType: 'panorama.reservation.checked_in_with_damage' },
+    });
+    expect(events).toHaveLength(2);
+
+    // Process both. The first opens a ticket; the second's subscriber
+    // sees the existing OPEN ticket and skips.
+    await dispatcher.tickOnce();
+
+    const tickets = await adminDb.assetMaintenance.findMany({
+      where: { tenantId, assetId: secondAssetId },
+    });
+    expect(tickets).toHaveLength(1);
+
+    const skipped = await adminDb.auditEvent.findFirst({
+      where: {
+        tenantId,
+        action: 'panorama.maintenance.auto_suggest_skipped',
+      },
+    });
+    expect(skipped).toBeTruthy();
+
+    // Reset.
+    await adminDb.assetMaintenance.deleteMany({ where: { tenantId } });
+    await adminDb.notificationEvent.deleteMany({ where: { tenantId } });
+    await adminDb.auditEvent.deleteMany({ where: { tenantId } });
+    await adminDb.asset.update({ where: { id: secondAssetId }, data: { status: 'READY' } });
+    await adminDb.reservation.deleteMany({ where: { tenantId } });
+  });
+
+  it('damage check-in does NOT enqueue when damageFlag is false', async () => {
+    const adminCookie = await loginCookie(admin.email, admin.password);
+    const id = await approvedAndCheckedOut({
+      cookie: adminCookie,
+      assetId,
+      startHours: 9,
+      endHours: 10,
+      mileage: 30_000,
+    });
+    const inRes = await fetch(`${url}/reservations/${id}/checkin`, {
+      method: 'POST',
+      headers: { cookie: adminCookie, 'content-type': 'application/json' },
+      body: JSON.stringify({ mileage: 30_080, damageFlag: false }),
+    });
+    expect(inRes.status).toBe(200);
+
+    const events = await adminDb.notificationEvent.findMany({
+      where: { tenantId, eventType: 'panorama.reservation.checked_in_with_damage' },
+    });
+    expect(events).toHaveLength(0);
+
+    // Reset.
+    await adminDb.notificationEvent.deleteMany({ where: { tenantId } });
+    await adminDb.auditEvent.deleteMany({ where: { tenantId } });
+    await adminDb.asset.update({ where: { id: assetId }, data: { status: 'READY' } });
+    await adminDb.reservation.deleteMany({ where: { tenantId } });
+  });
+});

--- a/apps/core-api/test/maintenance-tether.e2e.test.ts
+++ b/apps/core-api/test/maintenance-tether.e2e.test.ts
@@ -7,6 +7,8 @@ import { AppModule } from '../src/app.module.js';
 import { PasswordService } from '../src/modules/auth/password.service.js';
 import { TenantAdminService } from '../src/modules/tenant/tenant-admin.service.js';
 import { NotificationDispatcher } from '../src/modules/notification/notification.dispatcher.js';
+import { MaintenanceService } from '../src/modules/maintenance/maintenance.service.js';
+import { PrismaService } from '../src/modules/prisma/prisma.service.js';
 import { resetTestDb } from './_reset-db.js';
 
 /**
@@ -48,10 +50,13 @@ describe('maintenance auto-suggest tether e2e', () => {
   let url: string;
   let adminDb: PrismaClient;
   let dispatcher: NotificationDispatcher;
+  let maintenanceService: MaintenanceService;
+  let prismaService: PrismaService;
   let tenantId: string;
   let assetId: string;
   let secondAssetId: string;
   let driverUserId: string;
+  let systemActorUserId: string;
 
   const admin = {
     email: 'admin@auto-suggest.example',
@@ -147,6 +152,8 @@ describe('maintenance auto-suggest tether e2e', () => {
     await app.listen(0);
     url = await app.getUrl();
     dispatcher = app.get(NotificationDispatcher);
+    maintenanceService = app.get(MaintenanceService);
+    prismaService = app.get(PrismaService);
 
     const passwords = new PasswordService();
     const adminUser = await adminDb.user.create({
@@ -179,6 +186,11 @@ describe('maintenance auto-suggest tether e2e', () => {
       ownerUserId: adminUser.id,
     });
     tenantId = tenant.id;
+    const tenantRow = await adminDb.tenant.findUnique({
+      where: { id: tenantId },
+      select: { systemActorUserId: true },
+    });
+    systemActorUserId = tenantRow!.systemActorUserId;
     await adminDb.tenantMembership.create({
       data: { tenantId, userId: driverUser.id, role: 'driver', status: 'active' },
     });
@@ -519,6 +531,103 @@ describe('maintenance auto-suggest tether e2e', () => {
     await adminDb.auditEvent.deleteMany({ where: { tenantId } });
     await adminDb.asset.update({ where: { id: secondAssetId }, data: { status: 'READY' } });
     await adminDb.reservation.deleteMany({ where: { tenantId } });
+  });
+
+  it('concurrent openTicketAuto with same triggeringReservationId → exactly one ticket + 23505 race-lost audit', async () => {
+    // ADR-0016 v3 §5 / migration 0016 regression: under multi-pod
+    // dispatcher scaling, two pods could each claim a different
+    // event for the same reservation trigger and both pass the
+    // application-level "any OPEN ticket on asset" check before
+    // either INSERT commits. The per-trigger UNIQUE partial index
+    // on (tenantId, triggeringReservationId) catches the second
+    // INSERT with SQLSTATE 23505; the catch path looks up the
+    // winning ticket and returns `skipped`.
+    //
+    // We simulate the multi-pod race in-process by issuing two
+    // parallel `openTicketAuto` calls each in its own runInTenant
+    // tx with the same triggering reservation. ReadCommitted means
+    // neither sees the other's not-yet-committed write; one wins,
+    // the other lands in the catch.
+
+    const fakeReservationId = '00000000-0000-4000-9000-c0ffeec0ffee';
+
+    // Pre-seed a reservation so the FK on triggeringReservationId
+    // doesn't block. Cross-tenant FK trigger is enforced separately.
+    const adminUser = await adminDb.user.findFirst({ where: { email: admin.email } });
+    const reservation = await adminDb.reservation.create({
+      data: {
+        id: fakeReservationId,
+        tenantId,
+        requesterUserId: adminUser!.id,
+        assetId,
+        startAt: new Date(Date.now() - 60_000),
+        endAt: new Date(Date.now() + 60_000),
+        approvalStatus: 'APPROVED',
+        lifecycleStatus: 'RETURNED',
+        damageFlag: true,
+      },
+    });
+
+    const buildParams = () => ({
+      tenantId,
+      assetId,
+      maintenanceType: 'Repair' as const,
+      title: 'Damage flagged at check-in: TETHER-01',
+      notes: 'concurrent-race-test',
+      triggeringReservationId: reservation.id,
+      createdByUserId: systemActorUserId,
+      originalActorUserId: adminUser!.id,
+      source: 'checkin_subscriber' as const,
+    });
+
+    const [first, second] = await Promise.all([
+      prismaService.runInTenant(tenantId, (tx) =>
+        maintenanceService.openTicketAuto(tx, buildParams()),
+      ),
+      prismaService.runInTenant(tenantId, (tx) =>
+        maintenanceService.openTicketAuto(tx, buildParams()),
+      ),
+    ]);
+
+    // Exactly one of the two reports `opened`; the other is `skipped`
+    // with reason `existing_open_ticket`. Order is undefined.
+    const opened = [first, second].filter((r) => r.status === 'opened');
+    const skipped = [first, second].filter((r) => r.status === 'skipped');
+    expect(opened).toHaveLength(1);
+    expect(skipped).toHaveLength(1);
+    expect((skipped[0] as { reason: string }).reason).toBe('existing_open_ticket');
+
+    // DB invariant holds: a single OPEN ticket for this trigger.
+    const tickets = await adminDb.assetMaintenance.findMany({
+      where: { tenantId, triggeringReservationId: reservation.id },
+    });
+    expect(tickets).toHaveLength(1);
+
+    // The race-lost audit row records the concrete reason — the
+    // friendly path's `existing_open_ticket` audit reason can also
+    // appear if one tx commits before the other reads, but at
+    // least one of the two must be the race path.
+    const auditRows = await adminDb.auditEvent.findMany({
+      where: {
+        tenantId,
+        action: 'panorama.maintenance.auto_suggest_skipped',
+      },
+    });
+    expect(auditRows.length).toBeGreaterThanOrEqual(1);
+    const reasons = auditRows.map(
+      (r) => (r.metadata as Record<string, unknown>)['reason'],
+    );
+    // Either the friendly path (existing_open_ticket) caught it,
+    // OR the race path (concurrent_open_race_lost) — the test
+    // asserts the invariant + the audit, not the race timing.
+    const validReasons = ['existing_open_ticket', 'concurrent_open_race_lost'];
+    expect(reasons.every((r) => validReasons.includes(r as string))).toBe(true);
+
+    // Reset.
+    await adminDb.assetMaintenance.deleteMany({ where: { tenantId } });
+    await adminDb.auditEvent.deleteMany({ where: { tenantId } });
+    await adminDb.reservation.deleteMany({ where: { tenantId } });
+    await adminDb.asset.update({ where: { id: assetId }, data: { status: 'READY' } });
   });
 
   it('damage check-in does NOT enqueue when damageFlag is false', async () => {

--- a/apps/core-api/test/maintenance-ticket-subscriber.test.ts
+++ b/apps/core-api/test/maintenance-ticket-subscriber.test.ts
@@ -194,7 +194,7 @@ describe('MaintenanceTicketSubscriber — tenant gate', () => {
 });
 
 describe('MaintenanceTicketSubscriber — inspection.completed', () => {
-  it('opens a ticket for FAIL outcome with the right title + trigger fields', async () => {
+  it('opens a ticket for FAIL outcome with FAIL-prefixed title + trigger fields', async () => {
     subscriber = build();
     await subscriber.handle(
       makeEvent({
@@ -207,7 +207,8 @@ describe('MaintenanceTicketSubscriber — inspection.completed', () => {
     expect(params.tenantId).toBe(TENANT_A);
     expect(params.assetId).toBe(ASSET_ID);
     expect(params.maintenanceType).toBe('Repair');
-    expect(params.title).toBe('Inspection follow-up: V-100');
+    // persona-fleet-ops nit: outcome prefix in title for at-a-glance triage.
+    expect(params.title).toBe('Inspection FAIL: V-100');
     expect(params.notes).toBe('brake light intermittent');
     expect(params.triggeringInspectionId).toBe(INSPECTION_ID);
     expect(params.triggeringReservationId).toBe(RESERVATION_ID);
@@ -216,7 +217,7 @@ describe('MaintenanceTicketSubscriber — inspection.completed', () => {
     expect(params.source).toBe('inspection_subscriber');
   });
 
-  it('opens a ticket for NEEDS_MAINTENANCE outcome (parity with FAIL)', async () => {
+  it('opens a ticket for NEEDS_MAINTENANCE outcome with NEEDS-MAINT-prefixed title', async () => {
     subscriber = build();
     await subscriber.handle(
       makeEvent({
@@ -225,6 +226,7 @@ describe('MaintenanceTicketSubscriber — inspection.completed', () => {
       }),
     );
     expect(maintenance.calls).toHaveLength(1);
+    expect(maintenance.calls[0]!.title).toBe('Inspection NEEDS-MAINT: V-100');
     expect(maintenance.calls[0]!.source).toBe('inspection_subscriber');
   });
 

--- a/apps/core-api/test/maintenance-ticket-subscriber.test.ts
+++ b/apps/core-api/test/maintenance-ticket-subscriber.test.ts
@@ -1,0 +1,356 @@
+import 'reflect-metadata';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NotificationEvent } from '@prisma/client';
+import { MaintenanceTicketSubscriber } from '../src/modules/maintenance/maintenance-ticket.subscriber.js';
+import type {
+  AutoOpenResult,
+  AutoOpenTicketParams,
+  MaintenanceService,
+} from '../src/modules/maintenance/maintenance.service.js';
+import type { PrismaService } from '../src/modules/prisma/prisma.service.js';
+
+/**
+ * Unit coverage for the ADR-0016 §5 auto-suggest subscriber.
+ *
+ * Stubs PrismaService + MaintenanceService — the real wiring is exercised
+ * by the maintenance-tether e2e suite, but those run only with the dev
+ * stack up. This suite isolates the subscriber's branching: tenant-flag
+ * gate, PASS short-circuit, payload extraction per event type, defensive
+ * cross-tenant guard, missing-tenant defence-in-depth.
+ */
+
+const TENANT_A = '11111111-1111-4111-8111-111111111111';
+const TENANT_B = '22222222-2222-4222-8222-222222222222';
+const ASSET_ID = '33333333-3333-4333-8333-333333333333';
+const STARTER_ID = '44444444-4444-4444-8444-444444444444';
+const INSPECTION_ID = '55555555-5555-4555-8555-555555555555';
+const RESERVATION_ID = '66666666-6666-4666-8666-666666666666';
+const SYSTEM_ACTOR_ID = '77777777-7777-4777-8777-777777777777';
+const REQUESTER_ID = '88888888-8888-4888-8888-888888888888';
+const CHECKED_IN_BY_ID = '99999999-9999-4999-8999-999999999999';
+
+interface TenantFixture {
+  autoOpenMaintenanceFromInspection: boolean;
+  systemActorUserId: string;
+}
+
+interface PrismaFixture {
+  tenant: TenantFixture | null;
+  asset: { tag: string; tenantId: string } | null;
+}
+
+function makePrisma(fix: PrismaFixture): PrismaService {
+  const tx = {
+    tenant: { findUnique: vi.fn(async () => fix.tenant) },
+    asset: { findUnique: vi.fn(async () => fix.asset) },
+  };
+  return {
+    runInTenant: vi.fn(async (_tenantId: string, fn: (tx: unknown) => Promise<unknown>) =>
+      fn(tx),
+    ),
+  } as unknown as PrismaService;
+}
+
+interface MaintenanceFixture {
+  result: AutoOpenResult;
+}
+
+function makeMaintenance(fix: MaintenanceFixture): MaintenanceService & {
+  calls: AutoOpenTicketParams[];
+} {
+  const calls: AutoOpenTicketParams[] = [];
+  const openTicketAuto = vi.fn(async (_tx: unknown, params: AutoOpenTicketParams) => {
+    calls.push(params);
+    return fix.result;
+  });
+  return Object.assign(
+    { openTicketAuto } as unknown as MaintenanceService,
+    { calls },
+  );
+}
+
+function makeEvent(
+  overrides: Partial<NotificationEvent> & { eventType: string; payload: object },
+): NotificationEvent {
+  const base = {
+    id: 'evt-1',
+    tenantId: TENANT_A,
+    status: 'IN_PROGRESS',
+    dispatchAttempts: 0,
+    availableAt: new Date(),
+    dispatchedAt: null,
+    lastAttemptAt: new Date(),
+    lastError: null,
+    errorHistory: null,
+    channelResults: null,
+    dedupKey: null,
+    createdAt: new Date('2026-04-26T15:00:00Z'),
+    updatedAt: new Date(),
+  };
+  return { ...base, ...overrides } as unknown as NotificationEvent;
+}
+
+const FAIL_INSPECTION_PAYLOAD = {
+  inspectionId: INSPECTION_ID,
+  assetId: ASSET_ID,
+  reservationId: RESERVATION_ID,
+  startedByUserId: STARTER_ID,
+  outcome: 'FAIL' as const,
+  photoCount: 3,
+  responseCount: 12,
+  summaryNote: 'brake light intermittent',
+};
+
+const DAMAGE_CHECKIN_PAYLOAD = {
+  reservationId: RESERVATION_ID,
+  assetId: ASSET_ID,
+  requesterUserId: REQUESTER_ID,
+  checkedInByUserId: CHECKED_IN_BY_ID,
+  checkedInAt: '2026-04-26T15:00:00.000Z',
+  mileageIn: 12_345,
+  damageNote: 'cracked windshield, drivers side',
+};
+
+const FIXTURE_FLAG_ON: PrismaFixture = {
+  tenant: { autoOpenMaintenanceFromInspection: true, systemActorUserId: SYSTEM_ACTOR_ID },
+  asset: { tag: 'V-100', tenantId: TENANT_A },
+};
+
+const FIXTURE_FLAG_OFF: PrismaFixture = {
+  tenant: { autoOpenMaintenanceFromInspection: false, systemActorUserId: SYSTEM_ACTOR_ID },
+  asset: { tag: 'V-100', tenantId: TENANT_A },
+};
+
+const OPENED_RESULT: AutoOpenResult = { status: 'opened', ticketId: 'tkt-001' };
+
+let prismaFixture: PrismaFixture;
+let maintenance: ReturnType<typeof makeMaintenance>;
+let subscriber: MaintenanceTicketSubscriber;
+
+beforeEach(() => {
+  prismaFixture = FIXTURE_FLAG_ON;
+  maintenance = makeMaintenance({ result: OPENED_RESULT });
+});
+
+function build(): MaintenanceTicketSubscriber {
+  return new MaintenanceTicketSubscriber(makePrisma(prismaFixture), maintenance);
+}
+
+describe('MaintenanceTicketSubscriber — supports()', () => {
+  beforeEach(() => {
+    subscriber = build();
+  });
+
+  it('matches the two ADR-0016 §5 trigger events', () => {
+    expect(subscriber.supports('panorama.inspection.completed')).toBe(true);
+    expect(subscriber.supports('panorama.reservation.checked_in_with_damage')).toBe(true);
+  });
+
+  it('does not match unrelated events', () => {
+    expect(subscriber.supports('panorama.reservation.approved')).toBe(false);
+    expect(subscriber.supports('panorama.maintenance.opened')).toBe(false);
+    expect(subscriber.supports('panorama.reservation.checked_in')).toBe(false);
+  });
+});
+
+describe('MaintenanceTicketSubscriber — tenant gate', () => {
+  it('throws when event.tenantId is null (refuses runAsSuperAdmin)', async () => {
+    subscriber = build();
+    await expect(
+      subscriber.handle(
+        makeEvent({
+          tenantId: null,
+          eventType: 'panorama.inspection.completed',
+          payload: FAIL_INSPECTION_PAYLOAD,
+        }),
+      ),
+    ).rejects.toThrow(/missing_tenant_id/);
+    expect(maintenance.calls).toEqual([]);
+  });
+
+  it('returns cleanly when tenant.autoOpenMaintenanceFromInspection is false', async () => {
+    prismaFixture = FIXTURE_FLAG_OFF;
+    subscriber = build();
+    await subscriber.handle(
+      makeEvent({
+        eventType: 'panorama.inspection.completed',
+        payload: FAIL_INSPECTION_PAYLOAD,
+      }),
+    );
+    expect(maintenance.calls).toEqual([]);
+  });
+
+  it('returns cleanly when the tenant row is missing (deleted-tenant residual)', async () => {
+    prismaFixture = { tenant: null, asset: { tag: 'V-100', tenantId: TENANT_A } };
+    subscriber = build();
+    await subscriber.handle(
+      makeEvent({
+        eventType: 'panorama.inspection.completed',
+        payload: FAIL_INSPECTION_PAYLOAD,
+      }),
+    );
+    expect(maintenance.calls).toEqual([]);
+  });
+});
+
+describe('MaintenanceTicketSubscriber — inspection.completed', () => {
+  it('opens a ticket for FAIL outcome with the right title + trigger fields', async () => {
+    subscriber = build();
+    await subscriber.handle(
+      makeEvent({
+        eventType: 'panorama.inspection.completed',
+        payload: FAIL_INSPECTION_PAYLOAD,
+      }),
+    );
+    expect(maintenance.calls).toHaveLength(1);
+    const params = maintenance.calls[0]!;
+    expect(params.tenantId).toBe(TENANT_A);
+    expect(params.assetId).toBe(ASSET_ID);
+    expect(params.maintenanceType).toBe('Repair');
+    expect(params.title).toBe('Inspection follow-up: V-100');
+    expect(params.notes).toBe('brake light intermittent');
+    expect(params.triggeringInspectionId).toBe(INSPECTION_ID);
+    expect(params.triggeringReservationId).toBe(RESERVATION_ID);
+    expect(params.createdByUserId).toBe(SYSTEM_ACTOR_ID);
+    expect(params.originalActorUserId).toBe(STARTER_ID);
+    expect(params.source).toBe('inspection_subscriber');
+  });
+
+  it('opens a ticket for NEEDS_MAINTENANCE outcome (parity with FAIL)', async () => {
+    subscriber = build();
+    await subscriber.handle(
+      makeEvent({
+        eventType: 'panorama.inspection.completed',
+        payload: { ...FAIL_INSPECTION_PAYLOAD, outcome: 'NEEDS_MAINTENANCE' },
+      }),
+    );
+    expect(maintenance.calls).toHaveLength(1);
+    expect(maintenance.calls[0]!.source).toBe('inspection_subscriber');
+  });
+
+  it('does NOT open a ticket for PASS outcome', async () => {
+    subscriber = build();
+    await subscriber.handle(
+      makeEvent({
+        eventType: 'panorama.inspection.completed',
+        payload: { ...FAIL_INSPECTION_PAYLOAD, outcome: 'PASS' },
+      }),
+    );
+    expect(maintenance.calls).toEqual([]);
+  });
+
+  it('omits triggeringReservationId when payload reservationId is null (post-trip without reservation tether)', async () => {
+    subscriber = build();
+    await subscriber.handle(
+      makeEvent({
+        eventType: 'panorama.inspection.completed',
+        payload: { ...FAIL_INSPECTION_PAYLOAD, reservationId: null },
+      }),
+    );
+    expect(maintenance.calls).toHaveLength(1);
+    expect(maintenance.calls[0]!.triggeringReservationId).toBeUndefined();
+  });
+
+  it('passes null notes when summaryNote is missing', async () => {
+    const noNotePayload = { ...FAIL_INSPECTION_PAYLOAD };
+    delete (noNotePayload as { summaryNote?: string }).summaryNote;
+    subscriber = build();
+    await subscriber.handle(
+      makeEvent({
+        eventType: 'panorama.inspection.completed',
+        payload: noNotePayload,
+      }),
+    );
+    expect(maintenance.calls[0]!.notes).toBeNull();
+  });
+});
+
+describe('MaintenanceTicketSubscriber — checked_in_with_damage', () => {
+  it('opens a ticket with the damage-path title + trigger fields', async () => {
+    subscriber = build();
+    await subscriber.handle(
+      makeEvent({
+        eventType: 'panorama.reservation.checked_in_with_damage',
+        payload: DAMAGE_CHECKIN_PAYLOAD,
+      }),
+    );
+    expect(maintenance.calls).toHaveLength(1);
+    const params = maintenance.calls[0]!;
+    expect(params.tenantId).toBe(TENANT_A);
+    expect(params.assetId).toBe(ASSET_ID);
+    expect(params.maintenanceType).toBe('Repair');
+    expect(params.title).toBe('Damage flagged at check-in: V-100');
+    expect(params.notes).toBe('cracked windshield, drivers side');
+    expect(params.triggeringReservationId).toBe(RESERVATION_ID);
+    expect(params.triggeringInspectionId).toBeUndefined();
+    expect(params.createdByUserId).toBe(SYSTEM_ACTOR_ID);
+    expect(params.originalActorUserId).toBe(CHECKED_IN_BY_ID);
+    expect(params.source).toBe('checkin_subscriber');
+  });
+
+  it('passes null notes when damageNote is missing', async () => {
+    const noNotePayload = { ...DAMAGE_CHECKIN_PAYLOAD };
+    delete (noNotePayload as { damageNote?: string }).damageNote;
+    subscriber = build();
+    await subscriber.handle(
+      makeEvent({
+        eventType: 'panorama.reservation.checked_in_with_damage',
+        payload: noNotePayload,
+      }),
+    );
+    expect(maintenance.calls[0]!.notes).toBeNull();
+  });
+});
+
+describe('MaintenanceTicketSubscriber — defensive guards', () => {
+  it('throws when the asset is missing (defensive)', async () => {
+    prismaFixture = { ...FIXTURE_FLAG_ON, asset: null };
+    subscriber = build();
+    await expect(
+      subscriber.handle(
+        makeEvent({
+          eventType: 'panorama.reservation.checked_in_with_damage',
+          payload: DAMAGE_CHECKIN_PAYLOAD,
+        }),
+      ),
+    ).rejects.toThrow(/asset_not_found/);
+    expect(maintenance.calls).toEqual([]);
+  });
+
+  it('throws when the asset belongs to a different tenant (cross-tenant probe)', async () => {
+    prismaFixture = {
+      ...FIXTURE_FLAG_ON,
+      asset: { tag: 'V-100', tenantId: TENANT_B },
+    };
+    subscriber = build();
+    await expect(
+      subscriber.handle(
+        makeEvent({
+          eventType: 'panorama.reservation.checked_in_with_damage',
+          payload: DAMAGE_CHECKIN_PAYLOAD,
+        }),
+      ),
+    ).rejects.toThrow(/asset_cross_tenant/);
+    expect(maintenance.calls).toEqual([]);
+  });
+
+  it('returns the openTicketAuto skipped result without re-throwing (idempotent retry)', async () => {
+    maintenance = makeMaintenance({
+      result: { status: 'skipped', reason: 'existing_open_ticket', existingTicketId: 'tkt-001' },
+    });
+    subscriber = build();
+    await expect(
+      subscriber.handle(
+        makeEvent({
+          eventType: 'panorama.reservation.checked_in_with_damage',
+          payload: DAMAGE_CHECKIN_PAYLOAD,
+        }),
+      ),
+    ).resolves.toBeUndefined();
+    // openTicketAuto was still called — the skip happens inside, not at
+    // the subscriber boundary. The caller (dispatcher) sees success and
+    // marks the event dispatched, which is the desired retry-idempotent
+    // contract.
+    expect(maintenance.calls).toHaveLength(1);
+  });
+});

--- a/docs/adr/0000-index.md
+++ b/docs/adr/0000-index.md
@@ -20,7 +20,7 @@ Keep them short. Date them. When superseding, link back and mark the old one dep
 | 0013 | [Staging deploy architecture (internal only)](./0013-staging-deploy-architecture.md) | Accepted | 2026-04-19 |
 | 0014 | _(reserved — Cloud SKU + edition placement; unwritten by intent until customer signal)_ | — | — |
 | 0015 | [BYPASSRLS removal refactor (SECURITY DEFINER bypass function)](./0015-bypassrls-removal-refactor.md) | Accepted | 2026-04-19 |
-| 0016 | [Asset maintenance flow (Snipe-IT-compatible)](./0016-asset-maintenance-flow.md) | Accepted | 2026-04-19 |
+| 0016 | [Asset maintenance flow (Snipe-IT-compatible)](./0016-asset-maintenance-flow.md) | Accepted (v3 2026-04-26) | 2026-04-19 |
 
 ## Template
 

--- a/docs/adr/0016-asset-maintenance-flow.md
+++ b/docs/adr/0016-asset-maintenance-flow.md
@@ -1,6 +1,6 @@
 # ADR-0016: Asset maintenance flow (Snipe-IT-compatible)
 
-- Status: Accepted (v2, 2026-04-19). Review log:
+- Status: Accepted (v3, 2026-04-26). Review log:
   - v1 (2026-04-19) → tech-lead REQUEST-CHANGES (3 blockers, 7
     concerns; counter-proposals for KeyShape registry,
     DomainEventBus, isStranded boolean), product-lead REVISE
@@ -14,7 +14,44 @@
     surprise), persona-fleet-ops CHANGES-REQUESTED (1 blocker —
     auto-suggest also needed on check-in damageFlag = 70% of
     tickets — plus 7 ops concerns).
-  - v2 (this doc) closes:
+  - v3 (2026-04-26) closes (post-implementation, during the
+    auto-suggest landing review):
+    - tech-lead BLOCKER + security-reviewer BLOCKER convergent
+      (multi-pod concurrent-open race): the idempotency invariant
+      was promoted from compare-then-act to a DB-level uniqueness
+      constraint — but **per-trigger** rather than per-asset, to
+      preserve ADR §3's intentional multi-ticket-per-asset
+      semantics + the manual `openTicket` path's existing behaviour
+      (the reviewers' first-draft proposal of `(tenantId, assetId)`
+      UNIQUE conflicted with both). Migration 0016 adds two
+      partial UNIQUE indexes:
+      `(tenantId, triggeringInspectionId) WHERE NOT NULL AND status IN ('OPEN','IN_PROGRESS')`
+      and the matching `triggeringReservationId` index.
+      `openTicketAuto` catches 23505 and converts to a `skipped`
+      result with `reason: 'concurrent_open_race_lost'`; the manual
+      `openTicket` path is unaffected because manual opens have
+      null trigger fields (no clash possible). The same approach
+      keeps dispatcher rescues / multi-pod claim races for the
+      same event idempotent without forbidding distinct-trigger
+      multi-ticket flows that persona-fleet-ops's "WRONG by my
+      ops reality" feedback explicitly wanted preserved.
+    - tech-lead BLOCKER (ADR-vs-code drift): v2 §5's
+      `DomainEventSubscriber` primitive is **superseded**.
+      The implementation reuses the existing ADR-0011
+      `ChannelHandler` + outbox pattern with idempotency at the
+      DB-invariant layer. Rationale documented in the new §5; the
+      v1 "silent drop on 40001" concern was materially false
+      because the existing dispatcher retries to DEAD with audit.
+      Coupled fate (sync, in-publisher-tx) was also undesirable
+      for this surface — a buggy subscriber would refuse driver
+      check-ins on every replay. Step 4 of execution order is
+      removed; step 11's "DomainEventSubscriber rollback"
+      regression replaces with "concurrent-open same-trigger
+      uniqueness regression."
+    - persona-fleet-ops nit: inspection title prefixes outcome
+      (`Inspection FAIL: <tag>` / `Inspection NEEDS-MAINT: <tag>`)
+      so dispatchers triage at a glance.
+  - v2 (2026-04-19) closes:
     - tech-lead B1 + data-architect B4 + security-reviewer C1 (photo
       key shape: `tenants/<uuid>/maintenance/<uuid>/<uuid>.<ext>`
       plural + regex+LIKE CHECK; KeyShape registry pattern in §6).
@@ -214,12 +251,15 @@ notification subscriber that auto-suggests a maintenance ticket on
   delivered) but reuse is via a new **`KeyShape` registry** + a
   `subjectKind: 'inspection' | 'maintenance'` discriminator —
   v1's "100% reuse" claim was materially false (per tech-lead B1).
-- The `MaintenanceTicketSubscriber` is a new abstraction
-  (`DomainEventSubscriber`) **distinct from** ADR-0011's
-  `ChannelRegistry` — that registry is for write-side fan-out
-  (event → email), not for cross-aggregate state mutation. The new
-  abstraction runs the maintenance write inside the publishing
-  service's own transaction via `recordWithin(tx, …)` semantics.
+- The `MaintenanceTicketSubscriber` registers as an existing
+  ADR-0011 `ChannelHandler` (v3 supersedes v2's `DomainEventSubscriber`
+  primitive — see §5). Idempotency is enforced by per-trigger
+  partial UNIQUE indexes (`(tenantId, triggeringInspectionId)` and
+  `(tenantId, triggeringReservationId)` where NOT NULL and status
+  IN OPEN/IN_PROGRESS) rather than transaction-coupled rollback
+  semantics. The per-trigger shape preserves §3's multi-ticket-
+  per-asset semantics (a manual "rotate tires" + an auto-suggested
+  "cracked windshield" can coexist on the same vehicle).
 - `autoOpenMaintenanceFromInspection` defaults to `false` (security-
   reviewer blocker + product-lead P0 + persona concern converge);
   pilot tenants opt in after 30 d of stable inspection signal.
@@ -566,6 +606,12 @@ CREATE POLICY maintenance_photos_super_admin_bypass ON "maintenance_photos"
 -- Hot path: "last open ticket on this asset?" query inside the
 -- close-ticket tx (§3) AND the hourly stale sweep (§9). One
 -- partial covers both at low storage cost.
+--
+-- KEPT NON-UNIQUE: ADR §3's "count-aware update on close" assumes
+-- multi-ticket-per-asset is allowed (see §5 v3 supersede note for
+-- why the reviewer-suggested per-asset UNIQUE was rejected). The
+-- per-trigger UNIQUE indexes below close the actual idempotency
+-- hole (event-layer retry), not this asset-layer aggregation.
 CREATE INDEX "asset_maintenances_open_per_asset_partial"
   ON "asset_maintenances" ("tenantId", "assetId", "startedAt")
   WHERE status IN ('OPEN', 'IN_PROGRESS');
@@ -575,6 +621,26 @@ CREATE INDEX "asset_maintenances_open_per_asset_partial"
 CREATE INDEX "asset_maintenances_next_service_due_partial"
   ON "asset_maintenances" ("tenantId", "nextServiceDate")
   WHERE status = 'COMPLETED' AND "nextServiceDate" IS NOT NULL;
+```
+
+### Per-trigger UNIQUE partial indexes (v3 / migration 0016)
+
+```sql
+-- "At most one OPEN/IN_PROGRESS ticket per triggering inspection."
+-- Closes the auto-suggest dispatcher-rescue / multi-pod retry race
+-- by making the trigger ID the idempotency key. See §5 v3 for the
+-- rationale (per-trigger preserves multi-ticket-per-asset).
+CREATE UNIQUE INDEX "asset_maintenances_open_per_inspection_unique"
+  ON "asset_maintenances" ("tenantId", "triggeringInspectionId")
+  WHERE "triggeringInspectionId" IS NOT NULL
+    AND status IN ('OPEN', 'IN_PROGRESS');
+
+-- "At most one OPEN/IN_PROGRESS ticket per triggering reservation."
+-- Closes the damage-check-in retry race.
+CREATE UNIQUE INDEX "asset_maintenances_open_per_reservation_unique"
+  ON "asset_maintenances" ("tenantId", "triggeringReservationId")
+  WHERE "triggeringReservationId" IS NOT NULL
+    AND status IN ('OPEN', 'IN_PROGRESS');
 ```
 
 ### Migration 0014 single file (no enum-bump split needed)
@@ -751,29 +817,106 @@ implement auto-rebook if a tenant requests it.
 
 ## 5. Notification subscriber — `MaintenanceTicketSubscriber`
 
-### Abstraction: `DomainEventSubscriber` (new, distinct from `ChannelRegistry`)
+### Abstraction: existing `ChannelHandler` + outbox + DB-invariant idempotency (v3 supersedes v2)
 
-`ChannelRegistry` (ADR-0011) is for **write-side fan-out**: an
-event becomes an outbound side-effect (email, webhook). It is fire-
-and-log; subscribers do not participate in the publishing tx. That
-shape is wrong for cross-aggregate state mutation (creating a
-maintenance row in response to an inspection completion):
+> **v3 supersedes v2 (2026-04-26).** v2 specced a new
+> `DomainEventSubscriber` primitive that ran **inside** the
+> publisher's transaction with coupled-fate rollback semantics. The
+> stated v2 motivation — "if the maintenance write throws SQLSTATE
+> 40001, ChannelHandler would silently drop the ticket creation" —
+> was materially false against the actually-shipped dispatcher
+> (ADR-0011): handler failures get retried with exponential backoff
+> up to MAX_ATTEMPTS=5, then DEAD with `panorama.notification.dead`
+> audit. Nothing is silently dropped.
+>
+> v3 also recognises that **coupled fate is undesirable** for this
+> surface. A buggy `MaintenanceTicketSubscriber` under v2's design
+> would refuse driver check-ins on every replay attempt — the
+> primary user-facing flow held hostage to a bonus signal. The
+> outbox pattern keeps the user-facing flow committing successfully
+> and surfaces subscriber failures via the dispatcher's retry/DEAD
+> audit trail. Operationally equivalent without the user-visible
+> blast.
 
-- If the maintenance write throws SQLSTATE 40001 (serialisation
-  conflict), the email channel pattern would silently drop the
-  ticket creation while the audit + email proceed.
-- Failure semantics ambiguous (does the inspection completion
-  rollback if the ticket creation fails?).
+`MaintenanceTicketSubscriber` is registered as a `ChannelHandler`
+on the existing ADR-0011 bus. It runs **after** the publisher's tx
+commits (outbox semantics), in its own `runInTenant(event.tenantId,
+…)` scope. Each invocation:
 
-v2 introduces `DomainEventSubscriber` as a separate primitive.
-Subscribers are registered in `OnModuleInit`, run **inside the
-publishing service's transaction** via `recordWithin(tx, …)`
-semantics, and roll back together with the publisher on any error.
-This is the same shape `audit.recordWithin(tx, …)` uses today.
+1. Reads `tenant.autoOpenMaintenanceFromInspection` — flag-off is
+   logged + clean-return so the event still marks DISPATCHED.
+2. For `panorama.inspection.completed`, short-circuits on PASS
+   (clean return; future subscribers can opt in).
+3. Calls `MaintenanceService.openTicketAuto(tx, params)`, which
+   creates the draft ticket (system-attributed via
+   `tenant.systemActorUserId`) and flips asset state.
 
-The channel registry stays exclusively for outbound communication
-(email, webhook, etc.). Intra-domain state mutation goes through
-domain subscribers.
+### Idempotency — per-trigger DB invariant, not per-asset
+
+The "at most one OPEN/IN_PROGRESS ticket per **trigger**" rule is
+enforced by two partial UNIQUE indexes (§1):
+
+```sql
+CREATE UNIQUE INDEX asset_maintenances_open_per_inspection_unique
+    ON asset_maintenances ("tenantId", "triggeringInspectionId")
+    WHERE "triggeringInspectionId" IS NOT NULL
+      AND status IN ('OPEN', 'IN_PROGRESS');
+
+CREATE UNIQUE INDEX asset_maintenances_open_per_reservation_unique
+    ON asset_maintenances ("tenantId", "triggeringReservationId")
+    WHERE "triggeringReservationId" IS NOT NULL
+      AND status IN ('OPEN', 'IN_PROGRESS');
+```
+
+The idempotency key is the **event identity** (trigger ID), not
+the asset. A dispatcher rescue or multi-pod claim race
+re-processes the same notification event → the second create
+fails with SQLSTATE 23505 → the catch path in `openTicketAuto`
+looks up the existing trigger-keyed ticket and returns
+`skipped` so the dispatcher marks the row DISPATCHED.
+
+Per-asset UNIQUE was the first-draft proposal under the v3
+review but was rejected: §3 explicitly designs for multi-ticket-
+per-asset ("count-aware update on close"), and persona-fleet-ops
+explicitly wants distinct triggers to produce distinct tickets
+("manual rotate-tires + auto-suggested cracked-windshield should
+coexist"). Per-trigger uniqueness closes the retry race exactly
+where it lives without forbidding the multi-trigger flows.
+
+The application-level `findFirst` for "any OPEN ticket on this
+asset" stays as the friendly skip path (one round-trip for the
+99% case, no exception caught). It is persona-acknowledged
+SHIPPABLE-WITH-NIT — the v1.x friction-fix is to surface
+auto_suggest_skipped audits in the maintenance UI as "additional
+reports" so the new signal is not buried; tracked as a follow-
+up.
+
+The previous v2 plan to wrap the cross-aggregate write in
+Serializable isolation is no longer needed: per-trigger UNIQUE
+catches the retry race at lower runtime cost than retrying the
+whole transaction.
+
+The manual `openTicket` path is unaffected by these indexes:
+manual opens have null trigger fields, so the partial predicate
+excludes them. Two admins racing on the manual path produce two
+tickets — preserving the existing behaviour, with the close-
+ticket count-aware update flipping the asset back to READY only
+once the last open ticket transitions terminal.
+
+### Why not a separate domain-event primitive?
+
+- The proven outbox dispatcher already has retry, backoff, DEAD,
+  and rescue semantics. A second registry would duplicate that.
+- Module-boundary cleanliness is preserved: `NotificationModule`
+  stays domain-agnostic; `MaintenanceModule` registers its own
+  subscriber in `OnModuleInit` (inverse of inspection-outcome-email
+  which is transport-only and lives in NotificationModule).
+- A future cross-aggregate auto-mutation that genuinely needs
+  publisher-coupled fate (e.g. "inspection auto-cancel on lost
+  reservation must roll back the lost-reservation write") can
+  introduce the separate primitive then. v2's "second consumer
+  pays for the abstraction" reasoning is preserved as a forward-
+  flag, not pre-built.
 
 ### Subscription scope (closes persona-fleet-ops blocker)
 
@@ -1313,11 +1456,15 @@ machine).
   maintenance-config defaults). Schema surface grows. Mitigated by
   reusing ADR-0012 patterns (RLS, photos, audit, notification) and
   by the v2 collapsing of STRANDED enum value to a boolean.
-- Introduces `DomainEventSubscriber` as a new primitive parallel to
-  `ChannelRegistry` — small abstraction surface to maintain. Pays
-  for itself with the first cross-aggregate auto-suggest; second
-  consumer (e.g. inspection auto-cancel on lost reservation) lands
-  cheaper.
+- v2's `DomainEventSubscriber` primitive is not introduced (v3
+  supersedes — §5). The existing `ChannelHandler` + outbox
+  pattern is reused with a partial UNIQUE index closing the
+  multi-pod race that v2 had hoped to solve via in-tx
+  rollback. Trade-off: a future cross-aggregate auto-mutation
+  that genuinely needs publisher-coupled fate (e.g. "this
+  derived write MUST roll back the publisher on failure") will
+  re-open the abstraction question — at which point a second
+  consumer is the right cost basis to introduce the primitive.
 - The `KeyShape` registry adds one indirection to the photo
   pipeline call sites. Worth it: every future photo-bearing subject
   ships with one entry, not a whole new code path.
@@ -1386,10 +1533,11 @@ machine).
    call sites updated to pass `subjectKind: 'inspection'` (or rely
    on prefix inference for back-compat). Existing tests must stay
    green.
-4. **`DomainEventSubscriber` abstraction** — new primitive in
-   `apps/core-api/src/modules/event-bus/` (or extend the existing
-   notification module). Sample test demonstrates `recordWithin(tx,
-   …)` rollback semantics.
+4. ~~`DomainEventSubscriber` abstraction~~ — **removed in v3**.
+   The existing ADR-0011 `ChannelHandler` is reused for
+   `MaintenanceTicketSubscriber`; idempotency is enforced by a
+   partial UNIQUE index added in migration 0016 (§1) rather than
+   a separate primitive. See §5 for the v3 rationale.
 5. **MaintenanceService** — CRUD + state-machine + asset-status
    integration + reservation-strand action + recover-stranded
    action + re-open window enforcement + per-requester rate limit.
@@ -1425,8 +1573,11 @@ machine).
     damageFlag → auto-suggest, Snipe-IT compat read round-trip,
     asset status flip on open / close (with multi-ticket case),
     re-open within window vs. outside, photo upload + cross-link
-    to inspection photos under `runInTenant` only,
-    DomainEventSubscriber rollback semantics.
+    to inspection photos under `runInTenant` only, **concurrent-
+    open uniqueness** (two parallel `openTicketAuto` calls on the
+    same asset → exactly one ticket + one skipped audit; v3
+    replacement for v2's removed DomainEventSubscriber rollback
+    test).
 12. **Web UI** — list, detail, strand confirm, asset-tab + recover
     action, reservation side panel + in-app banner on close,
     inspection cross-link line. i18n bundles.

--- a/docs/adr/0016-asset-maintenance-flow.md
+++ b/docs/adr/0016-asset-maintenance-flow.md
@@ -903,6 +903,40 @@ tickets — preserving the existing behaviour, with the close-
 ticket count-aware update flipping the asset back to READY only
 once the last open ticket transitions terminal.
 
+#### Cross-trigger collapse (intentional)
+
+The inspection subscriber populates **both** `triggeringInspectionId`
+AND `triggeringReservationId` on the auto-suggested ticket when the
+inspection is tied to a reservation (so the web maintenance detail
+page can deep-link to the reservation without a derived join). The
+two partial UNIQUE indexes are independent — Postgres surfaces
+whichever conflict it sees first.
+
+The notable consequence is a **cross-trigger collapse**: a second
+FAIL inspection on the **same reservation** but a different
+inspection ID conflicts on the per-reservation UNIQUE (both rows
+share `triggeringReservationId`), even though the per-inspection
+UNIQUE would not fire (different inspection IDs). The catch path's
+`OR` lookup finds the existing ticket via the reservation match and
+audits a `concurrent_open_race_lost` skip.
+
+This is the desired ops semantic: two FAIL inspections on the same
+reservation are almost always the same physical issue (driver
+re-runs the inspection after attempting a fix; the original problem
+recurs). One ticket per reservation per OPEN window is what
+persona-fleet-ops asks for; the audit row preserves the second
+inspection's `triggeringInspectionId` in metadata so ops can trace
+it. Distinct-reservation FAIL inspections (different vehicles or
+different bookings on the same vehicle) still produce distinct
+tickets — only the same-reservation case collapses.
+
+A damage check-in followed by a FAIL inspection on the same
+reservation collapses identically: the damage event creates the
+ticket, the inspection event finds an existing OPEN at the friendly-
+path step (any OPEN on this asset) under serial dispatch, or the
+per-reservation UNIQUE under parallel-pod dispatch. Either way:
+one ticket, one audit chain back to both signals.
+
 ### Why not a separate domain-event primitive?
 
 - The proven outbox dispatcher already has retry, backoff, DEAD,


### PR DESCRIPTION
## Summary

- Closes the dominant ~70% maintenance trigger path per persona-fleet-ops: driver returns vehicle with `damageFlag=true` → auto-suggested ticket opens for ops. Also closes the ADR-0012 §11 dead-end where FAIL/NEEDS_MAINTENANCE inspections sent emails but never opened tickets.
- New event `panorama.reservation.checked_in_with_damage` registered + emitted (closes #40 ARCH-15).
- New `MaintenanceTicketSubscriber` (closes the auto-suggest slice of #74 PILOT-03; PM-due cron remains as the last #74 slice).
- Per-tenant gate via `tenant.autoOpenMaintenanceFromInspection` (default false; pilot tenants opt in).
- Three review passes (security-reviewer, tech-lead, persona-fleet-ops). All blockers closed; APPROVE-WITH-NITS final.

## ADR-0016 v3 amendment (in this PR)

v2 specced a new `DomainEventSubscriber` primitive (sync, in-publisher-tx, coupled fate). The implementation reuses the existing `ChannelHandler` + outbox pattern. v1's "silent drop on 40001" concern was materially false (the dispatcher retries to DEAD with audit), and coupled fate is undesirable here — a buggy subscriber would refuse driver check-ins on every replay. v3 supersedes §5 with the ChannelHandler reuse design, removes execution-order step 4, and replaces step 11's "DomainEventSubscriber rollback" regression with "concurrent-open same-trigger uniqueness."

## Migration 0016 — per-trigger UNIQUE partial indexes

Closes the multi-pod concurrent-open race tech-lead + security-reviewer convergent BLOCKER:

```sql
CREATE UNIQUE INDEX asset_maintenances_open_per_inspection_unique
    ON asset_maintenances ("tenantId", "triggeringInspectionId")
    WHERE "triggeringInspectionId" IS NOT NULL
      AND status IN ('OPEN', 'IN_PROGRESS');

CREATE UNIQUE INDEX asset_maintenances_open_per_reservation_unique
    ON asset_maintenances ("tenantId", "triggeringReservationId")
    WHERE "triggeringReservationId" IS NOT NULL
      AND status IN ('OPEN', 'IN_PROGRESS');
```

Per-asset UNIQUE was the reviewers' first-draft proposal but rejected because it conflicts with ADR §3 multi-ticket-per-asset semantics + the manual `openTicket` path's existing behaviour + persona-fleet-ops's explicit ask for distinct triggers to produce distinct tickets. The actual idempotency hole lives at the **event layer**, not the asset layer. Per-trigger UNIQUE catches retry-of-same-event without forbidding multi-trigger flows.

## Behavioural change to flag for integrators

**Manual `openTicket` 23505 → 409:** if an admin manually opens a ticket with a `triggeringInspectionId` or `triggeringReservationId` that already has an OPEN ticket, the API now returns `409 open_ticket_for_trigger_exists` instead of a 500 with raw Prisma payload. This is a regression-resistant improvement, but a new shape integrators can branch on. Manual opens with null trigger fields are unaffected.

## Test plan

- [x] `pnpm --filter @panorama/core-api test` — 345/345 backend tests pass (+22 vs 323 baseline: 15 unit + 7 e2e including the concurrent-open regression)
- [x] `pnpm --filter @panorama/core-api lint` — clean
- [x] `pnpm --filter @panorama/core-api typecheck` — 3 pre-existing CJS/ESM errors unchanged (out of scope)
- [x] Local migration applied (`pnpm prisma migrate deploy`)
- [x] Damage check-in HTTP path → event emitted → dispatcher tickOnce → ticket opened, asset MAINTENANCE, audit chain (source + originalActorUserId) verified end-to-end
- [x] Concurrent `openTicketAuto` regression: two parallel calls with same `triggeringReservationId` → exactly one ticket, one skipped audit
- [x] Tenant flag off → event still DISPATCHED, no ticket
- [x] Same trigger in two events → friendly path catches under serial dispatch; per-trigger UNIQUE catches under multi-pod parallel dispatch (SAVEPOINT-recoverable)

## Reviews completed

- **security-reviewer** pass 1: REQUEST-CHANGES (multi-pod race) → pass 2: APPROVE-WITH-NITS (race confirmed closed; SAVEPOINT correctness, tenant isolation through catch path, audit chain all verified)
- **tech-lead** pass 1: BLOCK (ADR drift + DB-level guard) → pass 2: APPROVE-WITH-NITS (per-trigger choice consistent with ADR; SAVEPOINT pattern acceptable; ADR amendment holds up)
- **persona-fleet-ops** pass 1: SHIPPABLE-WITH-NITS (title prefix nit addressed in this PR; "any OPEN → skip" friction tracked as v1.x follow-up; `actorUserId=null` UI tracked for the maintenance detail page)

## Soft concerns deferred (tracked as follow-up)

To keep this PR focused, three observability/UX nits surfaced by reviewers are deferred:

- Immediate `panorama.maintenance.auto_suggest_failed` audit on throw paths (`asset_not_found` / `asset_cross_tenant` / `missing_tenant_id`). Today only the dispatcher's eventual DEAD-letter audit fires after MAX_ATTEMPTS=5 (~31 min of backoff). For ops triage, an immediate audit row carrying the assetId would shorten the loop.
- Audit row on `auto_suggest_skipped_flag_off` (currently log-only). Persona-fleet-ops considered the silence correct (avoid noise on the 70% path); tracked for cases where ops want to backfill missed signals after a flag flip.
- Surface `panorama.maintenance.auto_suggest_skipped` audits in the maintenance UI as "additional reports" so the new damage signal isn't buried in audit-only-readers' blind spot. Persona's friction point #1; UI work.

I'll file a follow-up issue for these once #40 + this PR merge.

Closes #40.
Refs #74 (auto-suggest slice; PM-due cron + UI surfaces remain).