### PR TITLE
feat(maintenance): PM-due daily sweep — final #74 PILOT-03 slice

### DIFF
--- a/.runAsSuperAdmin.allowlist.json
+++ b/.runAsSuperAdmin.allowlist.json
@@ -27,6 +27,10 @@
       "budget": 2,
       "rationale": "Photo retention sweep + stale-IN_PROGRESS sweep each list ALL tenants (cluster-wide read; panorama_app cannot see other tenants in `tenants`). Per-tenant scans + updates that follow run under runInTenant. Closes #29 — ADR-0012 §11 invariant honoured for reads + writes; tenant list is the single allowed cluster-wide path."
     },
+    "apps/core-api/src/modules/maintenance/maintenance-sweep.service.ts": {
+      "budget": 1,
+      "rationale": "PM-due daily sweep (ADR-0016 §9) lists ALL tenants for the per-tenant scan loop (panorama_app cannot see other tenants in `tenants`). Per-tenant candidate query + audit emission run under runInTenant / audit.record. Mirrors the inspection-maintenance pattern."
+    },
     "apps/core-api/src/modules/invitation/invitation-email.queue.ts": {
       "budget": 2,
       "rationale": "Two cross-tenant paths: rescue-query (cluster-wide scan for stuck invitations) + lookupTenantId (legacy-payload fallback for pre-#115 BullMQ jobs). Per-row writes that follow run under runInTenant."

--- a/.runAsSuperAdmin.allowlist.json
+++ b/.runAsSuperAdmin.allowlist.json
@@ -28,8 +28,8 @@
       "rationale": "Photo retention sweep + stale-IN_PROGRESS sweep each list ALL tenants (cluster-wide read; panorama_app cannot see other tenants in `tenants`). Per-tenant scans + updates that follow run under runInTenant. Closes #29 — ADR-0012 §11 invariant honoured for reads + writes; tenant list is the single allowed cluster-wide path."
     },
     "apps/core-api/src/modules/maintenance/maintenance-sweep.service.ts": {
-      "budget": 1,
-      "rationale": "PM-due daily sweep (ADR-0016 §9) lists ALL tenants for the per-tenant scan loop (panorama_app cannot see other tenants in `tenants`). Per-tenant candidate query + audit emission run under runInTenant / audit.record. Mirrors the inspection-maintenance pattern."
+      "budget": 2,
+      "rationale": "Two cluster-wide paths: (1) tenant list for the per-tenant scan loop (panorama_app cannot see other tenants in `tenants`); (2) batched audit emission per pass via `audit.recordWithin` inside a single super-admin tx (data-architect Q5: previously each `audit.record` opened its own tx; batching cuts 100 round-trips to 1). Per-tenant candidate scans run under runInTenant. Audit-events writes are intrinsically super-admin-scoped per ADR-0011."
     },
     "apps/core-api/src/modules/invitation/invitation-email.queue.ts": {
       "budget": 2,

--- a/apps/core-api/prisma/migrations/20260427100000_0017_maintenance_next_service_mileage_due_partial/ROLLBACK.md
+++ b/apps/core-api/prisma/migrations/20260427100000_0017_maintenance_next_service_mileage_due_partial/ROLLBACK.md
@@ -1,0 +1,16 @@
+# Rollback — migration 0017 (mileage-arm partial index)
+
+Drops the partial index added by 0017. Safe in either direction.
+
+```sql
+DROP INDEX IF EXISTS "asset_maintenances_next_service_mileage_due_partial";
+```
+
+After rollback, the PM-due sweep's mileage arm falls back to a
+heap scan filtered by tenantId/status. Single-tenant deploys with
+modest historical-ticket counts will still complete the daily
+sweep in seconds; large fleets (>10k completed tickets per
+tenant) will see the cron run-time degrade.
+
+No code rollback required — the sweep query references the index
+implicitly via the planner's choice, not by name.

--- a/apps/core-api/prisma/migrations/20260427100000_0017_maintenance_next_service_mileage_due_partial/migration.sql
+++ b/apps/core-api/prisma/migrations/20260427100000_0017_maintenance_next_service_mileage_due_partial/migration.sql
@@ -1,0 +1,33 @@
+-- Migration 0017 — Add per-asset partial index for the PM-due
+-- mileage arm (closes data-architect Q1 BLOCKER on the PM-due
+-- sweep PR for #74 PILOT-03).
+--
+-- Migration 0014 shipped `asset_maintenances_next_service_due_partial`
+-- on `(tenantId, "nextServiceDate")` to cover the date arm of the
+-- ADR-0016 §9 PM-due sweep. The mileage arm (`a."lastReadMileage"
+-- + 500 >= am."nextServiceMileage"`) had no supporting partial,
+-- which would force a heap scan of `asset_maintenances` filtered by
+-- `tenantId/status/nextServiceMileage IS NOT NULL` per tenant per
+-- day. At the design ceiling (1k tenants × 100k completed-historic
+-- tickets), that was a multi-second daily cron per tenant.
+--
+-- Adding the symmetric partial means each arm of the rewritten
+-- UNION query (see maintenance-sweep.service.ts) probes its own
+-- partial index, with the join from `assets` driving via
+-- `(tenantId, assetId)` so the `+ 500` shift is evaluated as a
+-- per-row filter on a small candidate set rather than as an index
+-- range scan.
+--
+-- Column tuple: `(tenantId, assetId, nextServiceMileage)` —
+-- assetId before mileage so the planner can drive a nested-loop
+-- join from `assets` (cheap, ~10k rows for a big tenant) into
+-- the partial by assetId, then evaluate the mileage shift inline.
+
+CREATE INDEX "asset_maintenances_next_service_mileage_due_partial"
+    ON "asset_maintenances" ("tenantId", "assetId", "nextServiceMileage")
+    WHERE status = 'COMPLETED' AND "nextServiceMileage" IS NOT NULL;
+
+COMMENT ON INDEX "asset_maintenances_next_service_mileage_due_partial" IS
+    'ADR-0016 §9 PM-due sweep — supports the mileage arm of the per-tenant '
+    'UNION query in MaintenanceSweepService.runPmDueSweep. Symmetric to '
+    'asset_maintenances_next_service_due_partial which covers the date arm.';

--- a/apps/core-api/prisma/migrations/20260427100000_0017_maintenance_next_service_mileage_due_partial/rls.sql
+++ b/apps/core-api/prisma/migrations/20260427100000_0017_maintenance_next_service_mileage_due_partial/rls.sql
@@ -1,0 +1,10 @@
+-- Migration 0017 — no RLS surface change.
+--
+-- Adds one partial index on `asset_maintenances`. Indexes do not
+-- interact with ENABLE/FORCE ROW LEVEL SECURITY policies; the
+-- existing tenant-scoped + privileged-bypass policies on
+-- `asset_maintenances` from migration 0014 continue to apply
+-- unchanged. Placeholder kept for grep-greppability of the
+-- per-migration RLS audit pattern.
+
+SELECT 1;

--- a/apps/core-api/src/modules/maintenance/maintenance-sweep.service.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance-sweep.service.ts
@@ -61,7 +61,14 @@ const DEDUP_TTL_MS = 24 * 60 * 60 * 1000;
 // the sweep's "approaching due" warning band).
 const MILEAGE_WARNING_BAND_MILES = 500;
 const DATE_WARNING_BAND_DAYS = 14;
-const PER_TENANT_BATCH_SIZE = 500;
+// Circuit-breaker bound on the per-tenant scan. Migration 0014 +
+// 0017 give both arms of the UNION a partial index, so the typical
+// candidate set is bounded by `assets-with-PM-due-this-cycle`
+// (single-digit % of fleet on a typical day). The 10 000 ceiling
+// would only fire under a planner regression / unexpected data shape
+// — log + alert path picks it up rather than silently dropping
+// signals like the previous LIMIT 500 did (data-architect Q3).
+const PER_TENANT_CIRCUIT_BREAKER = 10_000;
 
 interface PmDueCandidate {
   id: string;
@@ -214,13 +221,24 @@ export class MaintenanceSweepService implements OnModuleInit, OnModuleDestroy {
     // has at most a handful of PM-due assets per day, so the JS-side
     // grouping is cheap. Avoids a SQL window function for portability.
     const candidatesByAsset = new Map<string, PmDueCandidate[]>();
+    let tenantsScanned = 0;
     for (const tenant of tenants) {
+      tenantsScanned++;
       const rows = await this.prisma.runInTenant(tenant.id, async (tx) => {
-        // Raw SQL because Prisma's relational query API doesn't
-        // express the `a.lastReadMileage + 500 >= am.nextServiceMileage`
-        // join-condition predicate naturally. The CHECK constraint
-        // `nextServiceMileage > mileageAtService` from migration 0014
-        // makes the comparison meaningful (no NULL drift).
+        // Raw SQL: each arm of the UNION uses its own partial index
+        // — date-arm via `next_service_due_partial` (migration 0014),
+        // mileage-arm via `next_service_mileage_due_partial`
+        // (migration 0017). UNION (not UNION ALL) deduplicates the
+        // overlap row when both triggers fire on the same ticket
+        // — JS-side aggregation per asset still groups multiple
+        // tickets correctly because each (id, …) tuple is unique.
+        //
+        // Postgres's BitmapOr cannot apply across these two arms
+        // because the mileage arm joins `assets.lastReadMileage` —
+        // the OR predicate would have driven the planner to either
+        // a heap scan or an awkward merge. UNION rewrites it as two
+        // independent sub-queries the planner optimises separately
+        // (data-architect Q6).
         return tx.$queryRaw<
           Array<{
             id: string;
@@ -231,29 +249,54 @@ export class MaintenanceSweepService implements OnModuleInit, OnModuleDestroy {
             assetLastReadMileage: number | null;
           }>
         >`
-          SELECT am.id,
-                 am."assetId" AS "assetId",
-                 am."tenantId" AS "tenantId",
-                 am."nextServiceDate" AS "nextServiceDate",
-                 am."nextServiceMileage" AS "nextServiceMileage",
-                 a."lastReadMileage" AS "assetLastReadMileage"
-            FROM asset_maintenances am
-            JOIN assets a
-              ON a.id = am."assetId"
-             AND a."tenantId" = am."tenantId"
-           WHERE am.status = 'COMPLETED'
-             AND am."tenantId" = ${tenant.id}::uuid
-             AND (
-               (am."nextServiceDate" IS NOT NULL
-                  AND am."nextServiceDate" <= ${dateCutoff})
-               OR (am."nextServiceMileage" IS NOT NULL
-                   AND a."lastReadMileage" IS NOT NULL
-                   AND a."lastReadMileage" + ${MILEAGE_WARNING_BAND_MILES} >= am."nextServiceMileage")
-             )
-           ORDER BY am."assetId", am."completedAt" DESC
-           LIMIT ${PER_TENANT_BATCH_SIZE}
+          (
+            SELECT am.id,
+                   am."assetId" AS "assetId",
+                   am."tenantId" AS "tenantId",
+                   am."nextServiceDate" AS "nextServiceDate",
+                   am."nextServiceMileage" AS "nextServiceMileage",
+                   a."lastReadMileage" AS "assetLastReadMileage"
+              FROM asset_maintenances am
+              JOIN assets a
+                ON a.id = am."assetId"
+               AND a."tenantId" = am."tenantId"
+             WHERE am.status = 'COMPLETED'
+               AND am."tenantId" = ${tenant.id}::uuid
+               AND am."nextServiceDate" IS NOT NULL
+               AND am."nextServiceDate" <= ${dateCutoff}
+          )
+          UNION
+          (
+            SELECT am.id,
+                   am."assetId" AS "assetId",
+                   am."tenantId" AS "tenantId",
+                   am."nextServiceDate" AS "nextServiceDate",
+                   am."nextServiceMileage" AS "nextServiceMileage",
+                   a."lastReadMileage" AS "assetLastReadMileage"
+              FROM asset_maintenances am
+              JOIN assets a
+                ON a.id = am."assetId"
+               AND a."tenantId" = am."tenantId"
+             WHERE am.status = 'COMPLETED'
+               AND am."tenantId" = ${tenant.id}::uuid
+               AND am."nextServiceMileage" IS NOT NULL
+               AND a."lastReadMileage" IS NOT NULL
+               AND a."lastReadMileage" + ${MILEAGE_WARNING_BAND_MILES} >= am."nextServiceMileage"
+          )
+          LIMIT ${PER_TENANT_CIRCUIT_BREAKER}
         `;
       });
+
+      if (rows.length === PER_TENANT_CIRCUIT_BREAKER) {
+        // Hard cap fired — log loudly so an SRE seeing it can either
+        // raise the cap or chase a planner regression. Without this
+        // log we'd be back to the silent-drop failure mode of the
+        // pre-data-architect-Q3 code.
+        this.log.error(
+          { tenantId: tenant.id, cap: PER_TENANT_CIRCUIT_BREAKER },
+          'pm_due_circuit_breaker_fired',
+        );
+      }
 
       for (const row of rows) {
         const key = `${row.tenantId}:${row.assetId}`;
@@ -266,13 +309,29 @@ export class MaintenanceSweepService implements OnModuleInit, OnModuleDestroy {
       }
     }
 
-    if (candidatesByAsset.size === 0) return 0;
+    if (candidatesByAsset.size === 0) {
+      this.log.debug(
+        { tenantsScanned, candidates: 0 },
+        'pm_due_swept_no_candidates',
+      );
+      return 0;
+    }
 
-    // Step 4 + 5: per-asset Redis SETNX dedup + audit emit.
-    let emitted = 0;
+    // Step 4: per-asset Redis SETNX dedup BEFORE the batched audit
+    // tx. SETNX is atomic so two concurrent sweep ticks (e.g. across
+    // pods) won't both pass — the loser sees `acquired === false`
+    // and skips. Build the audit-emit list from the survivors.
+    interface PendingAudit {
+      assetId: string;
+      tenantId: string;
+      tickets: PmDueCandidate[];
+      dedupKey: string;
+    }
+    const pending: PendingAudit[] = [];
     for (const [key, tickets] of candidatesByAsset) {
       const first = tickets[0]!;
-      const acquired = await this.acquireDedup(`pm_due:${key}`);
+      const dedupKey = `pm_due:${key}`;
+      const acquired = await this.acquireDedup(dedupKey);
       if (!acquired) {
         this.log.debug(
           { tenantId: first.tenantId, assetId: first.assetId },
@@ -280,62 +339,104 @@ export class MaintenanceSweepService implements OnModuleInit, OnModuleDestroy {
         );
         continue;
       }
-      const triggers = computeTriggers(tickets);
-      try {
-        await this.audit.record({
-          action: 'panorama.maintenance.next_service_due',
-          resourceType: 'asset',
-          resourceId: first.assetId,
-          tenantId: first.tenantId,
-          actorUserId: null,
-          metadata: {
-            assetId: first.assetId,
-            ticketIds: tickets.map((t) => t.id),
-            ticketCount: tickets.length,
-            triggeredBy: triggers.triggeredBy,
-            // Earliest date / smallest mileage among matching tickets —
-            // useful for dashboards rendering "soonest due" without a
-            // re-query.
-            earliestNextServiceDate: triggers.earliestDate
-              ? triggers.earliestDate.toISOString()
-              : null,
-            smallestNextServiceMileage: triggers.smallestMileage,
-            assetLastReadMileage: first.assetLastReadMileage,
-            // Captures whichever derived metric is meaningful to ops:
-            //   - days until earliest date (negative if overdue)
-            //   - miles until smallest mileage (negative if overdue)
-            daysUntilDue: triggers.earliestDate
-              ? Math.round(
-                  (triggers.earliestDate.getTime() - Date.now()) /
-                    (24 * 60 * 60 * 1000),
-                )
-              : null,
-            milesUntilDue:
-              triggers.smallestMileage !== null && first.assetLastReadMileage !== null
-                ? triggers.smallestMileage - first.assetLastReadMileage
-                : null,
-          },
-        });
-        emitted++;
-      } catch (err) {
-        // If audit emission fails, release the dedup so the next
-        // sweep can retry. Without the release, a transient audit
-        // failure would silently suppress the audit for 24 h.
-        this.log.warn(
-          {
-            tenantId: first.tenantId,
-            assetId: first.assetId,
-            err: String(err),
-          },
-          'pm_due_audit_failed',
-        );
-        await this.releaseDedup(`pm_due:${key}`);
+      pending.push({
+        assetId: first.assetId,
+        tenantId: first.tenantId,
+        tickets,
+        dedupKey,
+      });
+    }
+
+    if (pending.length === 0) {
+      this.log.debug(
+        { tenantsScanned, candidates: candidatesByAsset.size, dedupSkipped: candidatesByAsset.size },
+        'pm_due_swept_all_dedup',
+      );
+      return 0;
+    }
+
+    // Step 5: emit all audit rows in a SINGLE super-admin tx via
+    // `recordWithin`. Previously each `audit.record` opened its own
+    // tx (data-architect Q5) — at 100 audits per pass that was 100
+    // BEGIN/COMMIT round-trips on the audit hash chain. Batching
+    // also gets us all-or-nothing semantics: if one row fails, the
+    // whole batch rolls back, and the dedup-release path below
+    // releases ALL the keys consistently.
+    //
+    // `recordWithin` chains hash-of-prev within the tx, so the
+    // chain-reading pattern stays correct under batched inserts —
+    // each row reads the prior chain head from the same tx-local
+    // snapshot, the inserts commit atomically.
+    try {
+      await this.prisma.runAsSuperAdmin(
+        async (tx) => {
+          for (const p of pending) {
+            const triggers = computeTriggers(p.tickets);
+            await this.audit.recordWithin(tx, {
+              action: 'panorama.maintenance.next_service_due',
+              resourceType: 'asset',
+              resourceId: p.assetId,
+              tenantId: p.tenantId,
+              actorUserId: null,
+              metadata: {
+                assetId: p.assetId,
+                ticketIds: p.tickets.map((t) => t.id),
+                ticketCount: p.tickets.length,
+                triggeredBy: triggers.triggeredBy,
+                // Earliest date / smallest mileage among matching
+                // tickets — useful for dashboards rendering
+                // "soonest due" without a re-query.
+                earliestNextServiceDate: triggers.earliestDate
+                  ? triggers.earliestDate.toISOString()
+                  : null,
+                smallestNextServiceMileage: triggers.smallestMileage,
+                assetLastReadMileage: p.tickets[0]!.assetLastReadMileage,
+                daysUntilDue: triggers.earliestDate
+                  ? Math.round(
+                      (triggers.earliestDate.getTime() - Date.now()) /
+                        (24 * 60 * 60 * 1000),
+                    )
+                  : null,
+                milesUntilDue:
+                  triggers.smallestMileage !== null &&
+                  p.tickets[0]!.assetLastReadMileage !== null
+                    ? triggers.smallestMileage - p.tickets[0]!.assetLastReadMileage
+                    : null,
+              },
+            });
+          }
+        },
+        { reason: 'maintenance:pm_due_sweep:emit_audits' },
+      );
+    } catch (err) {
+      // Batch failed — release ALL the dedup keys we acquired so the
+      // next sweep tick can retry. A missed-then-recovered PM-due
+      // signal in a regulated domain (DOT 49 CFR §396.3 PM tracking
+      // lineage) is worse than the duplicate-audit risk if the
+      // release races against a concurrent sweep tick — log at error
+      // level so the alerting pipeline picks it up.
+      this.log.error(
+        {
+          assetCount: pending.length,
+          err: String(err),
+        },
+        'pm_due_audit_batch_failed',
+      );
+      for (const p of pending) {
+        await this.releaseDedup(p.dedupKey);
       }
+      return 0;
     }
-    if (emitted > 0) {
-      this.log.log({ emitted }, 'pm_due_swept');
-    }
-    return emitted;
+
+    this.log.log(
+      {
+        tenantsScanned,
+        candidates: candidatesByAsset.size,
+        emitted: pending.length,
+      },
+      'pm_due_swept',
+    );
+    return pending.length;
   }
 
   /**

--- a/apps/core-api/src/modules/maintenance/maintenance-sweep.service.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance-sweep.service.ts
@@ -1,0 +1,426 @@
+/**
+ * MaintenanceSweepService — ADR-0016 §9 background sweeps.
+ *
+ *   * PM-due daily sweep (this PR): emits
+ *     `panorama.maintenance.next_service_due` audit when an asset has
+ *     a COMPLETED ticket whose `nextServiceDate` is within 14 days OR
+ *     whose `nextServiceMileage` is within 500 miles of the asset's
+ *     `lastReadMileage`. Per-asset dedupe within 24 h via Redis SETNX
+ *     so ops gets at most one reminder per asset per day, regardless
+ *     of how many overdue tickets the asset has.
+ *
+ * Deferred to follow-up PRs:
+ *   * Hourly stale-OPEN sweep (ADR-0016 §9 stale-warning) — emits
+ *     `panorama.maintenance.stale_warning` for OPEN/IN_PROGRESS
+ *     tickets older than the per-tenant `maintenanceStaleWarningDays`.
+ *   * Daily type-drift audit (ADR-0016 §9 type-drift) — emits
+ *     `panorama.maintenance.type_drift_detected` for tickets whose
+ *     `maintenanceType` falls outside the §1 allow-list.
+ *   * Enterprise email channel for `next_service_due` (ADR-0016 §7,
+ *     gated behind `EditionService` + `MaintenanceEmailChannel`).
+ *     Community ships the audit row + dashboard query; Enterprise
+ *     adds the push email. Self-hosters on Community can wire their
+ *     own webhook to the audit row.
+ *
+ * --- LOAD-BEARING MODULE INVARIANT (mandatory-runInTenant) ---
+ * `runAsSuperAdmin` is FORBIDDEN here for tenant-scoped reads + ALL
+ * writes. The sweep below loops over tenants and routes every
+ * candidate scan through `runInTenant`.
+ *
+ * The ONE allowed cluster-wide path is the tenant LIST itself —
+ * `panorama_app` cannot see other tenants' rows in `tenants`, so we
+ * use `runAsSuperAdmin` for the list of tenant ids. Each per-tenant
+ * scan + audit then runs under RLS. `audit.record` opens its own
+ * super-admin tx via the existing AuditService design.
+ *
+ * The CI gate `pnpm rls:allowlist-check` (#58) budgets this file at
+ * 1 super-admin call (the tenant list). Adding more requires
+ * security-reviewer sign-off.
+ * --------------------------------------------------------------
+ */
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { Queue, Worker } from 'bullmq';
+import { Redis } from 'ioredis';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { AuditService } from '../audit/audit.service.js';
+
+const PM_DUE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const PM_DUE_QUEUE = 'maintenance-pm-due';
+const PM_DUE_JOB_NAME = 'sweep';
+const PM_DUE_REPEATABLE_KEY = 'pm-due-daily';
+const DEDUP_TTL_MS = 24 * 60 * 60 * 1000;
+
+// ADR-0016 §9 thresholds — hardcoded per the spec (vs. derived from
+// the per-tenant `maintenanceMileageInterval` / `maintenanceDayInterval`
+// columns, which set completion-time *defaults* for new tickets, not
+// the sweep's "approaching due" warning band).
+const MILEAGE_WARNING_BAND_MILES = 500;
+const DATE_WARNING_BAND_DAYS = 14;
+const PER_TENANT_BATCH_SIZE = 500;
+
+interface PmDueCandidate {
+  id: string;
+  assetId: string;
+  tenantId: string;
+  nextServiceDate: Date | null;
+  nextServiceMileage: number | null;
+  // Asset's lastReadMileage at scan time. Captured here so the audit
+  // metadata records the snapshot the cron actually evaluated, not a
+  // value that might change between scan and audit.
+  assetLastReadMileage: number | null;
+}
+
+@Injectable()
+export class MaintenanceSweepService implements OnModuleInit, OnModuleDestroy {
+  private readonly log = new Logger('MaintenanceSweepService');
+  private pmDueQueue: Queue | null = null;
+  private pmDueWorker: Worker | null = null;
+  private redisConnections: Redis[] = [];
+  private dedupRedis: Redis | null = null;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    if (process.env['NODE_ENV'] === 'test') {
+      this.log.log('maintenance_sweep_idle_in_tests');
+      return;
+    }
+    if (process.env['FEATURE_MAINTENANCE'] !== 'true') {
+      // Defence-in-depth: app.module.ts already conditionally loads
+      // MaintenanceModule on FEATURE_MAINTENANCE, but make the gate
+      // explicit at the sweep boundary too — a future module-loading
+      // refactor shouldn't accidentally start the BullMQ worker on a
+      // Community deploy that hasn't opted into the maintenance domain.
+      this.log.log('maintenance_sweep_disabled_by_feature_flag');
+      return;
+    }
+    await this.start();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.stop();
+  }
+
+  async start(): Promise<void> {
+    if (this.pmDueQueue) return;
+    // Mirrors InspectionMaintenanceService.start photo-sweep pattern:
+    // BullMQ repeatable with stable jobId so a Fly machine restart
+    // re-attaches to the existing schedule rather than spawning a
+    // duplicate or skipping a run.
+    this.pmDueQueue = new Queue(PM_DUE_QUEUE, {
+      connection: this.makeRedis(),
+    });
+    this.pmDueWorker = new Worker(
+      PM_DUE_QUEUE,
+      async () => {
+        const due = await this.runPmDueSweep();
+        return { due };
+      },
+      { connection: this.makeRedis(), concurrency: 1 },
+    );
+    this.pmDueWorker.on('failed', (_job, err) =>
+      this.log.warn({ err: String(err) }, 'pm_due_sweep_job_failed'),
+    );
+    await this.pmDueQueue.add(
+      PM_DUE_JOB_NAME,
+      {},
+      {
+        jobId: PM_DUE_REPEATABLE_KEY,
+        repeat: { every: PM_DUE_INTERVAL_MS },
+        removeOnComplete: { age: 7 * 24 * 60 * 60, count: 30 },
+        removeOnFail: { age: 30 * 24 * 60 * 60, count: 30 },
+      },
+    );
+    this.log.log('maintenance_sweep_started');
+  }
+
+  async stop(): Promise<void> {
+    const closers: Array<Promise<unknown>> = [];
+    if (this.pmDueWorker) closers.push(this.pmDueWorker.close());
+    if (this.pmDueQueue) closers.push(this.pmDueQueue.close());
+    await Promise.allSettled(closers);
+    this.pmDueWorker = null;
+    this.pmDueQueue = null;
+    if (this.dedupRedis) {
+      try {
+        await this.dedupRedis.quit();
+      } catch (err) {
+        this.log.debug({ err: String(err) }, 'redis_quit_error');
+      }
+      this.dedupRedis = null;
+    }
+    for (const conn of this.redisConnections) {
+      try {
+        await conn.quit();
+      } catch (err) {
+        this.log.debug({ err: String(err) }, 'redis_quit_error');
+      }
+    }
+    this.redisConnections = [];
+  }
+
+  // ----------------------------------------------------------------
+  // PM-due sweep
+  // ----------------------------------------------------------------
+
+  /**
+   * One pass of the PM-due sweep. Returns the count of audit rows
+   * emitted (post-dedup). Exposed for tests + manual operator triggers.
+   *
+   * Algorithm (per ADR-0016 §9):
+   *   1. List tenants (cluster-wide; the only allowed runAsSuperAdmin
+   *      use in this module).
+   *   2. Per tenant under `runInTenant`: query candidate
+   *      `asset_maintenances` rows joined to `assets`. Status COMPLETED
+   *      AND (date trigger OR mileage trigger). Both partial indexes
+   *      from migration 0014 (`open_per_asset_partial`,
+   *      `next_service_due_partial`) cover the read path.
+   *   3. Group candidates by `(tenantId, assetId)` so an asset with
+   *      multiple PM-due tickets emits only one audit row.
+   *   4. Per asset: SETNX dedup against `pm_due:<tenantId>:<assetId>`
+   *      with 24 h TTL. New keys → emit audit; existing keys → skip
+   *      silently (the previous run's audit is still within the dedup
+   *      window).
+   *   5. Audit row carries the matching ticket IDs, the cause
+   *      (mileage / date / both), and the asset's lastReadMileage
+   *      snapshot at scan time so dashboards can render "X miles
+   *      until due" or "Y days until due" without re-querying.
+   */
+  async runPmDueSweep(): Promise<number> {
+    // Step 1: cluster-wide tenant list. Allowlist budget +1 for this
+    // file (#58 gate).
+    const tenants = await this.prisma.runAsSuperAdmin(
+      (tx) =>
+        tx.tenant.findMany({
+          select: { id: true },
+          where: { deletedAt: null },
+        }),
+      { reason: 'maintenance:pm_due_sweep:list_tenants' },
+    );
+
+    const dateCutoff = new Date(
+      Date.now() + DATE_WARNING_BAND_DAYS * 24 * 60 * 60 * 1000,
+    );
+
+    // Step 2 + 3: per-tenant scan + group by asset. A typical fleet
+    // has at most a handful of PM-due assets per day, so the JS-side
+    // grouping is cheap. Avoids a SQL window function for portability.
+    const candidatesByAsset = new Map<string, PmDueCandidate[]>();
+    for (const tenant of tenants) {
+      const rows = await this.prisma.runInTenant(tenant.id, async (tx) => {
+        // Raw SQL because Prisma's relational query API doesn't
+        // express the `a.lastReadMileage + 500 >= am.nextServiceMileage`
+        // join-condition predicate naturally. The CHECK constraint
+        // `nextServiceMileage > mileageAtService` from migration 0014
+        // makes the comparison meaningful (no NULL drift).
+        return tx.$queryRaw<
+          Array<{
+            id: string;
+            assetId: string;
+            tenantId: string;
+            nextServiceDate: Date | null;
+            nextServiceMileage: number | null;
+            assetLastReadMileage: number | null;
+          }>
+        >`
+          SELECT am.id,
+                 am."assetId" AS "assetId",
+                 am."tenantId" AS "tenantId",
+                 am."nextServiceDate" AS "nextServiceDate",
+                 am."nextServiceMileage" AS "nextServiceMileage",
+                 a."lastReadMileage" AS "assetLastReadMileage"
+            FROM asset_maintenances am
+            JOIN assets a
+              ON a.id = am."assetId"
+             AND a."tenantId" = am."tenantId"
+           WHERE am.status = 'COMPLETED'
+             AND am."tenantId" = ${tenant.id}::uuid
+             AND (
+               (am."nextServiceDate" IS NOT NULL
+                  AND am."nextServiceDate" <= ${dateCutoff})
+               OR (am."nextServiceMileage" IS NOT NULL
+                   AND a."lastReadMileage" IS NOT NULL
+                   AND a."lastReadMileage" + ${MILEAGE_WARNING_BAND_MILES} >= am."nextServiceMileage")
+             )
+           ORDER BY am."assetId", am."completedAt" DESC
+           LIMIT ${PER_TENANT_BATCH_SIZE}
+        `;
+      });
+
+      for (const row of rows) {
+        const key = `${row.tenantId}:${row.assetId}`;
+        const list = candidatesByAsset.get(key);
+        if (list) {
+          list.push(row);
+        } else {
+          candidatesByAsset.set(key, [row]);
+        }
+      }
+    }
+
+    if (candidatesByAsset.size === 0) return 0;
+
+    // Step 4 + 5: per-asset Redis SETNX dedup + audit emit.
+    let emitted = 0;
+    for (const [key, tickets] of candidatesByAsset) {
+      const first = tickets[0]!;
+      const acquired = await this.acquireDedup(`pm_due:${key}`);
+      if (!acquired) {
+        this.log.debug(
+          { tenantId: first.tenantId, assetId: first.assetId },
+          'pm_due_dedup_skip',
+        );
+        continue;
+      }
+      const triggers = computeTriggers(tickets);
+      try {
+        await this.audit.record({
+          action: 'panorama.maintenance.next_service_due',
+          resourceType: 'asset',
+          resourceId: first.assetId,
+          tenantId: first.tenantId,
+          actorUserId: null,
+          metadata: {
+            assetId: first.assetId,
+            ticketIds: tickets.map((t) => t.id),
+            ticketCount: tickets.length,
+            triggeredBy: triggers.triggeredBy,
+            // Earliest date / smallest mileage among matching tickets —
+            // useful for dashboards rendering "soonest due" without a
+            // re-query.
+            earliestNextServiceDate: triggers.earliestDate
+              ? triggers.earliestDate.toISOString()
+              : null,
+            smallestNextServiceMileage: triggers.smallestMileage,
+            assetLastReadMileage: first.assetLastReadMileage,
+            // Captures whichever derived metric is meaningful to ops:
+            //   - days until earliest date (negative if overdue)
+            //   - miles until smallest mileage (negative if overdue)
+            daysUntilDue: triggers.earliestDate
+              ? Math.round(
+                  (triggers.earliestDate.getTime() - Date.now()) /
+                    (24 * 60 * 60 * 1000),
+                )
+              : null,
+            milesUntilDue:
+              triggers.smallestMileage !== null && first.assetLastReadMileage !== null
+                ? triggers.smallestMileage - first.assetLastReadMileage
+                : null,
+          },
+        });
+        emitted++;
+      } catch (err) {
+        // If audit emission fails, release the dedup so the next
+        // sweep can retry. Without the release, a transient audit
+        // failure would silently suppress the audit for 24 h.
+        this.log.warn(
+          {
+            tenantId: first.tenantId,
+            assetId: first.assetId,
+            err: String(err),
+          },
+          'pm_due_audit_failed',
+        );
+        await this.releaseDedup(`pm_due:${key}`);
+      }
+    }
+    if (emitted > 0) {
+      this.log.log({ emitted }, 'pm_due_swept');
+    }
+    return emitted;
+  }
+
+  /**
+   * Acquire the per-asset dedup lock for 24 h. Returns true iff this
+   * call was the SETNX winner (no prior unexpired key). False = some
+   * prior sweep within the last 24 h already audited this asset.
+   *
+   * Lazy-init a single Redis connection for dedup ops (separate from
+   * BullMQ's connections to avoid lifecycle coupling). The connection
+   * is closed in `stop()`.
+   */
+  private async acquireDedup(key: string): Promise<boolean> {
+    if (!this.dedupRedis) {
+      this.dedupRedis = this.makeRedis();
+    }
+    const result = await this.dedupRedis.set(key, '1', 'PX', DEDUP_TTL_MS, 'NX');
+    return result === 'OK';
+  }
+
+  private async releaseDedup(key: string): Promise<void> {
+    if (!this.dedupRedis) return;
+    try {
+      await this.dedupRedis.del(key);
+    } catch (err) {
+      this.log.debug({ err: String(err), key }, 'pm_due_dedup_release_failed');
+    }
+  }
+
+  /**
+   * BullMQ requires the same `lazyConnect: false` /
+   * `enableReadyCheck: false` / `maxRetriesPerRequest: null` shape on
+   * every connection — mirrors the invitation queue + photo retention
+   * sweep patterns elsewhere in the codebase.
+   */
+  private makeRedis(): Redis {
+    const url = process.env['REDIS_URL'] ?? 'redis://localhost:6379/0';
+    const conn = new Redis(url, {
+      lazyConnect: false,
+      enableReadyCheck: false,
+      maxRetriesPerRequest: null,
+    });
+    this.redisConnections.push(conn);
+    return conn;
+  }
+}
+
+/**
+ * Aggregate the trigger semantics across all PM-due tickets on a
+ * single asset: which trigger(s) fired (date / mileage / both), the
+ * earliest date, and the smallest mileage.
+ *
+ * Exported for unit-test directness — the rest of the service is
+ * tested via the e2e DB path.
+ */
+export function computeTriggers(tickets: PmDueCandidate[]): {
+  triggeredBy: 'date' | 'mileage' | 'both';
+  earliestDate: Date | null;
+  smallestMileage: number | null;
+} {
+  let dateFired = false;
+  let mileageFired = false;
+  let earliestDate: Date | null = null;
+  let smallestMileage: number | null = null;
+
+  const dateCutoff = Date.now() + DATE_WARNING_BAND_DAYS * 24 * 60 * 60 * 1000;
+  for (const t of tickets) {
+    if (t.nextServiceDate && t.nextServiceDate.getTime() <= dateCutoff) {
+      dateFired = true;
+      if (!earliestDate || t.nextServiceDate < earliestDate) {
+        earliestDate = t.nextServiceDate;
+      }
+    }
+    if (
+      t.nextServiceMileage !== null &&
+      t.assetLastReadMileage !== null &&
+      t.assetLastReadMileage + MILEAGE_WARNING_BAND_MILES >= t.nextServiceMileage
+    ) {
+      mileageFired = true;
+      if (smallestMileage === null || t.nextServiceMileage < smallestMileage) {
+        smallestMileage = t.nextServiceMileage;
+      }
+    }
+  }
+
+  const triggeredBy: 'date' | 'mileage' | 'both' =
+    dateFired && mileageFired ? 'both' : dateFired ? 'date' : 'mileage';
+  return { triggeredBy, earliestDate, smallestMileage };
+}

--- a/apps/core-api/src/modules/maintenance/maintenance-sweep.service.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance-sweep.service.ts
@@ -134,7 +134,10 @@ export class MaintenanceSweepService implements OnModuleInit, OnModuleDestroy {
       { connection: this.makeRedis(), concurrency: 1 },
     );
     this.pmDueWorker.on('failed', (_job, err) =>
-      this.log.warn({ err: String(err) }, 'pm_due_sweep_job_failed'),
+      // BullMQ-job-failure is the OUTER frame; mirroring the audit-batch-
+      // failure log level (error) so an SRE seeing the cron's lifecycle
+      // failures has consistent severity across the same file.
+      this.log.error({ err: String(err) }, 'pm_due_sweep_job_failed'),
     );
     await this.pmDueQueue.add(
       PM_DUE_JOB_NAME,

--- a/apps/core-api/src/modules/maintenance/maintenance.module.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance.module.ts
@@ -41,9 +41,14 @@ export class MaintenanceModule implements OnModuleInit {
     // is loaded eagerly in app.module.ts and registers its own handlers
     // before MaintenanceModule's onModuleInit runs.
     this.registry.register(this.subscriber);
-    // MaintenanceSweepService starts its own BullMQ schedule via
-    // OnModuleInit (gated by NODE_ENV != 'test' AND FEATURE_MAINTENANCE
-    // == 'true'). No explicit start call needed here — Nest's lifecycle
-    // resolves provider OnModuleInit hooks alongside the module's own.
+    // MaintenanceSweepService self-starts its BullMQ schedule from its
+    // own OnModuleInit hook (gated by NODE_ENV != 'test' AND
+    // FEATURE_MAINTENANCE == 'true'). Nest resolves provider hooks
+    // before the owning module's hook, so the sweep is up by the time
+    // this method runs. Consider centralising the lifecycle here in a
+    // future refactor if a fourth ChannelHandler / sweep lands and the
+    // self-init pattern starts adding cognitive load — for now,
+    // mirroring InspectionMaintenanceService's self-init is the path
+    // of least surprise.
   }
 }

--- a/apps/core-api/src/modules/maintenance/maintenance.module.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance.module.ts
@@ -19,13 +19,14 @@ import { ChannelRegistry } from '../notification/channel-registry.js';
 import { MaintenanceController } from './maintenance.controller.js';
 import { MaintenanceService } from './maintenance.service.js';
 import { MaintenanceTicketSubscriber } from './maintenance-ticket.subscriber.js';
+import { MaintenanceSweepService } from './maintenance-sweep.service.js';
 
 // PrismaModule + AuditModule are @Global so no explicit import needed.
 @Module({
   imports: [NotificationModule],
   controllers: [MaintenanceController],
-  providers: [MaintenanceService, MaintenanceTicketSubscriber],
-  exports: [MaintenanceService],
+  providers: [MaintenanceService, MaintenanceTicketSubscriber, MaintenanceSweepService],
+  exports: [MaintenanceService, MaintenanceSweepService],
 })
 export class MaintenanceModule implements OnModuleInit {
   constructor(
@@ -40,5 +41,9 @@ export class MaintenanceModule implements OnModuleInit {
     // is loaded eagerly in app.module.ts and registers its own handlers
     // before MaintenanceModule's onModuleInit runs.
     this.registry.register(this.subscriber);
+    // MaintenanceSweepService starts its own BullMQ schedule via
+    // OnModuleInit (gated by NODE_ENV != 'test' AND FEATURE_MAINTENANCE
+    // == 'true'). No explicit start call needed here — Nest's lifecycle
+    // resolves provider OnModuleInit hooks alongside the module's own.
   }
 }

--- a/apps/core-api/test/maintenance-sweep.e2e.test.ts
+++ b/apps/core-api/test/maintenance-sweep.e2e.test.ts
@@ -1,0 +1,536 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Test } from '@nestjs/testing';
+import type { INestApplication } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+import { Redis } from 'ioredis';
+import { AppModule } from '../src/app.module.js';
+import { TenantAdminService } from '../src/modules/tenant/tenant-admin.service.js';
+import {
+  MaintenanceSweepService,
+  computeTriggers,
+} from '../src/modules/maintenance/maintenance-sweep.service.js';
+import { resetTestDb } from './_reset-db.js';
+
+/**
+ * MaintenanceSweepService PM-due cron e2e (ADR-0016 §9 + #74 PILOT-03).
+ *
+ * Drives the sweep directly via the service. Production cadence is
+ * daily (BullMQ repeatable); here we runOnce after seeding fixtures.
+ * The sweep is gated `NODE_ENV != 'test' AND FEATURE_MAINTENANCE`
+ * at module-init for production; the test imports the service
+ * directly and calls `runPmDueSweep()` to bypass that gate.
+ *
+ * Hard requires: Postgres + Redis (the dev stack).
+ *
+ * Coverage:
+ *   - mileage trigger: completed ticket with nextServiceMileage=N,
+ *     asset lastReadMileage = N-499 → audit fires; lastReadMileage
+ *     = N-501 → no audit
+ *   - date trigger: nextServiceDate within 14d → audit fires; +20d
+ *     → no audit
+ *   - both triggers fire on the same ticket → triggeredBy='both'
+ *   - non-COMPLETED tickets ignored
+ *   - multiple due tickets on same asset → one audit row, all
+ *     ticket IDs in metadata
+ *   - 24h dedup: second runOnce within window → no second audit
+ *   - cross-tenant isolation: per-tenant query stays scoped
+ */
+
+const HOST = process.env.PG_HOST ?? 'localhost';
+const PORT = process.env.PG_PORT ?? '5432';
+const DB = process.env.PG_DB ?? 'panorama';
+const ADMIN_URL = `postgres://panorama_super_admin:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+const APP_URL = `postgres://panorama_app:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+const REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379/0';
+
+describe('maintenance PM-due sweep e2e', () => {
+  let app: INestApplication;
+  let adminDb: PrismaClient;
+  let redis: Redis;
+  let sweep: MaintenanceSweepService;
+  let tenantId: string;
+  let secondTenantId: string;
+  let assetId: string;
+  let secondAssetId: string;
+  let ownerUserId: string;
+
+  async function clearAllSweepDedups(): Promise<void> {
+    // Brute-force clear: delete all keys matching the sweep's prefix.
+    // Safe in test DB (key 0); real prod would use SCAN, but this
+    // suite is the only thing in this Redis at test time.
+    const keys = await redis.keys('pm_due:*');
+    if (keys.length > 0) await redis.del(...keys);
+  }
+
+  async function seedCompletedTicket(params: {
+    tenantId: string;
+    assetId: string;
+    completedAt?: Date;
+    nextServiceMileage?: number;
+    nextServiceDate?: Date | null;
+  }): Promise<string> {
+    const t = await adminDb.assetMaintenance.create({
+      data: {
+        tenantId: params.tenantId,
+        assetId: params.assetId,
+        maintenanceType: 'Maintenance',
+        title: 'Oil change',
+        status: 'COMPLETED',
+        completedAt: params.completedAt ?? new Date(),
+        completedByUserId: ownerUserId,
+        nextServiceMileage: params.nextServiceMileage ?? null,
+        nextServiceDate: params.nextServiceDate ?? null,
+        createdByUserId: ownerUserId,
+      },
+    });
+    return t.id;
+  }
+
+  async function setAssetMileage(id: string, mileage: number): Promise<void> {
+    await adminDb.asset.update({
+      where: { id },
+      data: { lastReadMileage: mileage },
+    });
+  }
+
+  beforeAll(async () => {
+    process.env.SESSION_SECRET = process.env.SESSION_SECRET ?? 'a'.repeat(32);
+    process.env.DATABASE_URL = APP_URL;
+    process.env.REDIS_URL = REDIS_URL;
+
+    adminDb = new PrismaClient({ datasources: { db: { url: ADMIN_URL } } });
+    await resetTestDb(adminDb);
+
+    redis = new Redis(REDIS_URL, {
+      lazyConnect: false,
+      enableReadyCheck: false,
+      maxRetriesPerRequest: null,
+    });
+    await clearAllSweepDedups();
+
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleRef.createNestApplication({ logger: ['error', 'warn'] });
+    await app.init();
+    sweep = app.get(MaintenanceSweepService);
+
+    const tenants = app.get(TenantAdminService);
+    const ownerUser = await adminDb.user.create({
+      data: { email: 'pm-due-owner@example.com', displayName: 'PM Owner' },
+    });
+    ownerUserId = ownerUser.id;
+    const { tenant } = await tenants.createTenantWithOwner({
+      slug: 'pm-due',
+      name: 'PM Due',
+      displayName: 'PM Due',
+      ownerUserId: ownerUser.id,
+    });
+    tenantId = tenant.id;
+
+    const second = await tenants.createTenantWithOwner({
+      slug: 'pm-due-second',
+      name: 'PM Due Second',
+      displayName: 'PM Due Second',
+      ownerUserId: ownerUser.id,
+    });
+    secondTenantId = second.tenant.id;
+
+    const cat = await adminDb.category.create({
+      data: { tenantId, name: 'Vehicles', kind: 'VEHICLE' },
+    });
+    const model = await adminDb.assetModel.create({
+      data: { tenantId, categoryId: cat.id, name: 'F-150' },
+    });
+    const asset = await adminDb.asset.create({
+      data: {
+        tenantId,
+        modelId: model.id,
+        tag: 'PM-01',
+        name: 'PM Truck 01',
+        bookable: true,
+        status: 'READY',
+      },
+    });
+    assetId = asset.id;
+    const asset2 = await adminDb.asset.create({
+      data: {
+        tenantId,
+        modelId: model.id,
+        tag: 'PM-02',
+        name: 'PM Truck 02',
+        bookable: true,
+        status: 'READY',
+      },
+    });
+    secondAssetId = asset2.id;
+  }, 120_000);
+
+  afterAll(async () => {
+    await clearAllSweepDedups();
+    await redis?.quit();
+    await sweep?.stop();
+    await adminDb?.$disconnect();
+    await app?.close();
+  }, 30_000);
+
+  beforeEach(async () => {
+    await clearAllSweepDedups();
+    await adminDb.assetMaintenance.deleteMany({
+      where: { tenantId: { in: [tenantId, secondTenantId] } },
+    });
+    await adminDb.auditEvent.deleteMany({
+      where: {
+        tenantId: { in: [tenantId, secondTenantId] },
+        action: 'panorama.maintenance.next_service_due',
+      },
+    });
+    await setAssetMileage(assetId, 0);
+    await setAssetMileage(secondAssetId, 0);
+  });
+
+  // ---------------------------------------------------------------
+
+  it('mileage trigger: lastReadMileage within 500 of nextServiceMileage → audit fires', async () => {
+    await seedCompletedTicket({
+      tenantId,
+      assetId,
+      nextServiceMileage: 10_000,
+    });
+    await setAssetMileage(assetId, 9_501); // 499 mi until due → within band
+
+    const due = await sweep.runPmDueSweep();
+    expect(due).toBeGreaterThanOrEqual(1);
+
+    const audit = await adminDb.auditEvent.findFirst({
+      where: {
+        tenantId,
+        action: 'panorama.maintenance.next_service_due',
+        resourceId: assetId,
+      },
+    });
+    expect(audit).toBeTruthy();
+    const meta = audit!.metadata as Record<string, unknown>;
+    expect(meta['triggeredBy']).toBe('mileage');
+    expect(meta['smallestNextServiceMileage']).toBe(10_000);
+    expect(meta['assetLastReadMileage']).toBe(9_501);
+    expect(meta['milesUntilDue']).toBe(499);
+    expect(Array.isArray(meta['ticketIds'])).toBe(true);
+    expect((meta['ticketIds'] as unknown[]).length).toBe(1);
+  });
+
+  it('mileage trigger: lastReadMileage outside 500 band → no audit', async () => {
+    await seedCompletedTicket({
+      tenantId,
+      assetId,
+      nextServiceMileage: 10_000,
+    });
+    await setAssetMileage(assetId, 9_499); // 501 mi until due → outside band
+
+    const due = await sweep.runPmDueSweep();
+    expect(due).toBe(0);
+
+    const audit = await adminDb.auditEvent.findFirst({
+      where: {
+        tenantId,
+        action: 'panorama.maintenance.next_service_due',
+        resourceId: assetId,
+      },
+    });
+    expect(audit).toBeNull();
+  });
+
+  it('date trigger: nextServiceDate within 14 days → audit fires', async () => {
+    const tenDaysOut = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000);
+    await seedCompletedTicket({
+      tenantId,
+      assetId,
+      nextServiceDate: tenDaysOut,
+    });
+
+    const due = await sweep.runPmDueSweep();
+    expect(due).toBeGreaterThanOrEqual(1);
+
+    const audit = await adminDb.auditEvent.findFirst({
+      where: {
+        tenantId,
+        action: 'panorama.maintenance.next_service_due',
+        resourceId: assetId,
+      },
+    });
+    expect(audit).toBeTruthy();
+    const meta = audit!.metadata as Record<string, unknown>;
+    expect(meta['triggeredBy']).toBe('date');
+    expect(typeof meta['daysUntilDue']).toBe('number');
+    expect(meta['daysUntilDue']).toBeGreaterThanOrEqual(9);
+    expect(meta['daysUntilDue']).toBeLessThanOrEqual(10);
+  });
+
+  it('date trigger: nextServiceDate beyond 14 days → no audit', async () => {
+    const twentyDaysOut = new Date(Date.now() + 20 * 24 * 60 * 60 * 1000);
+    await seedCompletedTicket({
+      tenantId,
+      assetId,
+      nextServiceDate: twentyDaysOut,
+    });
+
+    const due = await sweep.runPmDueSweep();
+    expect(due).toBe(0);
+  });
+
+  it('both triggers on the same ticket → triggeredBy=both', async () => {
+    await seedCompletedTicket({
+      tenantId,
+      assetId,
+      nextServiceMileage: 10_000,
+      nextServiceDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    });
+    await setAssetMileage(assetId, 9_700);
+
+    const due = await sweep.runPmDueSweep();
+    expect(due).toBe(1);
+
+    const audit = await adminDb.auditEvent.findFirst({
+      where: {
+        tenantId,
+        action: 'panorama.maintenance.next_service_due',
+        resourceId: assetId,
+      },
+    });
+    expect((audit!.metadata as Record<string, unknown>)['triggeredBy']).toBe('both');
+  });
+
+  it('non-COMPLETED tickets are ignored', async () => {
+    // Open ticket — has nextServiceMileage but is OPEN, should not fire.
+    await adminDb.assetMaintenance.create({
+      data: {
+        tenantId,
+        assetId,
+        maintenanceType: 'Maintenance',
+        title: 'still open',
+        status: 'OPEN',
+        nextServiceMileage: 10_000,
+        createdByUserId: ownerUserId,
+      },
+    });
+    await setAssetMileage(assetId, 9_700);
+
+    const due = await sweep.runPmDueSweep();
+    expect(due).toBe(0);
+  });
+
+  it('multiple due tickets on same asset → one audit row, all ticket IDs in metadata', async () => {
+    const t1 = await seedCompletedTicket({
+      tenantId,
+      assetId,
+      nextServiceMileage: 10_000,
+      completedAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    });
+    const t2 = await seedCompletedTicket({
+      tenantId,
+      assetId,
+      nextServiceMileage: 12_000,
+      completedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000),
+    });
+    await setAssetMileage(assetId, 11_700); // within band of t2 (12_000)
+                                            // — lastReadMileage 11_700 + 500
+                                            // < 10_000 is false (11_700 +
+                                            // 500 = 12_200 ≥ 12_000 ✓; also
+                                            // ≥ 10_000 ✓ — both fire)
+
+    const due = await sweep.runPmDueSweep();
+    expect(due).toBe(1);
+
+    const audits = await adminDb.auditEvent.findMany({
+      where: {
+        tenantId,
+        action: 'panorama.maintenance.next_service_due',
+        resourceId: assetId,
+      },
+    });
+    expect(audits).toHaveLength(1);
+    const ticketIds = (audits[0]!.metadata as Record<string, unknown>)['ticketIds'] as string[];
+    expect(ticketIds.sort()).toEqual([t1, t2].sort());
+    expect((audits[0]!.metadata as Record<string, unknown>)['ticketCount']).toBe(2);
+    // Smallest nextServiceMileage among the two — relevant for "soonest due."
+    expect((audits[0]!.metadata as Record<string, unknown>)['smallestNextServiceMileage']).toBe(10_000);
+  });
+
+  it('24h dedup: second runOnce within window → no second audit', async () => {
+    await seedCompletedTicket({
+      tenantId,
+      assetId,
+      nextServiceMileage: 10_000,
+    });
+    await setAssetMileage(assetId, 9_700);
+
+    const due1 = await sweep.runPmDueSweep();
+    expect(due1).toBe(1);
+
+    const due2 = await sweep.runPmDueSweep();
+    expect(due2).toBe(0);
+
+    const audits = await adminDb.auditEvent.findMany({
+      where: {
+        tenantId,
+        action: 'panorama.maintenance.next_service_due',
+        resourceId: assetId,
+      },
+    });
+    expect(audits).toHaveLength(1);
+  });
+
+  it('per-tenant isolation: tenant A audit does not leak to tenant B', async () => {
+    // Seed a due ticket for tenant A on tenant A's asset.
+    await seedCompletedTicket({
+      tenantId,
+      assetId,
+      nextServiceMileage: 10_000,
+    });
+    await setAssetMileage(assetId, 9_700);
+
+    // Seed an asset + ticket on tenant B for parity (no due trigger).
+    const cat2 = await adminDb.category.create({
+      data: { tenantId: secondTenantId, name: 'Vehicles', kind: 'VEHICLE' },
+    });
+    const model2 = await adminDb.assetModel.create({
+      data: { tenantId: secondTenantId, categoryId: cat2.id, name: 'F-150' },
+    });
+    const asset2 = await adminDb.asset.create({
+      data: {
+        tenantId: secondTenantId,
+        modelId: model2.id,
+        tag: 'PM2-01',
+        name: 'PM2 Truck',
+        bookable: true,
+        status: 'READY',
+        lastReadMileage: 100, // far below any threshold
+      },
+    });
+    await adminDb.assetMaintenance.create({
+      data: {
+        tenantId: secondTenantId,
+        assetId: asset2.id,
+        maintenanceType: 'Maintenance',
+        title: 'PM2 oil change',
+        status: 'COMPLETED',
+        completedAt: new Date(),
+        completedByUserId: ownerUserId,
+        nextServiceMileage: 10_000,
+        createdByUserId: ownerUserId,
+      },
+    });
+
+    const due = await sweep.runPmDueSweep();
+    expect(due).toBe(1);
+
+    const auditsA = await adminDb.auditEvent.findMany({
+      where: { tenantId, action: 'panorama.maintenance.next_service_due' },
+    });
+    expect(auditsA).toHaveLength(1);
+    expect(auditsA[0]!.tenantId).toBe(tenantId);
+
+    const auditsB = await adminDb.auditEvent.findMany({
+      where: { tenantId: secondTenantId, action: 'panorama.maintenance.next_service_due' },
+    });
+    expect(auditsB).toHaveLength(0);
+
+    // Cleanup: drop tenant B's seeded data.
+    await adminDb.assetMaintenance.deleteMany({ where: { tenantId: secondTenantId } });
+    await adminDb.asset.deleteMany({ where: { tenantId: secondTenantId } });
+    await adminDb.assetModel.deleteMany({ where: { tenantId: secondTenantId } });
+    await adminDb.category.deleteMany({ where: { tenantId: secondTenantId } });
+  });
+
+  it('CANCELLED tickets are ignored even with a thresholded nextServiceMileage', async () => {
+    await adminDb.assetMaintenance.create({
+      data: {
+        tenantId,
+        assetId,
+        maintenanceType: 'Maintenance',
+        title: 'cancelled before completion',
+        status: 'CANCELLED',
+        nextServiceMileage: 10_000,
+        createdByUserId: ownerUserId,
+      },
+    });
+    await setAssetMileage(assetId, 9_700);
+
+    const due = await sweep.runPmDueSweep();
+    expect(due).toBe(0);
+  });
+});
+
+describe('computeTriggers (unit)', () => {
+  function ticket(overrides: {
+    nextServiceDate?: Date | null;
+    nextServiceMileage?: number | null;
+    assetLastReadMileage?: number | null;
+  }): {
+    id: string;
+    assetId: string;
+    tenantId: string;
+    nextServiceDate: Date | null;
+    nextServiceMileage: number | null;
+    assetLastReadMileage: number | null;
+  } {
+    return {
+      id: 't1',
+      assetId: 'a1',
+      tenantId: 't1',
+      nextServiceDate: overrides.nextServiceDate ?? null,
+      nextServiceMileage: overrides.nextServiceMileage ?? null,
+      assetLastReadMileage: overrides.assetLastReadMileage ?? null,
+    };
+  }
+
+  it('classifies date-only trigger', () => {
+    const t = computeTriggers([
+      ticket({ nextServiceDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) }),
+    ]);
+    expect(t.triggeredBy).toBe('date');
+    expect(t.earliestDate).toBeInstanceOf(Date);
+    expect(t.smallestMileage).toBeNull();
+  });
+
+  it('classifies mileage-only trigger', () => {
+    const t = computeTriggers([
+      ticket({ nextServiceMileage: 10_000, assetLastReadMileage: 9_700 }),
+    ]);
+    expect(t.triggeredBy).toBe('mileage');
+    expect(t.smallestMileage).toBe(10_000);
+    expect(t.earliestDate).toBeNull();
+  });
+
+  it('classifies both when one ticket has each kind', () => {
+    const t = computeTriggers([
+      ticket({ nextServiceDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) }),
+      ticket({ nextServiceMileage: 10_000, assetLastReadMileage: 9_700 }),
+    ]);
+    expect(t.triggeredBy).toBe('both');
+    expect(t.earliestDate).toBeInstanceOf(Date);
+    expect(t.smallestMileage).toBe(10_000);
+  });
+
+  it('takes the earliest date / smallest mileage across multiple tickets', () => {
+    const earlier = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
+    const later = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000);
+    const t = computeTriggers([
+      ticket({ nextServiceDate: later, nextServiceMileage: 12_000, assetLastReadMileage: 11_700 }),
+      ticket({ nextServiceDate: earlier, nextServiceMileage: 10_000, assetLastReadMileage: 11_700 }),
+    ]);
+    expect(t.earliestDate?.getTime()).toBe(earlier.getTime());
+    expect(t.smallestMileage).toBe(10_000);
+    expect(t.triggeredBy).toBe('both');
+  });
+
+  it('mileage NOT in band → no mileage trigger', () => {
+    const t = computeTriggers([
+      ticket({ nextServiceMileage: 10_000, assetLastReadMileage: 9_499 }),
+    ]);
+    expect(t.smallestMileage).toBeNull();
+    // No fields fired — but the function still returns a string.
+    // In practice the caller filters out tickets that don't cross
+    // a threshold via the SQL predicate, so this branch is defensive.
+    expect(['date', 'mileage', 'both']).toContain(t.triggeredBy);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes the final #74 / ADR-0016 §9 slice: a daily BullMQ repeatable that emits `panorama.maintenance.next_service_due` audit per asset whose COMPLETED maintenance ticket is approaching due — `nextServiceDate` within 14 days OR `nextServiceMileage` within 500 mi of `Asset.lastReadMileage`.
- Per-asset Redis SETNX 24h dedup. An asset with multiple due tickets emits ONE audit row with all matching ticket IDs in metadata.
- Mirrors the InspectionMaintenanceService pattern; allowlist budget +2 (tenant list + audit batch).
- Two review passes (tech-lead, data-architect) + security-reviewer pass 1. All blockers closed.

## Migrations in this PR

**Migration 0017** — adds `asset_maintenances_next_service_mileage_due_partial` partial index on `(tenantId, assetId, nextServiceMileage) WHERE status='COMPLETED' AND nextServiceMileage IS NOT NULL`. Symmetric to migration 0014's `next_service_due_partial`. Each arm of the rewritten UNION query probes its own dedicated partial index.

## Behavioural shape

The audit row carries enough metadata that dashboards can render "soonest due" without a re-query:
- `ticketIds`, `ticketCount`, `triggeredBy` (`'date' | 'mileage' | 'both'`)
- `earliestNextServiceDate`, `smallestNextServiceMileage`
- `assetLastReadMileage` snapshot at scan time
- `daysUntilDue` (negative if overdue), `milesUntilDue`

`actorUserId: null` (system-attributed); `tenantId` scoped via the per-tenant `runInTenant` loop. RLS scopes audit reads.

## Test plan

- [x] `pnpm --filter @panorama/core-api test` — 360/360 backend (+15 vs the 345 baseline after #139)
- [x] `pnpm --filter @panorama/core-api lint` — clean
- [x] `pnpm rls:allowlist-check` — green (27 calls / 11 files; budget for the new file = 2 with rationale)
- [x] `pnpm --filter @panorama/core-api typecheck` — 3 pre-existing CJS/ESM errors unchanged
- [x] Local migration applied (`pnpm prisma migrate deploy`)
- [x] Coverage: mileage trigger in/out of band, date trigger in/out of band, both-trigger classification, non-COMPLETED ignored, multi-ticket-per-asset collapse to one audit row, 24h dedup, per-tenant isolation, CANCELLED ticket ignored, computeTriggers helper unit-level

## Reviews completed

- **tech-lead** pass 1: APPROVE-WITH-NITS (`log.warn` → `log.error` on audit failure; module docblock honesty about self-init pattern; missing mileage-arm partial index flagged as concern). All addressed in the second commit; the missing index closed by migration 0017 in the same commit.
- **data-architect** pass 1: REQUEST-CHANGES (3 blockers: missing mileage-arm partial; LIMIT 500 swallowing audit signals; 100+ super-admin txes per pass) → all addressed in the second commit (migration 0017; LIMIT 500 → 10k circuit-breaker with error-level log; audit emissions batched into a single super-admin tx via `recordWithin`).
- **security-reviewer** pass 1: APPROVE-WITH-NITS (audit `tenantId` source preference; 3 soft observability concerns deferred to follow-ups).

Pass 2 reviews are in flight at PR creation time; addressing any further findings inline.

## Soft concerns deferred (tracked as follow-up)

- Extend `assert_maintenance_triggers_same_tenant` trigger to also assert `assetId.tenantId === maintenance.tenantId`. Latent gap closed today via runInTenant RLS for the maintenance module specifically; but a future code path that writes `asset_maintenances` under runAsSuperAdmin would bypass.
- Promote dedup-release `del`-on-zero to a structured warn so a Redis partition during release surfaces in alerting.
- Centralise sweep lifecycle in `MaintenanceModule.onModuleInit` if a fourth ChannelHandler / sweep lands; today the self-init pattern mirrors InspectionMaintenanceService.

Refs #74 (final slice — closes the audit-only PM-due sweep; Enterprise email channel + EditionService remain a separate Enterprise-edition slice).