### PR TITLE
chore(i18n): JSX gate locks in trilingual hygiene (#44 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm i18n:check
+      - run: pnpm i18n:jsx-gate
 
   license-check:
     name: Dependency licence scan

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typecheck": "turbo run typecheck",
     "clean": "turbo run clean && rimraf node_modules .turbo",
     "i18n:check": "tsx scripts/i18n-check.ts",
+    "i18n:jsx-gate": "tsx scripts/i18n-jsx-gate.ts",
     "license:check": "tsx scripts/license-check.ts",
     "migrations:check": "tsx scripts/check-migration-conventions.ts",
     "ensure:community-complete": "tsx scripts/ensure-community-complete.ts",

--- a/scripts/i18n-jsx-gate.ts
+++ b/scripts/i18n-jsx-gate.ts
@@ -1,0 +1,153 @@
+/**
+ * i18n JSX gate.
+ *
+ * Walks `apps/web/src/**\/*.tsx` and fails if any JSXText node contains
+ * two or more letter-word tokens that aren't in the allowlist. The goal
+ * is to lock in trilingual hygiene after the #44 effort: future PRs
+ * that reintroduce hardcoded English JSX text trip CI.
+ *
+ * Heuristic limitations:
+ * - Only flags `JSXText` nodes. Hardcoded `placeholder="..."`,
+ *   `title="..."`, or `{'string literal'}` inside JSX still pass.
+ *   Those have a much lower regression rate in this codebase (the
+ *   established pattern routes them through `messages.t(...)` already),
+ *   and widening the rule introduces more false positives than it
+ *   catches.
+ * - Allowlist is exact-match. Add entries with intent — every line
+ *   weakens the gate.
+ */
+
+import { promises as fs } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as ts from 'typescript';
+
+const ROOT = new URL('../', import.meta.url);
+const SCAN_DIR = new URL('apps/web/src/', ROOT);
+
+// Phrases the heuristic flags but should not block CI. Each entry is
+// the trimmed JSXText. Whitespace and JSX entity references (`&nbsp;`)
+// are stripped before comparison.
+const ALLOWLIST = new Set<string>([
+  // Visual separators / fixed glyphs
+  '—',
+  '→',
+  '←',
+  '...',
+  '…',
+]);
+
+// JSX elements whose text content is intentionally literal (code
+// snippets, keyboard shortcuts, sample IDs). Skipped wholesale.
+const LITERAL_PARENT_ELEMENTS = new Set<string>(['code', 'pre', 'kbd', 'samp']);
+
+interface Violation {
+  file: string;
+  line: number;
+  text: string;
+}
+
+async function* walk(dir: URL): AsyncGenerator<URL> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+    const child = new URL(
+      entry.name + (entry.isDirectory() ? '/' : ''),
+      dir,
+    );
+    if (entry.isDirectory()) {
+      yield* walk(child);
+    } else if (entry.name.endsWith('.tsx')) {
+      yield child;
+    }
+  }
+}
+
+function countWords(text: string): number {
+  // A "word" is a run of 2+ letters. Single-letter tokens like "a" or
+  // "I" don't count toward the threshold so we don't trip on
+  // separators like " - " or ":" embedded in expression-heavy JSX.
+  const words = text.match(/[A-Za-zÀ-ÿ]{2,}/g) ?? [];
+  return words.length;
+}
+
+function isInsideLiteralParent(node: ts.Node): boolean {
+  let cur: ts.Node | undefined = node.parent;
+  while (cur) {
+    if (ts.isJsxElement(cur)) {
+      const tagName = cur.openingElement.tagName;
+      if (ts.isIdentifier(tagName) && LITERAL_PARENT_ELEMENTS.has(tagName.text)) {
+        return true;
+      }
+    }
+    cur = cur.parent;
+  }
+  return false;
+}
+
+async function check(filePath: URL): Promise<Violation[]> {
+  const sourceText = await fs.readFile(filePath, 'utf8');
+  const path = fileURLToPath(filePath);
+  const sf = ts.createSourceFile(
+    path,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX,
+  );
+  const violations: Violation[] = [];
+  const rootPath = fileURLToPath(ROOT);
+
+  function visit(node: ts.Node): void {
+    if (ts.isJsxText(node)) {
+      const raw = node.getText();
+      // Collapse whitespace + entity refs so multi-line JSXText with
+      // mostly whitespace gets evaluated on its actual word content.
+      const trimmed = raw.replace(/&nbsp;/g, ' ').trim();
+      if (trimmed.length === 0) return;
+      if (ALLOWLIST.has(trimmed)) return;
+      if (isInsideLiteralParent(node)) return;
+      if (countWords(trimmed) >= 2) {
+        const lc = sf.getLineAndCharacterOfPosition(node.getStart());
+        const display =
+          trimmed.length > 80 ? trimmed.slice(0, 77) + '…' : trimmed;
+        violations.push({
+          file: path.startsWith(rootPath) ? path.slice(rootPath.length) : path,
+          line: lc.line + 1,
+          text: display,
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sf);
+  return violations;
+}
+
+async function main(): Promise<void> {
+  const all: Violation[] = [];
+  for await (const file of walk(SCAN_DIR)) {
+    all.push(...(await check(file)));
+  }
+  if (all.length > 0) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `i18n JSX gate failed — ${all.length} hardcoded JSX text node(s):`,
+    );
+    for (const v of all) {
+      // eslint-disable-next-line no-console
+      console.error(`  ${v.file}:${v.line}: ${v.text}`);
+    }
+    process.exit(1);
+  }
+  // eslint-disable-next-line no-console
+  console.log(
+    'i18n JSX gate OK — no hardcoded JSX text in apps/web/src.',
+  );
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

After #147 (UX-05 reservations) and #148 (UX-07-10 inspections + admin
templates), every user-facing page in `apps/web/src` is trilingual.
This PR adds a CI gate that prevents regression: future PRs that
reintroduce hardcoded JSX text trip the build.

Implementation: `scripts/i18n-jsx-gate.ts` walks every `.tsx` file
under `apps/web/src` with the TypeScript compiler API, finds JSXText
nodes containing 2+ letter-word tokens, and fails if any are not in
the allowlist or inside a literal-content parent (`<code>`, `<pre>`,
`<kbd>`, `<samp>`).

## Heuristic limitations (called out in the script header)

- Only flags `JSXText`. Hardcoded `placeholder="..."`, `title="..."`,
  or `{'literal'}` inside JSX still pass. The codebase routes these
  through `messages.t(...)` already; widening introduces more false
  positives than it catches.
- Allowlist is exact-match (5 visual separators currently). Add
  entries with intent.

## Self-test

Dropped a fixture `apps/web/src/app/__test_gate_fixture__.tsx`
containing an unwrapped JSX text node:

```
i18n JSX gate failed — 1 hardcoded JSX text node(s):
  apps/web/src/app/__test_gate_fixture__.tsx:2: This is hardcoded English that should fail
```

Exit code 1, fixture removed, gate passes clean against the current
codebase (the lone `<code>pnpm --filter…</code>` in `assets/page.tsx`
is correctly skipped via the literal-parent rule).

## CI integration

Appended to the existing `i18n-coverage` job (shares checkout + pnpm
install with the existing `i18n:check`). The CI step name on this PR
will already report `i18n coverage (EN = PT-BR = ES)`.

## Test plan

- [x] Gate passes locally on current main (HEAD = 7ababcd)
- [x] Self-tested with fixture .tsx
- [x] No new dependencies (`typescript` + `tsx` already in devDeps)
- [ ] CI run on this branch confirms the new step lands cleanly

## Closes

Proposed item #3 from the session-4 handoff (`docs/audits/HANDOFF-2026-04-27-session-4.md`).