### PR TITLE
feat(observability): audit-on-throw + dedup-warn + chain-integrity (session-4 soft follow-ups)

### DIFF
--- a/apps/core-api/src/modules/maintenance/maintenance-sweep.service.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance-sweep.service.ts
@@ -462,9 +462,24 @@ export class MaintenanceSweepService implements OnModuleInit, OnModuleDestroy {
   private async releaseDedup(key: string): Promise<void> {
     if (!this.dedupRedis) return;
     try {
-      await this.dedupRedis.del(key);
+      const removed = await this.dedupRedis.del(key);
+      if (removed === 0) {
+        // Key vanished between `acquireDedup` (winning SETNX) and this
+        // release. Possible causes: Redis partition + replica catch-up,
+        // a parallel sweep tick already released, or the 24 h TTL
+        // fired (unlikely within one tick). Worth surfacing to
+        // alerting because under healthy operation this branch
+        // shouldn't fire — silently logging at debug let a real
+        // partition slip through unnoticed (security-reviewer pass-1
+        // soft on #140).
+        this.log.warn({ key }, 'pm_due_dedup_release_returned_zero');
+      }
     } catch (err) {
-      this.log.debug({ err: String(err), key }, 'pm_due_dedup_release_failed');
+      // Promoted from debug to warn for the same reason: a failure to
+      // release the dedup key after a batch failure means the next
+      // tick can't dedup against this asset until TTL fires (24 h),
+      // and ops should know.
+      this.log.warn({ err: String(err), key }, 'pm_due_dedup_release_failed');
     }
   }
 

--- a/apps/core-api/src/modules/maintenance/maintenance-ticket.subscriber.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance-ticket.subscriber.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import type { NotificationEvent, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service.js';
 import type { ChannelHandler } from '../notification/channel-registry.js';
+import { AuditService } from '../audit/audit.service.js';
 import { MaintenanceService, type AutoOpenTicketParams } from './maintenance.service.js';
 
 /**
@@ -69,6 +70,7 @@ export class MaintenanceTicketSubscriber implements ChannelHandler {
   constructor(
     private readonly prisma: PrismaService,
     private readonly maintenance: MaintenanceService,
+    private readonly audit: AuditService,
   ) {}
 
   supports(eventType: string): boolean {
@@ -82,61 +84,139 @@ export class MaintenanceTicketSubscriber implements ChannelHandler {
     if (!event.tenantId) {
       // Auto-suggest is strictly tenant-scoped — refuse rather than fall
       // through to runAsSuperAdmin and write under the wrong tenant.
+      // Audit the failure before the throw so a flag-flip backfill or
+      // a forensic walkthrough has an immediate trail; the dispatcher's
+      // retry path will still fire and eventually DEAD-letter after
+      // MAX_ATTEMPTS=5 (~31 min backoff) — this audit just doesn't
+      // make ops wait for it.
+      await this.recordFailureAudit(event, 'missing_tenant_id', null);
       throw new Error('missing_tenant_id');
     }
     const tenantId = event.tenantId;
 
-    await this.prisma.runInTenant(tenantId, async (tx) => {
-      const tenant = await tx.tenant.findUnique({
-        where: { id: tenantId },
-        select: {
-          autoOpenMaintenanceFromInspection: true,
-          systemActorUserId: true,
+    // Set inside `runInTenant` and consumed AFTER it returns. The
+    // flag-off audit cannot be written from within the tenant tx
+    // (audit_events writes need super-admin); lifting it out keeps
+    // the privilege boundary clean.
+    let flagOff = false;
+
+    try {
+      await this.prisma.runInTenant(tenantId, async (tx) => {
+        const tenant = await tx.tenant.findUnique({
+          where: { id: tenantId },
+          select: {
+            autoOpenMaintenanceFromInspection: true,
+            systemActorUserId: true,
+          },
+        });
+        if (!tenant) {
+          // Stale event for a deleted tenant. Throwing would loop the
+          // dispatcher's retry path. Return cleanly so the row marks
+          // dispatched and the issue (deleted-tenant residual events)
+          // surfaces via the cleanup audit trail elsewhere.
+          this.log.warn(
+            { eventId: event.id, eventType: event.eventType, tenantId },
+            'auto_suggest_tenant_missing',
+          );
+          return;
+        }
+        if (!tenant.autoOpenMaintenanceFromInspection) {
+          // Per-tenant opt-in — log + return cleanly so the event marks
+          // dispatched on first attempt instead of accumulating retries.
+          flagOff = true;
+          this.log.log(
+            { eventId: event.id, eventType: event.eventType, tenantId },
+            'auto_suggest_skipped_flag_off',
+          );
+          return;
+        }
+
+        const params = await this.buildParams(tx, event, tenant.systemActorUserId);
+        if (!params) {
+          // PASS outcome on inspection.completed → no ticket. The event
+          // itself still dispatches successfully.
+          return;
+        }
+
+        const result = await this.maintenance.openTicketAuto(tx, params);
+        this.log.log(
+          {
+            eventId: event.id,
+            eventType: event.eventType,
+            tenantId,
+            source: params.source,
+            result: result.status,
+            ...(result.status === 'opened'
+              ? { ticketId: result.ticketId }
+              : { reason: result.reason, existingTicketId: result.existingTicketId }),
+          },
+          'auto_suggest_processed',
+        );
+      });
+    } catch (err) {
+      // The runInTenant tx has already rolled back at this point, so
+      // an audit row written here lands cleanly outside it. Don't
+      // mask the original error if the audit itself fails — re-throw
+      // either way so the dispatcher's retry/DEAD-letter path stays
+      // authoritative.
+      const reason = err instanceof Error ? err.message : 'unknown';
+      await this.recordFailureAudit(event, reason, extractAssetId(event));
+      throw err;
+    }
+
+    if (flagOff) {
+      // Backfill-recoverable trail: when a tenant flips the flag from
+      // false → true, ops needs to know which events were dropped on
+      // the floor so they can decide whether to replay or accept the
+      // gap. The dispatcher already marks the event dispatched
+      // successfully; this is the second leg.
+      await this.audit.record({
+        action: 'panorama.maintenance.auto_suggest_skipped',
+        resourceType: 'notification_event',
+        resourceId: event.id,
+        tenantId,
+        actorUserId: null,
+        metadata: {
+          eventType: event.eventType,
+          reason: 'flag_off',
+          assetId: extractAssetId(event),
         },
       });
-      if (!tenant) {
-        // Stale event for a deleted tenant. Throwing would loop the
-        // dispatcher's retry path. Return cleanly so the row marks
-        // dispatched and the issue (deleted-tenant residual events)
-        // surfaces via the cleanup audit trail elsewhere.
-        this.log.warn(
-          { eventId: event.id, eventType: event.eventType, tenantId },
-          'auto_suggest_tenant_missing',
-        );
-        return;
-      }
-      if (!tenant.autoOpenMaintenanceFromInspection) {
-        // Per-tenant opt-in — log + return cleanly so the event marks
-        // dispatched on first attempt instead of accumulating retries.
-        this.log.log(
-          { eventId: event.id, eventType: event.eventType, tenantId },
-          'auto_suggest_skipped_flag_off',
-        );
-        return;
-      }
+    }
+  }
 
-      const params = await this.buildParams(tx, event, tenant.systemActorUserId);
-      if (!params) {
-        // PASS outcome on inspection.completed → no ticket. The event
-        // itself still dispatches successfully.
-        return;
-      }
-
-      const result = await this.maintenance.openTicketAuto(tx, params);
-      this.log.log(
-        {
-          eventId: event.id,
+  private async recordFailureAudit(
+    event: NotificationEvent,
+    reason: string,
+    assetId: string | null,
+  ): Promise<void> {
+    try {
+      await this.audit.record({
+        action: 'panorama.maintenance.auto_suggest_failed',
+        resourceType: assetId ? 'asset' : 'notification_event',
+        resourceId: assetId ?? event.id,
+        tenantId: event.tenantId ?? null,
+        actorUserId: null,
+        metadata: {
           eventType: event.eventType,
-          tenantId,
-          source: params.source,
-          result: result.status,
-          ...(result.status === 'opened'
-            ? { ticketId: result.ticketId }
-            : { reason: result.reason, existingTicketId: result.existingTicketId }),
+          eventId: event.id,
+          reason,
         },
-        'auto_suggest_processed',
+      });
+    } catch (auditErr) {
+      // If audit itself fails, log + continue. The dispatcher's
+      // eventual DEAD-letter audit (MAX_ATTEMPTS=5) is the
+      // backstop; this is the soft trail.
+      this.log.error(
+        {
+          err: String(auditErr),
+          originalReason: reason,
+          eventId: event.id,
+          tenantId: event.tenantId,
+        },
+        'auto_suggest_audit_failed',
       );
-    });
+    }
   }
 
   /**
@@ -241,4 +321,20 @@ export class MaintenanceTicketSubscriber implements ChannelHandler {
     // supports() should have filtered these out, but defence-in-depth.
     throw new Error(`unsupported_event_type:${event.eventType}`);
   }
+}
+
+/**
+ * Pull `assetId` out of the event payload when present. Both supported
+ * event types carry it; an unrecognised event type returns null and
+ * the audit row falls back to `notification_event` resource scope.
+ */
+function extractAssetId(event: NotificationEvent): string | null {
+  if (
+    event.eventType !== 'panorama.inspection.completed' &&
+    event.eventType !== 'panorama.reservation.checked_in_with_damage'
+  ) {
+    return null;
+  }
+  const payload = event.payload as { assetId?: string } | null;
+  return payload?.assetId ?? null;
 }

--- a/apps/core-api/test/audit-chain-integrity.e2e.test.ts
+++ b/apps/core-api/test/audit-chain-integrity.e2e.test.ts
@@ -1,0 +1,217 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Test } from '@nestjs/testing';
+import type { INestApplication } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+import { createHash } from 'node:crypto';
+import { AppModule } from '../src/app.module.js';
+import { AuditService } from '../src/modules/audit/audit.service.js';
+import { PrismaService } from '../src/modules/prisma/prisma.service.js';
+import { resetTestDb } from './_reset-db.js';
+
+/**
+ * Hash-chain integrity for batched `audit.recordWithin` calls inside
+ * a single super-admin tx (tech-lead pass-2 soft on #140 +
+ * MaintenanceSweepService PM-due audit batching).
+ *
+ * The invariant: when N rows are inserted via `recordWithin(tx, …)`
+ * inside one transaction, row[k+1].prevHash MUST equal row[k].selfHash.
+ * That holds today because Prisma transaction clients honour
+ * read-your-own-writes within the same tx, so the `findFirst({
+ * orderBy: { id: 'desc' } })` lookup at the top of `recordWithin`
+ * sees the row inserted on the prior call. If a future Prisma upgrade
+ * changes the tx-client snapshot semantics, this test catches it
+ * before the chain breaks silently in production.
+ *
+ * Coverage:
+ *   1. Five consecutive `recordWithin` calls in one tx → chain links
+ *      forward, each row's prevHash matches predecessor selfHash.
+ *   2. Batch's first row links to the global chain tail (the row
+ *      that was head BEFORE the batch).
+ *   3. Each row's selfHash recomputes from (prevHash, payload) so
+ *      tampering with any field downstream breaks verification.
+ */
+
+const HOST = process.env.PG_HOST ?? 'localhost';
+const PORT = process.env.PG_PORT ?? '5432';
+const DB = process.env.PG_DB ?? 'panorama';
+const ADMIN_URL = `postgres://panorama_super_admin:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+const APP_URL = `postgres://panorama_app:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+
+interface AuditRowSlim {
+  id: bigint;
+  action: string;
+  tenantId: string | null;
+  resourceType: string;
+  resourceId: string | null;
+  metadata: unknown;
+  occurredAt: Date;
+  prevHash: Buffer | null;
+  selfHash: Buffer;
+}
+
+describe('audit hash-chain integrity — batched recordWithin', () => {
+  let app: INestApplication;
+  let adminDb: PrismaClient;
+  let audit: AuditService;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    process.env.SESSION_SECRET = process.env.SESSION_SECRET ?? 'a'.repeat(32);
+    process.env.DATABASE_URL = APP_URL;
+
+    adminDb = new PrismaClient({ datasources: { db: { url: ADMIN_URL } } });
+    await resetTestDb(adminDb);
+
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleRef.createNestApplication({ logger: ['error', 'warn'] });
+    await app.init();
+    audit = app.get(AuditService);
+    prisma = app.get(PrismaService);
+  }, 120_000);
+
+  afterAll(async () => {
+    await adminDb?.$disconnect();
+    await app?.close();
+  }, 30_000);
+
+  it('chains hashes within a single batched tx + extends from prior tail', async () => {
+    // Capture the current chain tail BEFORE the batch so we can verify
+    // the first row of the batch links back to it (or is null when the
+    // table is empty — `resetTestDb` truncates audit_events between
+    // suites in the same run).
+    const priorTail = await adminDb.auditEvent.findFirst({
+      orderBy: { id: 'desc' },
+      select: { selfHash: true },
+    });
+    const priorTailHash: Buffer | null = priorTail?.selfHash ?? null;
+
+    // Mark batch rows with a unique tenantId so we can SELECT them
+    // back without matching unrelated audits emitted by the boot path.
+    const batchTenantId = '00000000-0000-4000-8000-000000000044';
+    const before = Date.now();
+
+    await prisma.runAsSuperAdmin(
+      async (tx) => {
+        for (let i = 0; i < 5; i++) {
+          await audit.recordWithin(tx, {
+            action: `panorama.audit_chain_test.row_${i}`,
+            resourceType: 'audit_chain_test',
+            resourceId: `row-${i}`,
+            tenantId: batchTenantId,
+            actorUserId: null,
+            metadata: { i },
+          });
+        }
+      },
+      { reason: 'audit_chain_test:batch' },
+    );
+
+    // Query the 5 batched rows back, ordered the way they were inserted.
+    const rows = (await adminDb.auditEvent.findMany({
+      where: { tenantId: batchTenantId },
+      orderBy: { id: 'asc' },
+      select: {
+        id: true,
+        action: true,
+        tenantId: true,
+        resourceType: true,
+        resourceId: true,
+        metadata: true,
+        occurredAt: true,
+        prevHash: true,
+        selfHash: true,
+      },
+    })) as unknown as AuditRowSlim[];
+
+    expect(rows).toHaveLength(5);
+
+    // The first row's prevHash must equal the chain tail captured
+    // BEFORE the batch (or null if the chain was empty).
+    if (priorTailHash === null) {
+      expect(rows[0]!.prevHash).toBeNull();
+    } else {
+      expect(rows[0]!.prevHash).not.toBeNull();
+      expect(Buffer.compare(rows[0]!.prevHash!, priorTailHash)).toBe(0);
+    }
+
+    // Each subsequent row's prevHash must match its predecessor's
+    // selfHash. This is the load-bearing assertion for the
+    // read-your-own-writes invariant — if Prisma ever changes
+    // tx-client snapshot semantics, this fails.
+    for (let i = 1; i < rows.length; i++) {
+      const prev = rows[i - 1]!;
+      const cur = rows[i]!;
+      expect(cur.prevHash).not.toBeNull();
+      expect(Buffer.compare(cur.prevHash!, prev.selfHash)).toBe(0);
+    }
+
+    // selfHash recomputability: each row's selfHash must equal
+    // sha256(prevHash || canonical_payload). If a downstream tool
+    // tampers with any field — action, resourceId, tenantId, metadata,
+    // occurredAt — the recomputed hash diverges and verification
+    // tooling (when it ships) will catch it.
+    for (const row of rows) {
+      const payload = {
+        action: row.action,
+        resourceType: row.resourceType,
+        resourceId: row.resourceId,
+        tenantId: row.tenantId,
+        actorUserId: null as string | null,
+        metadata: row.metadata ?? null,
+        occurredAt: row.occurredAt.toISOString(),
+      };
+      const h = createHash('sha256');
+      if (row.prevHash) h.update(row.prevHash);
+      h.update(JSON.stringify(payload));
+      const expected = h.digest();
+      expect(Buffer.compare(row.selfHash, expected)).toBe(0);
+    }
+
+    // Sanity: occurredAt is within the test window.
+    const after = Date.now();
+    for (const row of rows) {
+      expect(row.occurredAt.getTime()).toBeGreaterThanOrEqual(before - 1_000);
+      expect(row.occurredAt.getTime()).toBeLessThanOrEqual(after + 1_000);
+    }
+  }, 30_000);
+
+  it('a second batch in the same suite continues the chain', async () => {
+    // Locks the regression: if the batch boundary somehow reset the
+    // chain pointer (e.g., a future change introducing a per-tx
+    // sequence start), the second batch's first row would link to
+    // null instead of the prior batch's tail.
+    const batchTenantId = '00000000-0000-4000-8000-000000000045';
+
+    await prisma.runAsSuperAdmin(
+      async (tx) => {
+        for (let i = 0; i < 3; i++) {
+          await audit.recordWithin(tx, {
+            action: `panorama.audit_chain_test.batch2_${i}`,
+            resourceType: 'audit_chain_test',
+            resourceId: `b2-row-${i}`,
+            tenantId: batchTenantId,
+            actorUserId: null,
+            metadata: { i },
+          });
+        }
+      },
+      { reason: 'audit_chain_test:batch2' },
+    );
+
+    const rows = (await adminDb.auditEvent.findMany({
+      where: { tenantId: batchTenantId },
+      orderBy: { id: 'asc' },
+      select: { prevHash: true, selfHash: true },
+    })) as unknown as Array<{ prevHash: Buffer | null; selfHash: Buffer }>;
+
+    expect(rows).toHaveLength(3);
+    // First row of batch 2 links to *some* prior tail (cannot be null
+    // — the previous test's batch already extended the chain).
+    expect(rows[0]!.prevHash).not.toBeNull();
+    // Internal links remain coherent.
+    for (let i = 1; i < rows.length; i++) {
+      expect(Buffer.compare(rows[i]!.prevHash!, rows[i - 1]!.selfHash)).toBe(0);
+    }
+  }, 30_000);
+});

--- a/apps/core-api/test/maintenance-ticket-subscriber.test.ts
+++ b/apps/core-api/test/maintenance-ticket-subscriber.test.ts
@@ -8,6 +8,7 @@ import type {
   MaintenanceService,
 } from '../src/modules/maintenance/maintenance.service.js';
 import type { PrismaService } from '../src/modules/prisma/prisma.service.js';
+import type { AuditEventInput, AuditService } from '../src/modules/audit/audit.service.js';
 
 /**
  * Unit coverage for the ADR-0016 §5 auto-suggest subscriber.
@@ -69,6 +70,28 @@ function makeMaintenance(fix: MaintenanceFixture): MaintenanceService & {
   );
 }
 
+interface AuditFixture {
+  /** Set to true to make `audit.record` reject on call (covers the
+   *  `auto_suggest_audit_failed` log path). */
+  failOnRecord?: boolean;
+}
+
+function makeAudit(fix: AuditFixture = {}): AuditService & {
+  records: AuditEventInput[];
+} {
+  const records: AuditEventInput[] = [];
+  const record = vi.fn(async (event: AuditEventInput) => {
+    records.push(event);
+    if (fix.failOnRecord) {
+      throw new Error('audit_db_unreachable');
+    }
+  });
+  return Object.assign(
+    { record } as unknown as AuditService,
+    { records },
+  );
+}
+
 function makeEvent(
   overrides: Partial<NotificationEvent> & { eventType: string; payload: object },
 ): NotificationEvent {
@@ -125,15 +148,17 @@ const OPENED_RESULT: AutoOpenResult = { status: 'opened', ticketId: 'tkt-001' };
 
 let prismaFixture: PrismaFixture;
 let maintenance: ReturnType<typeof makeMaintenance>;
+let audit: ReturnType<typeof makeAudit>;
 let subscriber: MaintenanceTicketSubscriber;
 
 beforeEach(() => {
   prismaFixture = FIXTURE_FLAG_ON;
   maintenance = makeMaintenance({ result: OPENED_RESULT });
+  audit = makeAudit();
 });
 
 function build(): MaintenanceTicketSubscriber {
-  return new MaintenanceTicketSubscriber(makePrisma(prismaFixture), maintenance);
+  return new MaintenanceTicketSubscriber(makePrisma(prismaFixture), maintenance, audit);
 }
 
 describe('MaintenanceTicketSubscriber — supports()', () => {
@@ -354,5 +379,140 @@ describe('MaintenanceTicketSubscriber — defensive guards', () => {
     // marks the event dispatched, which is the desired retry-idempotent
     // contract.
     expect(maintenance.calls).toHaveLength(1);
+  });
+});
+
+describe('MaintenanceTicketSubscriber — audit on throw + skip', () => {
+  // ADR-0016 §5 v3 / security-reviewer pass-1 soft (#139): every
+  // throw path emits an immediate audit row before re-raising, so
+  // ops gets a forensic trail without waiting for the dispatcher's
+  // MAX_ATTEMPTS=5 DEAD-letter (~31 min backoff). The flag-off
+  // skip is similarly audited so a flag-flip backfill can recover
+  // the dropped events.
+
+  it('audits + re-throws on missing_tenant_id', async () => {
+    subscriber = build();
+    await expect(
+      subscriber.handle(
+        makeEvent({
+          tenantId: null,
+          eventType: 'panorama.inspection.completed',
+          payload: FAIL_INSPECTION_PAYLOAD,
+        }),
+      ),
+    ).rejects.toThrow(/missing_tenant_id/);
+    expect(audit.records).toHaveLength(1);
+    const row = audit.records[0]!;
+    expect(row.action).toBe('panorama.maintenance.auto_suggest_failed');
+    expect(row.tenantId).toBeNull();
+    expect(row.metadata).toMatchObject({ reason: 'missing_tenant_id' });
+  });
+
+  it('audits + re-throws on asset_not_found, with assetId resourceId', async () => {
+    prismaFixture = { ...FIXTURE_FLAG_ON, asset: null };
+    subscriber = build();
+    await expect(
+      subscriber.handle(
+        makeEvent({
+          eventType: 'panorama.reservation.checked_in_with_damage',
+          payload: DAMAGE_CHECKIN_PAYLOAD,
+        }),
+      ),
+    ).rejects.toThrow(/asset_not_found/);
+    expect(audit.records).toHaveLength(1);
+    const row = audit.records[0]!;
+    expect(row.action).toBe('panorama.maintenance.auto_suggest_failed');
+    expect(row.resourceType).toBe('asset');
+    expect(row.resourceId).toBe(ASSET_ID);
+    expect(row.tenantId).toBe(TENANT_A);
+    expect(row.metadata).toMatchObject({ reason: 'asset_not_found' });
+  });
+
+  it('audits + re-throws on asset_cross_tenant', async () => {
+    prismaFixture = {
+      ...FIXTURE_FLAG_ON,
+      asset: { tag: 'V-100', tenantId: TENANT_B },
+    };
+    subscriber = build();
+    await expect(
+      subscriber.handle(
+        makeEvent({
+          eventType: 'panorama.inspection.completed',
+          payload: FAIL_INSPECTION_PAYLOAD,
+        }),
+      ),
+    ).rejects.toThrow(/asset_cross_tenant/);
+    expect(audit.records).toHaveLength(1);
+    expect(audit.records[0]!.metadata).toMatchObject({
+      reason: 'asset_cross_tenant',
+    });
+  });
+
+  it('audits the flag-off skip path so a flag-flip backfill is recoverable', async () => {
+    prismaFixture = FIXTURE_FLAG_OFF;
+    subscriber = build();
+    await subscriber.handle(
+      makeEvent({
+        eventType: 'panorama.inspection.completed',
+        payload: FAIL_INSPECTION_PAYLOAD,
+      }),
+    );
+    expect(maintenance.calls).toEqual([]);
+    expect(audit.records).toHaveLength(1);
+    const row = audit.records[0]!;
+    expect(row.action).toBe('panorama.maintenance.auto_suggest_skipped');
+    expect(row.metadata).toMatchObject({
+      reason: 'flag_off',
+      assetId: ASSET_ID,
+      eventType: 'panorama.inspection.completed',
+    });
+  });
+
+  it('does NOT audit the happy path or PASS-outcome short-circuit', async () => {
+    subscriber = build();
+    await subscriber.handle(
+      makeEvent({
+        eventType: 'panorama.inspection.completed',
+        payload: FAIL_INSPECTION_PAYLOAD,
+      }),
+    );
+    // Happy path → openTicketAuto fired, no failure audit, no flag-off
+    // audit. (The `panorama.maintenance.opened` audit fires inside
+    // openTicketAuto itself, exercised by the maintenance.e2e suite.)
+    expect(audit.records).toEqual([]);
+  });
+
+  it('does NOT audit on PASS outcome (PASS short-circuit is healthy)', async () => {
+    subscriber = build();
+    await subscriber.handle(
+      makeEvent({
+        eventType: 'panorama.inspection.completed',
+        payload: { ...FAIL_INSPECTION_PAYLOAD, outcome: 'PASS' },
+      }),
+    );
+    expect(audit.records).toEqual([]);
+  });
+
+  it('does NOT mask the original error if the audit itself throws', async () => {
+    audit = makeAudit({ failOnRecord: true });
+    // Asset-cross-tenant throw + audit-record throw → the original
+    // `asset_cross_tenant` must surface to the dispatcher (the
+    // dispatcher's eventual DEAD-letter is the backstop).
+    prismaFixture = {
+      ...FIXTURE_FLAG_ON,
+      asset: { tag: 'V-100', tenantId: TENANT_B },
+    };
+    subscriber = build();
+    await expect(
+      subscriber.handle(
+        makeEvent({
+          eventType: 'panorama.inspection.completed',
+          payload: FAIL_INSPECTION_PAYLOAD,
+        }),
+      ),
+    ).rejects.toThrow(/asset_cross_tenant/);
+    // audit.record was attempted (and threw) — the throw didn't
+    // bubble up to mask the asset_cross_tenant.
+    expect(audit.records).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Bundle of the three soft items from session-4 reviews on #139 / #140
(MaintenanceTicketSubscriber + MaintenanceSweepService).

## (1) MaintenanceTicketSubscriber audit-on-throw

Every throw path in `handle()` now emits an immediate
`panorama.maintenance.auto_suggest_failed` audit row before re-raising:
`missing_tenant_id`, `asset_not_found`, `asset_cross_tenant`, and
the defence-in-depth `unsupported_event_type:*`. The dispatcher's
retry/DEAD-letter (MAX_ATTEMPTS=5, ~31 min backoff) remains
authoritative — this audit just gives ops an immediate trail
without waiting for it.

The `auto_suggest_skipped_flag_off` log-only path also gains an
audit row (`panorama.maintenance.auto_suggest_skipped`,
`reason: 'flag_off'`). When a tenant flips
`autoOpenMaintenanceFromInspection` from false → true, ops can
walk the audit log to decide whether to replay the dropped events
or accept the gap.

If the audit itself throws, the original error is NOT masked:
`recordFailureAudit` swallows the audit-side error + logs at
`auto_suggest_audit_failed`; the original cause re-raises.

7 new unit tests + the existing 15 all pass.

## (2) MaintenanceSweepService dedup-release warn promotion

- `del returns 0` → new `pm_due_dedup_release_returned_zero` warn
  (was silent — security-reviewer pass-1 soft on #140).
- `del throws` → `pm_due_dedup_release_failed` promoted from
  debug → warn so the alerting pipeline picks up Redis partitions
  during release.

## (3) Chain-integrity test for batched recordWithin

New `audit-chain-integrity.e2e.test.ts` (tech-lead pass-2 soft on
#140). Locks the load-bearing invariant: `audit.recordWithin(tx, …)`
reads the chain head from the same tx-local snapshot, so 5
consecutive calls in one super-admin tx produce a coherent chain
(`row[k+1].prevHash == row[k].selfHash`). Selfhash recomputability
asserts the tampering-detection contract on action / resourceId /
tenantId / metadata / occurredAt.

Catches a future Prisma upgrade changing tx-client
read-your-own-writes semantics.

## Test plan

- [x] `pnpm --filter @panorama/core-api test` — **379/379** (was
      370; +9 net)
- [x] `pnpm --filter @panorama/web typecheck` — clean
- [x] `pnpm i18n:check` — parity green
- [x] `pnpm i18n:jsx-gate` — clean
- [x] `pnpm rls:allowlist-check` — 29/12 unchanged (audit calls
      live in AuditService, already counted)