### PR TITLE
feat(auth): CSRF Origin/Referer validation middleware (#34 SEC-02)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,20 @@ SESSION_SECRET=replace-me-with-32-random-bytes-base64url
 SESSION_COOKIE_NAME=panorama_session
 
 # ===========================================================================
+# CSRF Origin allowlist (SEC-02 / #34)
+# ===========================================================================
+# Comma-separated list of trusted scheme://host origins. State-changing
+# requests (POST/PUT/PATCH/DELETE) with an `Origin` header must match one
+# of these or the auth `APP_BASE_URL`. Server-to-server fetches that omit
+# `Origin` are allowed (they cannot impersonate users without the HttpOnly
+# session cookie).
+#
+# Examples:
+#   single deployment behind a proxy: WEB_ORIGIN=https://panorama.example.com
+#   web on a different host:          WEB_ORIGIN=https://panorama.example.com,https://staging.example.com
+WEB_ORIGIN=http://localhost:3000
+
+# ===========================================================================
 # OIDC providers (optional; password auth still works without these)
 # ===========================================================================
 OIDC_GOOGLE_CLIENT_ID=

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,8 +33,15 @@ Panorama ships with sane defaults (see `apps/core-api/src/config/security.ts`):
 
 - Secure/HttpOnly/SameSite=Lax session cookies, with `Secure` enforced when the
   deployment has `NODE_ENV=production`
-- CSRF tokens rotated per session, with double-submit support for APIs
-  _(NOTE: audit-flagged as not yet implemented — see issue [#34](https://github.com/VitorMRodovalho/panorama/issues/34))_
+- CSRF defense — layered:
+  - `SameSite=Lax` session cookies block the dominant cross-site form-POST vector
+  - `CsrfOriginMiddleware` validates `Origin` (or `Referer` fallback) against a
+    trusted-origin allowlist on every state-changing request (POST/PUT/PATCH/
+    DELETE). Configure via `WEB_ORIGIN` (comma-separated). Server-to-server
+    fetches that omit both headers are allowed and rely on the `HttpOnly`
+    cookie chain. _Tracked in [#34](https://github.com/VitorMRodovalho/panorama/issues/34) — full double-submit cookie + per-session CSRF token is a
+    future M effort if the threat model grows beyond what SameSite + Origin
+    cover._
 - HSTS + CSP + X-Content-Type-Options + Referrer-Policy set via middleware
 - Argon2id password hashing (with bcrypt fallback for Snipe-IT migrations)
 - OIDC logins refused unless the IdP asserts `email_verified=true`.
@@ -81,8 +88,12 @@ Primary threats we defend against:
    see company B's vehicles. Enforced at the query layer via Prisma middleware
    AND at the Postgres layer via row-level security (RLS) policies that read a
    per-transaction GUC. See [`docs/adr/0003-multi-tenancy.md`](./docs/adr/0003-multi-tenancy.md).
-2. **CSRF on state changes** — session cookies are SameSite=Lax and every POST
-   requires a token.
+2. **CSRF on state changes** — `SameSite=Lax` session cookies + `CsrfOriginMiddleware`
+   validating `Origin`/`Referer` against the configured trusted-origin allowlist
+   on every state-changing request. Server-to-server fetches (no Origin) are
+   allowed because they cannot impersonate a user without the `HttpOnly`
+   session cookie. See `apps/core-api/src/modules/auth/csrf-origin.middleware.ts`
+   and #34.
 3. **SSRF on proxy endpoints** — any outbound fetch whose target is derived
    from user input goes through an allowlist + redirect-disabled fetcher.
    The object-storage `S3_ENDPOINT` is DNS-resolved at boot and rejected if

--- a/apps/core-api/.env.example
+++ b/apps/core-api/.env.example
@@ -48,6 +48,14 @@ FEATURE_MAINTENANCE=false
 SESSION_SECRET=replace-me-with-32-random-bytes-in-base64url
 SESSION_COOKIE_NAME=panorama_session
 
+# --- CSRF Origin allowlist (SEC-02 / #34) ---
+# Comma-separated list of trusted scheme://host origins. State-changing
+# requests (POST/PUT/PATCH/DELETE) with an `Origin` header must match
+# one of these or the auth `APP_BASE_URL`. Server-to-server fetches that
+# omit `Origin` are allowed (they cannot impersonate users without the
+# HttpOnly session cookie). Add the web app's origin in dev:
+WEB_ORIGIN=http://localhost:3000
+
 # --- OIDC / OAuth2 providers (optional at dev time) ---
 OIDC_GOOGLE_CLIENT_ID=
 OIDC_GOOGLE_CLIENT_SECRET=

--- a/apps/core-api/src/modules/auth/auth.config.ts
+++ b/apps/core-api/src/modules/auth/auth.config.ts
@@ -40,6 +40,16 @@ export interface AuthConfig {
     google?: OidcProviderConfig;
     microsoft?: OidcProviderConfig;
   };
+  /**
+   * Trusted scheme://host origins for the CSRF Origin/Referer gate
+   * (SEC-02 / #34). Lowercased and deduplicated. Always includes
+   * `baseUrl` so a single-origin deploy works with no extra config;
+   * `WEB_ORIGIN` adds split-origin entries (e.g. when web and api
+   * live on different hosts).
+   */
+  csrf: {
+    trustedOrigins: ReadonlySet<string>;
+  };
 }
 
 @Injectable()
@@ -92,15 +102,24 @@ export class AuthConfigService {
       };
     }
 
+    const baseUrl = (process.env.APP_BASE_URL ?? 'http://localhost:4000')
+      .replace(/\/+$/, '')
+      .toLowerCase();
+    const csrfOrigins = new Set<string>([baseUrl]);
+    for (const o of parseOriginList(process.env.WEB_ORIGIN)) {
+      csrfOrigins.add(o);
+    }
+
     this.config = {
       sessionSecret,
       sessionCookieName: process.env.SESSION_COOKIE_NAME ?? 'panorama_session',
       oauthStateCookieName: process.env.OAUTH_STATE_COOKIE_NAME ?? 'panorama_oauth',
       sessionMaxAgeSeconds: Number(process.env.SESSION_MAX_AGE_SECONDS ?? 60 * 60 * 24 * 7), // 7d
       oauthStateMaxAgeSeconds: 5 * 60, // 5 min
-      baseUrl: (process.env.APP_BASE_URL ?? 'http://localhost:4000').replace(/\/+$/, ''),
+      baseUrl,
       isProduction,
       providers,
+      csrf: { trustedOrigins: csrfOrigins },
     };
   }
 
@@ -118,4 +137,17 @@ function parseDomainList(raw: string | undefined): string[] {
     .split(',')
     .map((d) => d.trim().toLowerCase())
     .filter((d) => d.length > 0);
+}
+
+/**
+ * Parse `WEB_ORIGIN` (comma-separated scheme://host list). Lowercased,
+ * trailing-slash-stripped, deduplicated. Mirrors `parseDomainList`'s
+ * shape so the codebase stays consistent on env-list parsing.
+ */
+function parseOriginList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase().replace(/\/+$/, ''))
+    .filter((s) => s.length > 0);
 }

--- a/apps/core-api/src/modules/auth/auth.module.ts
+++ b/apps/core-api/src/modules/auth/auth.module.ts
@@ -2,6 +2,7 @@ import { MiddlewareConsumer, Module, RequestMethod, type NestModule } from '@nes
 import { AuthConfigService } from './auth.config.js';
 import { AuthController } from './auth.controller.js';
 import { AuthService } from './auth.service.js';
+import { CsrfOriginMiddleware } from './csrf-origin.middleware.js';
 import { DiscoveryService } from './discovery.service.js';
 import { OidcService } from './oidc.service.js';
 import { PasswordService } from './password.service.js';
@@ -36,6 +37,7 @@ import { RedisModule } from '../redis/redis.module.js';
   providers: [
     AuthConfigService,
     AuthService,
+    CsrfOriginMiddleware,
     DiscoveryService,
     OidcService,
     PasswordService,
@@ -55,6 +57,13 @@ import { RedisModule } from '../redis/redis.module.js';
 })
 export class AuthModule implements NestModule {
   configure(consumer: MiddlewareConsumer): void {
+    // CSRF Origin/Referer gate runs FIRST: a cross-origin POST gets
+    // rejected before we touch the session, the DB, or anything else.
+    // SEC-02 / #34 — pairs with the SameSite=Lax cookie set in
+    // session.service.ts. Documented in SECURITY.md §Hardening.
+    consumer
+      .apply(CsrfOriginMiddleware)
+      .forRoutes({ path: '*', method: RequestMethod.ALL });
     // Every request runs through the session middleware so downstream
     // code never sees a request without a resolved tenant context.
     // `{ path: '*', method: RequestMethod.ALL }` is the ESM-safe form —

--- a/apps/core-api/src/modules/auth/csrf-origin.middleware.ts
+++ b/apps/core-api/src/modules/auth/csrf-origin.middleware.ts
@@ -24,21 +24,34 @@ import { AuthConfigService } from './auth.config.js';
  *
  *   * GET / HEAD / OPTIONS — always allowed. State-changing methods
  *     (POST / PUT / PATCH / DELETE) go through the check.
- *   * If `Origin` header is present, it MUST match the configured
- *     `WEB_ORIGIN` (comma-separated allowlist, defaulting to the
- *     auth base URL). Mismatch → 403 + warn audit log.
+ *   * If `Origin` is present, it MUST match the configured trusted
+ *     origin set (auth `baseUrl` + comma-separated `WEB_ORIGIN`).
+ *     Mismatch → 403 + warn log.
  *   * If `Origin` is absent BUT `Referer` is present, the
  *     scheme://host of `Referer` MUST be in the allowlist.
  *   * If both are absent — typical for server-to-server fetches that
- *     this codebase performs (Next.js server actions → core-api),
- *     allow but log at debug. Server-side calls cannot impersonate a
- *     user without the HttpOnly session cookie, so the SameSite +
- *     auth chain still applies.
+ *     this codebase performs (Next.js server actions → core-api) —
+ *     allow but log at debug. SameSite=Lax stops the session cookie
+ *     from riding along on a cross-site browser fetch, so the blast
+ *     radius for "no headers AND somehow has the cookie" is bounded
+ *     by an attacker who already has the user's HttpOnly cookie
+ *     (out-of-scope of CSRF defense).
+ *
+ *   * `Origin` shows up as a `string[]` only via misconfigured
+ *     ingress / proxies that concatenate duplicate headers. RFC 6454
+ *     mandates exactly one `Origin` per request, so we fail-closed
+ *     on duplicates rather than picking one and creating a bypass
+ *     for `[trusted, evil.com]`-style spoofs.
  *
  * SEC-02 / #34: documented as the doc-vs-code gap. Full double-submit
  * cookie + header pattern is a future M effort if the threat model
- * grows; this layer matches modern browser semantics and is the
- * pragmatic 80% under a single-session-cookie design.
+ * grows; this layer matches modern browser semantics (every Chromium /
+ * WebKit / Gecko release since 2021 sends `Origin` on cross-origin
+ * POST/PUT/DELETE) and is the pragmatic 80% under a single-session-
+ * cookie design.
+ *
+ * Trusted-origin set is built once at module init; rotation requires
+ * a redeploy (documented in SECURITY.md / .env.example).
  */
 @Injectable()
 export class CsrfOriginMiddleware implements NestMiddleware {
@@ -46,14 +59,7 @@ export class CsrfOriginMiddleware implements NestMiddleware {
   private readonly trustedOrigins: ReadonlySet<string>;
 
   constructor(cfg: AuthConfigService) {
-    const fromEnv = (process.env.WEB_ORIGIN ?? '')
-      .split(',')
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0)
-      .map((s) => s.replace(/\/+$/, ''));
-    const fromBase = cfg.config.baseUrl.replace(/\/+$/, '');
-    const all = new Set<string>([fromBase, ...fromEnv]);
-    this.trustedOrigins = all;
+    this.trustedOrigins = cfg.config.csrf.trustedOrigins;
   }
 
   use(req: Request, _res: Response, next: NextFunction): void {
@@ -62,16 +68,27 @@ export class CsrfOriginMiddleware implements NestMiddleware {
       return next();
     }
 
-    const origin = headerValue(req.headers['origin']);
-    const referer = headerValue(req.headers['referer']);
+    const origin = singleHeaderValue(req.headers['origin']);
+    const referer = singleHeaderValue(req.headers['referer']);
+
+    if (origin === DUPLICATE || referer === DUPLICATE) {
+      // RFC 6454 mandates exactly one Origin per request. Duplicate
+      // Origin / Referer headers signal an ingress that concatenates
+      // —  picking `[0]` permissively would create a `[trusted, evil]`
+      // spoof bypass. Fail-closed instead.
+      this.log.warn(
+        {
+          method,
+          path: req.path,
+          rawOrigin: req.headers['origin'],
+          rawReferer: req.headers['referer'],
+        },
+        'csrf_header_duplicate',
+      );
+      throw new ForbiddenException('csrf_origin_mismatch');
+    }
 
     if (!origin && !referer) {
-      // Server-to-server fetches (e.g. apps/web's server actions
-      // forwarding a user request to core-api) typically omit both.
-      // SameSite=Lax + the encrypted session cookie still gate the
-      // user-impersonation path — the attacker would need the
-      // HttpOnly cookie to forge a server-side call, which they can't
-      // get cross-origin.
       this.log.debug(
         { method, path: req.path },
         'csrf_no_origin_or_referer',
@@ -79,7 +96,8 @@ export class CsrfOriginMiddleware implements NestMiddleware {
       return next();
     }
 
-    const candidate = origin ?? deriveOriginFromReferer(referer);
+    const candidate =
+      (origin ?? deriveOriginFromReferer(referer))?.toLowerCase() ?? null;
     if (candidate === null) {
       // Malformed Referer with no Origin; Cisco-style proxies
       // sometimes mangle it. Refuse rather than fail-open.
@@ -108,9 +126,16 @@ export class CsrfOriginMiddleware implements NestMiddleware {
   }
 }
 
-function headerValue(raw: string | string[] | undefined): string | null {
+const DUPLICATE = Symbol('duplicate');
+type HeaderResult = string | null | typeof DUPLICATE;
+
+function singleHeaderValue(raw: string | string[] | undefined): HeaderResult {
   if (raw === undefined) return null;
-  if (Array.isArray(raw)) return raw[0] ?? null;
+  if (Array.isArray(raw)) {
+    if (raw.length === 0) return null;
+    if (raw.length > 1) return DUPLICATE;
+    return raw[0] ?? null;
+  }
   return raw;
 }
 

--- a/apps/core-api/src/modules/auth/csrf-origin.middleware.ts
+++ b/apps/core-api/src/modules/auth/csrf-origin.middleware.ts
@@ -1,0 +1,125 @@
+import {
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NestMiddleware,
+} from '@nestjs/common';
+import type { NextFunction, Request, Response } from 'express';
+import { AuthConfigService } from './auth.config.js';
+
+/**
+ * Defense-in-depth CSRF gate via `Origin` / `Referer` header validation.
+ * Layered with `SameSite=Lax` cookies (set in session.service.ts) and
+ * the existing helmet defaults.
+ *
+ * `SameSite=Lax` already blocks the dominant CSRF vector (cross-site
+ * form POST without top-level navigation); this middleware closes the
+ * residual gaps:
+ *
+ *   * Browsers with partial / legacy SameSite support
+ *   * Same-site cross-origin (subdomain attacks)
+ *   * Top-level navigations whose target is a state-changing endpoint
+ *
+ * Rules:
+ *
+ *   * GET / HEAD / OPTIONS — always allowed. State-changing methods
+ *     (POST / PUT / PATCH / DELETE) go through the check.
+ *   * If `Origin` header is present, it MUST match the configured
+ *     `WEB_ORIGIN` (comma-separated allowlist, defaulting to the
+ *     auth base URL). Mismatch → 403 + warn audit log.
+ *   * If `Origin` is absent BUT `Referer` is present, the
+ *     scheme://host of `Referer` MUST be in the allowlist.
+ *   * If both are absent — typical for server-to-server fetches that
+ *     this codebase performs (Next.js server actions → core-api),
+ *     allow but log at debug. Server-side calls cannot impersonate a
+ *     user without the HttpOnly session cookie, so the SameSite +
+ *     auth chain still applies.
+ *
+ * SEC-02 / #34: documented as the doc-vs-code gap. Full double-submit
+ * cookie + header pattern is a future M effort if the threat model
+ * grows; this layer matches modern browser semantics and is the
+ * pragmatic 80% under a single-session-cookie design.
+ */
+@Injectable()
+export class CsrfOriginMiddleware implements NestMiddleware {
+  private readonly log = new Logger('CsrfOriginMiddleware');
+  private readonly trustedOrigins: ReadonlySet<string>;
+
+  constructor(cfg: AuthConfigService) {
+    const fromEnv = (process.env.WEB_ORIGIN ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+      .map((s) => s.replace(/\/+$/, ''));
+    const fromBase = cfg.config.baseUrl.replace(/\/+$/, '');
+    const all = new Set<string>([fromBase, ...fromEnv]);
+    this.trustedOrigins = all;
+  }
+
+  use(req: Request, _res: Response, next: NextFunction): void {
+    const method = req.method.toUpperCase();
+    if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
+      return next();
+    }
+
+    const origin = headerValue(req.headers['origin']);
+    const referer = headerValue(req.headers['referer']);
+
+    if (!origin && !referer) {
+      // Server-to-server fetches (e.g. apps/web's server actions
+      // forwarding a user request to core-api) typically omit both.
+      // SameSite=Lax + the encrypted session cookie still gate the
+      // user-impersonation path — the attacker would need the
+      // HttpOnly cookie to forge a server-side call, which they can't
+      // get cross-origin.
+      this.log.debug(
+        { method, path: req.path },
+        'csrf_no_origin_or_referer',
+      );
+      return next();
+    }
+
+    const candidate = origin ?? deriveOriginFromReferer(referer);
+    if (candidate === null) {
+      // Malformed Referer with no Origin; Cisco-style proxies
+      // sometimes mangle it. Refuse rather than fail-open.
+      this.log.warn(
+        { method, path: req.path, referer },
+        'csrf_referer_unparseable',
+      );
+      throw new ForbiddenException('csrf_origin_mismatch');
+    }
+    if (!this.trustedOrigins.has(candidate)) {
+      this.log.warn(
+        {
+          method,
+          path: req.path,
+          origin,
+          referer,
+          candidate,
+          trustedCount: this.trustedOrigins.size,
+        },
+        'csrf_origin_mismatch',
+      );
+      throw new ForbiddenException('csrf_origin_mismatch');
+    }
+
+    next();
+  }
+}
+
+function headerValue(raw: string | string[] | undefined): string | null {
+  if (raw === undefined) return null;
+  if (Array.isArray(raw)) return raw[0] ?? null;
+  return raw;
+}
+
+function deriveOriginFromReferer(referer: string | null): string | null {
+  if (!referer) return null;
+  try {
+    const u = new URL(referer);
+    return `${u.protocol}//${u.host}`;
+  } catch {
+    return null;
+  }
+}

--- a/apps/core-api/test/csrf-origin.middleware.test.ts
+++ b/apps/core-api/test/csrf-origin.middleware.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { ForbiddenException } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { CsrfOriginMiddleware } from '../src/modules/auth/csrf-origin.middleware.js';
@@ -38,14 +38,20 @@ function makeReq(opts: {
 
 const noopRes = {} as Response;
 
-function makeMiddleware(envWebOrigin?: string): CsrfOriginMiddleware {
-  if (envWebOrigin === undefined) {
-    delete process.env.WEB_ORIGIN;
-  } else {
-    process.env.WEB_ORIGIN = envWebOrigin;
-  }
+/**
+ * Build a typed AuthConfigService stub. The middleware now consumes
+ * the parsed-and-deduped origin set from `cfg.config.csrf.trustedOrigins`
+ * (the env-parsing lives in auth.config.ts), so the test fixture
+ * mirrors that shape directly. Each entry should be lowercase +
+ * trailing-slash-stripped to match the real parser.
+ */
+function makeMiddleware(extraOrigins: string[] = []): CsrfOriginMiddleware {
+  const trustedOrigins = new Set<string>([
+    BASE_URL,
+    ...extraOrigins.map((o) => o.replace(/\/+$/, '').toLowerCase()),
+  ]);
   const cfg = {
-    config: { baseUrl: BASE_URL },
+    config: { baseUrl: BASE_URL, csrf: { trustedOrigins } },
   } as unknown as AuthConfigService;
   return new CsrfOriginMiddleware(cfg);
 }
@@ -65,7 +71,7 @@ describe('CsrfOriginMiddleware — origin allowlist', () => {
   let mw: CsrfOriginMiddleware;
 
   beforeEach(() => {
-    mw = makeMiddleware('http://localhost:3000');
+    mw = makeMiddleware(['http://localhost:3000']);
   });
 
   it('allows when both Origin and Referer are absent (server-to-server)', () => {
@@ -173,10 +179,12 @@ describe('CsrfOriginMiddleware — origin allowlist', () => {
 });
 
 describe('CsrfOriginMiddleware — multi-origin allowlist', () => {
-  it('parses comma-separated WEB_ORIGIN entries and trims whitespace', () => {
-    const mw = makeMiddleware(
-      ' http://localhost:3000 , https://staging.example.com , https://prod.example.com ',
-    );
+  it('accepts every entry from a multi-origin trusted set', () => {
+    const mw = makeMiddleware([
+      'http://localhost:3000',
+      'https://staging.example.com',
+      'https://prod.example.com',
+    ]);
     for (const allowed of [
       'http://localhost:3000',
       'https://staging.example.com',
@@ -195,11 +203,11 @@ describe('CsrfOriginMiddleware — multi-origin allowlist', () => {
     }
   });
 
-  it('strips trailing slashes when matching against WEB_ORIGIN entries', () => {
-    const mw = makeMiddleware('https://prod.example.com/');
+  it('matches case-insensitively (browsers normalise lowercase, but be paranoid)', () => {
+    const mw = makeMiddleware(['https://Prod.Example.Com']);
     let nextCalled = false;
     mw.use(
-      makeReq({ method: 'POST', origin: 'https://prod.example.com' }),
+      makeReq({ method: 'POST', origin: 'HTTPS://prod.example.com' }),
       noopRes,
       () => {
         nextCalled = true;
@@ -208,12 +216,29 @@ describe('CsrfOriginMiddleware — multi-origin allowlist', () => {
     expect(nextCalled).toBe(true);
   });
 
-  it('handles header arrays (some proxies duplicate headers)', () => {
-    const mw = makeMiddleware('http://localhost:3000');
+  it('rejects fail-closed when Origin shows up as a duplicate header', () => {
+    // RFC 6454 mandates exactly one Origin per request. A proxy
+    // concatenating duplicates would create a `[trusted, evil.com]`
+    // bypass if we picked `[0]` permissively. Fail-closed instead.
+    const mw = makeMiddleware(['http://localhost:3000']);
     const req = {
       method: 'POST',
       path: '/auth/login',
       headers: { origin: ['http://localhost:3000', 'http://evil.com'] },
+    } as unknown as Request;
+    expect(() =>
+      mw.use(req, noopRes, () => {
+        throw new Error('should not be called');
+      }),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('treats an empty Origin array as absent (server-to-server allowed)', () => {
+    const mw = makeMiddleware(['http://localhost:3000']);
+    const req = {
+      method: 'POST',
+      path: '/auth/login',
+      headers: { origin: [] as string[] },
     } as unknown as Request;
     let nextCalled = false;
     mw.use(req, noopRes, () => {
@@ -221,8 +246,4 @@ describe('CsrfOriginMiddleware — multi-origin allowlist', () => {
     });
     expect(nextCalled).toBe(true);
   });
-});
-
-afterEach(() => {
-  delete process.env.WEB_ORIGIN;
 });

--- a/apps/core-api/test/csrf-origin.middleware.test.ts
+++ b/apps/core-api/test/csrf-origin.middleware.test.ts
@@ -1,0 +1,228 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ForbiddenException } from '@nestjs/common';
+import type { Request, Response } from 'express';
+import { CsrfOriginMiddleware } from '../src/modules/auth/csrf-origin.middleware.js';
+import type { AuthConfigService } from '../src/modules/auth/auth.config.js';
+
+/**
+ * SEC-02 / #34 layered CSRF gate. Verifies the Origin/Referer rules:
+ *   1. Safe methods (GET/HEAD/OPTIONS) skip the check entirely
+ *   2. POST/PUT/PATCH/DELETE with no Origin AND no Referer → allow
+ *      (server-to-server fetch path; SameSite + cookie auth still apply)
+ *   3. Origin matches a trusted entry → allow
+ *   4. Origin mismatches → 403
+ *   5. Origin absent + Referer scheme://host matches → allow
+ *   6. Origin absent + Referer scheme://host mismatches → 403
+ *   7. Malformed Referer (no Origin) → 403 (fail-closed)
+ *   8. Multi-origin allowlist via WEB_ORIGIN env var → all entries pass
+ */
+
+const BASE_URL = 'http://localhost:4000';
+
+function makeReq(opts: {
+  method?: string;
+  origin?: string | undefined;
+  referer?: string | undefined;
+  path?: string;
+}): Request {
+  const headers: Record<string, string | undefined> = {};
+  if (opts.origin !== undefined) headers['origin'] = opts.origin;
+  if (opts.referer !== undefined) headers['referer'] = opts.referer;
+  return {
+    method: opts.method ?? 'POST',
+    path: opts.path ?? '/auth/login',
+    headers,
+  } as unknown as Request;
+}
+
+const noopRes = {} as Response;
+
+function makeMiddleware(envWebOrigin?: string): CsrfOriginMiddleware {
+  if (envWebOrigin === undefined) {
+    delete process.env.WEB_ORIGIN;
+  } else {
+    process.env.WEB_ORIGIN = envWebOrigin;
+  }
+  const cfg = {
+    config: { baseUrl: BASE_URL },
+  } as unknown as AuthConfigService;
+  return new CsrfOriginMiddleware(cfg);
+}
+
+describe('CsrfOriginMiddleware — safe methods', () => {
+  it.each(['GET', 'HEAD', 'OPTIONS'])('skips %s', (method) => {
+    const mw = makeMiddleware();
+    let nextCalled = false;
+    mw.use(makeReq({ method, origin: 'http://evil.com' }), noopRes, () => {
+      nextCalled = true;
+    });
+    expect(nextCalled).toBe(true);
+  });
+});
+
+describe('CsrfOriginMiddleware — origin allowlist', () => {
+  let mw: CsrfOriginMiddleware;
+
+  beforeEach(() => {
+    mw = makeMiddleware('http://localhost:3000');
+  });
+
+  it('allows when both Origin and Referer are absent (server-to-server)', () => {
+    let nextCalled = false;
+    mw.use(makeReq({ method: 'POST' }), noopRes, () => {
+      nextCalled = true;
+    });
+    expect(nextCalled).toBe(true);
+  });
+
+  it('allows when Origin matches the WEB_ORIGIN entry', () => {
+    let nextCalled = false;
+    mw.use(
+      makeReq({ method: 'POST', origin: 'http://localhost:3000' }),
+      noopRes,
+      () => {
+        nextCalled = true;
+      },
+    );
+    expect(nextCalled).toBe(true);
+  });
+
+  it('allows when Origin matches the auth baseUrl entry', () => {
+    let nextCalled = false;
+    mw.use(makeReq({ method: 'POST', origin: BASE_URL }), noopRes, () => {
+      nextCalled = true;
+    });
+    expect(nextCalled).toBe(true);
+  });
+
+  it('rejects when Origin matches none of the trusted entries', () => {
+    expect(() =>
+      mw.use(
+        makeReq({ method: 'POST', origin: 'http://evil.com' }),
+        noopRes,
+        () => {
+          throw new Error('should not be called');
+        },
+      ),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('rejects when Origin is wrong even if Referer is right (Origin wins)', () => {
+    // Modern browsers always send Origin on POST; if Origin is wrong,
+    // we don't fall back to Referer to "rescue" a cross-origin request.
+    expect(() =>
+      mw.use(
+        makeReq({
+          method: 'POST',
+          origin: 'http://evil.com',
+          referer: 'http://localhost:3000/login',
+        }),
+        noopRes,
+        () => {
+          throw new Error('should not be called');
+        },
+      ),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('falls back to Referer when Origin is missing', () => {
+    let nextCalled = false;
+    mw.use(
+      makeReq({
+        method: 'POST',
+        referer: 'http://localhost:3000/some/path?q=1',
+      }),
+      noopRes,
+      () => {
+        nextCalled = true;
+      },
+    );
+    expect(nextCalled).toBe(true);
+  });
+
+  it('rejects when Referer is from a different origin', () => {
+    expect(() =>
+      mw.use(
+        makeReq({
+          method: 'POST',
+          referer: 'http://evil.com/login',
+        }),
+        noopRes,
+        () => {
+          throw new Error('should not be called');
+        },
+      ),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('rejects fail-closed when Referer is malformed and Origin is absent', () => {
+    expect(() =>
+      mw.use(
+        makeReq({
+          method: 'POST',
+          referer: 'not-a-url',
+        }),
+        noopRes,
+        () => {
+          throw new Error('should not be called');
+        },
+      ),
+    ).toThrow(ForbiddenException);
+  });
+});
+
+describe('CsrfOriginMiddleware — multi-origin allowlist', () => {
+  it('parses comma-separated WEB_ORIGIN entries and trims whitespace', () => {
+    const mw = makeMiddleware(
+      ' http://localhost:3000 , https://staging.example.com , https://prod.example.com ',
+    );
+    for (const allowed of [
+      'http://localhost:3000',
+      'https://staging.example.com',
+      'https://prod.example.com',
+      BASE_URL,
+    ]) {
+      let nextCalled = false;
+      mw.use(
+        makeReq({ method: 'POST', origin: allowed }),
+        noopRes,
+        () => {
+          nextCalled = true;
+        },
+      );
+      expect(nextCalled, `should allow ${allowed}`).toBe(true);
+    }
+  });
+
+  it('strips trailing slashes when matching against WEB_ORIGIN entries', () => {
+    const mw = makeMiddleware('https://prod.example.com/');
+    let nextCalled = false;
+    mw.use(
+      makeReq({ method: 'POST', origin: 'https://prod.example.com' }),
+      noopRes,
+      () => {
+        nextCalled = true;
+      },
+    );
+    expect(nextCalled).toBe(true);
+  });
+
+  it('handles header arrays (some proxies duplicate headers)', () => {
+    const mw = makeMiddleware('http://localhost:3000');
+    const req = {
+      method: 'POST',
+      path: '/auth/login',
+      headers: { origin: ['http://localhost:3000', 'http://evil.com'] },
+    } as unknown as Request;
+    let nextCalled = false;
+    mw.use(req, noopRes, () => {
+      nextCalled = true;
+    });
+    expect(nextCalled).toBe(true);
+  });
+});
+
+afterEach(() => {
+  delete process.env.WEB_ORIGIN;
+});


### PR DESCRIPTION
## Summary

Closes the doc-vs-code gap from SEC-02. SECURITY.md previously claimed
"CSRF tokens rotated per session, with double-submit support for APIs"
but the code relied solely on `SameSite=Lax`. This PR adds a layered
defense via `Origin`/`Referer` header validation, and updates
SECURITY.md to accurately describe what's now in place.

## What changed

- `CsrfOriginMiddleware` (new) registered FIRST in the auth-module
  chain. Validates the `Origin` (or `Referer` fallback) of every
  state-changing request (POST/PUT/PATCH/DELETE) against an
  allowlist. Mismatch → 403 + warn log.
- `AuthConfig.csrf.trustedOrigins` derived from `APP_BASE_URL` +
  `WEB_ORIGIN` (comma-separated). Same shape as
  `OIDC_GOOGLE_TRUSTED_HD_DOMAINS` for consistency. Case-insensitive
  + trailing-slash-tolerant.
- 15 unit tests (`csrf-origin.middleware.test.ts`).
- `SECURITY.md` and both `.env.example` files updated with the
  layered posture and `WEB_ORIGIN` config.

## Allow-when-no-headers branch

Both `Origin` and `Referer` absent → allow. This is the load-bearing
trust assumption: `apps/web`'s server actions forwarding to core-api
omit both. SameSite=Lax stops the session cookie from riding along
on cross-site browser fetches, so an attacker without the HttpOnly
cookie cannot exercise this branch.

## Reviews

Both `security-reviewer` and `tech-lead` reviewed pre-push.
APPROVE-WITH-NITS; convergent fixes folded into a follow-up commit:

- Lift `WEB_ORIGIN` parsing into `AuthConfigService` (tech-lead)
- Fail-closed on duplicate Origin/Referer headers (security-reviewer)
- Case-insensitive origin matching (security-reviewer)
- Comment refresh on the no-headers branch (security-reviewer)

Deferred to follow-ups (per the reviews):
- One e2e wiring AppModule + cross-origin POST → 403 (tech-lead nice-to-have)
- Full double-submit cookie + per-session CSRF token (#34 itself
  may be re-scoped after this lands; the doc-vs-code gap closed
  either way)

## Test plan

- [x] `pnpm --filter @panorama/core-api test` — **394/394** (was 379;
      +15 net from the new unit tests)
- [x] `pnpm rls:allowlist-check` — 29/12 unchanged
- [x] Typecheck clean (3 pre-existing CJS/ESM errors unaffected)
- [x] `pnpm i18n:check` + `i18n:jsx-gate` — green (untouched)
- [ ] e2e cross-origin POST → 403 — deferred per tech-lead review