### PR TITLE
chore(lint): real ESLint on migrator/shared/plugin-sdk/ui-kit (#39 ARCH-05)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,11 @@ Never force-push to `main` or `release/*`.
 pnpm test                 # all packages
 pnpm --filter @panorama/core-api test
 # pnpm e2e                # Playwright lands in 0.4+ — task removed pending first spec
-pnpm lint                 # ESLint + Prettier + markdownlint
-pnpm typecheck
+pnpm lint                 # ESLint (typescript-eslint recommendedTypeChecked) across
+                          # core-api, web (next lint), migrator, shared, plugin-sdk,
+                          # ui-kit. i18n bundles use pnpm i18n:check + i18n:jsx-gate.
+                          # No Prettier or markdownlint enforcement today.
+pnpm typecheck            # tsc --noEmit across the monorepo
 ```
 
 ## Reporting security issues

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "echo 'i18n — json bundles only, no build step'",
     "test": "echo 'i18n — coverage gate runs from root via scripts/i18n-check.ts'",
-    "lint": "echo 'i18n — no lint, bundles are json'",
+    "lint": "echo 'i18n — no lint (JSON bundles only); coverage + JSX gate run from root via pnpm i18n:check + i18n:jsx-gate. #39 ARCH-05.'",
     "typecheck": "echo 'i18n — no typecheck, bundles are json'"
   }
 }

--- a/packages/migrator/eslint.config.mjs
+++ b/packages/migrator/eslint.config.mjs
@@ -1,0 +1,47 @@
+// ESLint flat config for @panorama/migrator (#39 ARCH-05 follow-up).
+// Mirrors apps/core-api/eslint.config.mjs minus the Nest-specific
+// relaxations (no NestJS lifecycle hooks here). Type-aware rules run
+// over `src/` only — `test/` and `vitest.config.ts` aren't in this
+// package's tsconfig and would error on parser projectService discovery.
+
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: [
+      'dist/**',
+      'coverage/**',
+      'node_modules/**',
+      'test/**',
+      'vitest.config.ts',
+      'eslint.config.mjs',
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/await-thenable': 'error',
+      '@typescript-eslint/no-for-in-array': 'error',
+      // Permissive surface (off, not warn) — same baseline as core-api
+      // so one package's churn doesn't drag the rest. Ratchet later.
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/require-await': 'off',
+    },
+  },
+);

--- a/packages/migrator/package.json
+++ b/packages/migrator/package.json
@@ -17,7 +17,7 @@
     "dev": "tsx src/cli.ts",
     "cli": "tsx src/cli.ts",
     "test": "vitest run",
-    "lint": "echo 'nothing to lint yet'",
+    "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "clean": "rimraf dist"
   },

--- a/packages/migrator/src/commands/inventory.ts
+++ b/packages/migrator/src/commands/inventory.ts
@@ -76,9 +76,10 @@ export async function runInventory(opts: InventoryOptions): Promise<InventoryRep
   const users = await client.fetchAll<unknown>('users');
   const duplicateEmails = findDuplicateEmails(users);
 
-  const statusLabelsResp = (await client.get('statuslabels', { limit: 500 })) as {
-    rows?: Array<{ name?: string | null }>;
-  };
+  const statusLabelsResp = await client.get<{ rows?: { name?: string }[] }>(
+    'statuslabels',
+    { limit: 500 },
+  );
   const unknownStatusLabels = (statusLabelsResp.rows ?? [])
     .map((row) => row.name ?? '')
     .filter((name) => name && !KNOWN_STATUS_LABEL_NAMES.has(name));

--- a/packages/migrator/src/snipeit-client.ts
+++ b/packages/migrator/src/snipeit-client.ts
@@ -50,11 +50,18 @@ export class SnipeItClient {
     this.maxRetries = opts.maxRetries ?? 3;
   }
 
-  async get<T = unknown>(endpoint: string, params?: Record<string, unknown>): Promise<T> {
+  async get<T = unknown>(
+    endpoint: string,
+    params?: Record<string, string | number | boolean>,
+  ): Promise<T> {
+    // Narrowed from `unknown` so `String(v)` here is safe — non-primitive
+    // values would have stringified to "[object Object]" and produced a
+    // silent garbage URL. ESLint `no-base-to-string` would catch the
+    // unknown-typed variant.
     const url = new URL(this.baseUrl + '/api/v1/' + endpoint.replace(/^\/+/, ''));
     if (params) {
       for (const [k, v] of Object.entries(params)) {
-        if (v !== undefined && v !== null) url.searchParams.set(k, String(v));
+        url.searchParams.set(k, String(v));
       }
     }
 
@@ -103,13 +110,13 @@ export class SnipeItClient {
   /** Fetch every page of a paginated endpoint. Uses the Snipe-IT shape {total, rows}. */
   async fetchAll<T = unknown>(
     endpoint: string,
-    extraParams: Record<string, unknown> = {},
+    extraParams: Record<string, string | number | boolean> = {},
   ): Promise<T[]> {
     const collected: T[] = [];
     let offset = 0;
     while (true) {
       const params = { ...extraParams, limit: this.pageSize, offset };
-      const res = (await this.get(endpoint, params)) as { total?: number; rows?: unknown[] };
+      const res = await this.get<{ rows?: unknown[]; total?: number }>(endpoint, params);
       const rows = (res.rows ?? []) as T[];
       collected.push(...rows);
       const total = typeof res.total === 'number' ? res.total : collected.length;
@@ -121,10 +128,15 @@ export class SnipeItClient {
   }
 
   /** Light-weight count probe — reads one page with limit=1 and returns the `total`. */
-  async count(endpoint: string, extraParams: Record<string, unknown> = {}): Promise<number> {
-    const res = (await this.get(endpoint, { ...extraParams, limit: 1, offset: 0 })) as {
-      total?: number;
-    };
+  async count(
+    endpoint: string,
+    extraParams: Record<string, string | number | boolean> = {},
+  ): Promise<number> {
+    const res = await this.get<{ total?: number }>(endpoint, {
+      ...extraParams,
+      limit: 1,
+      offset: 0,
+    });
     return typeof res.total === 'number' ? res.total : 0;
   }
 

--- a/packages/plugin-sdk/eslint.config.mjs
+++ b/packages/plugin-sdk/eslint.config.mjs
@@ -1,0 +1,45 @@
+// ESLint flat config for @panorama/plugin-sdk (#39 ARCH-05 follow-up).
+// See packages/migrator/eslint.config.mjs for rationale; this is the
+// same baseline. plugin-sdk/ is a public SDK surface (consumers will
+// be third parties) — type-aware rules catch the highest-leverage
+// regressions before they ship.
+
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: [
+      'dist/**',
+      'coverage/**',
+      'node_modules/**',
+      'test/**',
+      'vitest.config.ts',
+      'eslint.config.mjs',
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/await-thenable': 'error',
+      '@typescript-eslint/no-for-in-array': 'error',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/require-await': 'off',
+    },
+  },
+);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc",
     "test": "echo 'plugin-sdk — runtime + tests land with first plugin in 0.4'",
-    "lint": "echo 'plugin-sdk lint — no ESLint config yet, gated by typecheck'",
+    "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "clean": "rimraf dist"
   },

--- a/packages/shared/eslint.config.mjs
+++ b/packages/shared/eslint.config.mjs
@@ -1,0 +1,43 @@
+// ESLint flat config for @panorama/shared (#39 ARCH-05 follow-up).
+// See packages/migrator/eslint.config.mjs for rationale; this is the
+// same baseline. shared/ is types + Zod schemas, no runtime tests yet.
+
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: [
+      'dist/**',
+      'coverage/**',
+      'node_modules/**',
+      'test/**',
+      'vitest.config.ts',
+      'eslint.config.mjs',
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/await-thenable': 'error',
+      '@typescript-eslint/no-for-in-array': 'error',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/require-await': 'off',
+    },
+  },
+);

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc",
     "test": "echo 'shared — types only, no runtime tests yet'",
-    "lint": "echo 'nothing to lint yet'",
+    "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "clean": "rimraf dist"
   },

--- a/packages/ui-kit/eslint.config.mjs
+++ b/packages/ui-kit/eslint.config.mjs
@@ -1,0 +1,43 @@
+// ESLint flat config for @panorama/ui-kit (#39 ARCH-05 follow-up).
+// Baseline mirrors migrator/shared/plugin-sdk; package is a 6-line
+// placeholder today, lint runs cheap.
+
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: [
+      'dist/**',
+      'coverage/**',
+      'node_modules/**',
+      'test/**',
+      'vitest.config.ts',
+      'eslint.config.mjs',
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/await-thenable': 'error',
+      '@typescript-eslint/no-for-in-array': 'error',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/require-await': 'off',
+    },
+  },
+);

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc",
     "test": "echo 'ui-kit — scaffold only, first components land in 0.2'",
-    "lint": "echo 'nothing to lint yet'",
+    "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "clean": "rimraf dist"
   },


### PR DESCRIPTION
## Summary

Closes the residual placeholder-packages slice of #39. core-api +
web already had real lint after Wave 2d.A; this extends the gate
to the four substantive workspace packages and updates
CONTRIBUTING.md to match reality.

## Coverage delta

| Package | LOC (src) | Before | After |
|---|---|---|---|
| `@panorama/migrator` | 284 | echo stub | `eslint --max-warnings=0` |
| `@panorama/shared` | 169 | echo stub | `eslint --max-warnings=0` |
| `@panorama/plugin-sdk` | 52 | echo stub | `eslint --max-warnings=0` |
| `@panorama/ui-kit` | 6 | echo stub | `eslint --max-warnings=0` |
| `@panorama/i18n` | 0 (JSON) | echo | echo + #39 ref |

Each config mirrors `apps/core-api/eslint.config.mjs` minus the
NestJS / test-fixture relaxations.

## Real bug surfaced + fixed

`@typescript-eslint/no-base-to-string` caught a footgun in
`SnipeItClient.get` line 57: `String(v)` on `unknown` produces
literal `"[object Object]"` for non-primitive params. Narrowed to
`Record<string, string | number | boolean>`. All callers already
pass primitives → no behaviour change. Plus three
`no-unnecessary-type-assertion` auto-fixes (the `as { rows; total }`
casts on `client.get(...)` results swapped for the generic param of
`get<T>(...)` at the call site).

## CONTRIBUTING.md

`pnpm lint                 # ESLint + Prettier + markdownlint` →
accurate description of what actually runs. Prettier + markdownlint
remain not enforced (out of scope).

## Test plan

- [x] `pnpm lint` — **7/7 packages green** via turbo
- [x] `pnpm --filter @panorama/migrator typecheck` — clean
- [x] `pnpm --filter @panorama/migrator test` — 6/6 pass
- [x] `pnpm install --frozen-lockfile` — no drift
- [ ] CI confirms lockfile + lint posture

Note: ESLint deps (`@eslint/js`, `typescript-eslint`, `eslint`) are
public-hoisted via pnpm's default `*eslint*` pattern from core-api's
devDependencies. Robust today; if pnpm policy changes, follow-up PR
makes per-package devDeps explicit.