### PR TITLE
docs(audit): document multi-strand chain semantics + per-tenant test (#113)

### DIFF
--- a/apps/core-api/src/modules/audit/audit.service.ts
+++ b/apps/core-api/src/modules/audit/audit.service.ts
@@ -15,6 +15,45 @@ import { PrismaService } from '../prisma/prisma.service.js';
  * audit log since we only need *a* consistent predecessor pointer,
  * not a globally-total order. Verification tooling traverses the
  * id-ordered chain at audit time.
+ *
+ * --- Multi-strand semantics (#113 / RLS-01) ---
+ *
+ * The chain is **multi-strand**, not single-linear, because the
+ * `findFirst` chain-head read is filtered by RLS at the role's
+ * visibility:
+ *
+ *   * `recordWithin(tx, …)` called from `runInTenant(tenantA, …)`
+ *     reads the latest row visible to tenantA (own rows + NULL-tenant
+ *     rows per `audit_events_tenant_read`). Writes carry
+ *     `tenantId = tenantA`.
+ *   * `recordWithin(tx, …)` called from `runAsSuperAdmin(…)` (or the
+ *     SECURITY DEFINER triggers post-#41) reads the global latest row.
+ *     Writes typically carry `tenantId = NULL` for cluster-wide
+ *     system events.
+ *
+ * This is by ADR-0003's least-privilege contract — `panorama_app`
+ * cannot see other tenants' rows, so the chain head it reads is
+ * tenant-scoped. The trade-off: a single global linear chain would
+ * require every tenant write to escalate to super-admin for the
+ * head read (a SECURITY DEFINER helper), which weakens the RLS
+ * isolation property for an append-only verification benefit.
+ *
+ * **Verification tooling implications:**
+ *
+ *   1. Verify each tenant's strand independently — filter to
+ *      `tenantId IN (tenant, NULL)`, order by `id`, walk prev/self hash.
+ *      Cross-strand prev_hash links (a tenant linking forward to a
+ *      NULL-tenant row visible to it) are normal and verify cleanly.
+ *   2. Verify the global super-admin strand — no tenantId filter,
+ *      order by `id`, walk the chain. The global strand sees every
+ *      row but its `prev_hash` was written from the global head at
+ *      write time, so it's coherent on its own.
+ *   3. Cross-tenant timeline reconstruction uses `occurredAt`, NOT
+ *      the prev_hash links — links are local to a strand.
+ *
+ * The `tenantId` column is the natural strand discriminator: NULL
+ * for system / privileged-write events, the tenant uuid for
+ * tenant-scoped writes.
  */
 export interface AuditEventInput {
   /** e.g. `panorama.invitation.created`. */

--- a/apps/core-api/test/audit-chain-integrity.e2e.test.ts
+++ b/apps/core-api/test/audit-chain-integrity.e2e.test.ts
@@ -8,11 +8,12 @@ import { AppModule } from '../src/app.module.js';
 import { AuditService } from '../src/modules/audit/audit.service.js';
 import { PrismaService } from '../src/modules/prisma/prisma.service.js';
 import { resetTestDb } from './_reset-db.js';
+import { createTenantForTest } from './_create-tenant.js';
 
 /**
- * Hash-chain integrity for batched `audit.recordWithin` calls inside
- * a single super-admin tx (tech-lead pass-2 soft on #140 +
- * MaintenanceSweepService PM-due audit batching).
+ * Hash-chain integrity for batched `audit.recordWithin` calls
+ * (tech-lead pass-2 soft on #140 + MaintenanceSweepService PM-due
+ * audit batching, extended in #113 for the multi-strand reality).
  *
  * The invariant: when N rows are inserted via `recordWithin(tx, …)`
  * inside one transaction, row[k+1].prevHash MUST equal row[k].selfHash.
@@ -24,12 +25,17 @@ import { resetTestDb } from './_reset-db.js';
  * before the chain breaks silently in production.
  *
  * Coverage:
- *   1. Five consecutive `recordWithin` calls in one tx → chain links
- *      forward, each row's prevHash matches predecessor selfHash.
- *   2. Batch's first row links to the global chain tail (the row
- *      that was head BEFORE the batch).
- *   3. Each row's selfHash recomputes from (prevHash, payload) so
- *      tampering with any field downstream breaks verification.
+ *   1. **Super-admin (global) strand** — five consecutive
+ *      `recordWithin` calls in one super-admin tx; chain links
+ *      forward, prevHash recomputable. Locks the global-strand
+ *      invariant against Prisma upgrades.
+ *   2. **Cross-batch global** — second super-admin batch in the same
+ *      suite continues the chain (no per-tx reset).
+ *   3. **Per-tenant strand (#113)** — three consecutive `recordWithin`
+ *      calls under `runInTenant(tenantA, …)`. Under `panorama_app`
+ *      the chain-head read is RLS-filtered to (tenantA + NULL), so
+ *      the strand we observe back is what tenantA would see at
+ *      verification time. Asserts the strand is internally coherent.
  */
 
 const HOST = process.env.PG_HOST ?? 'localhost';
@@ -210,6 +216,66 @@ describe('audit hash-chain integrity — batched recordWithin', () => {
     // — the previous test's batch already extended the chain).
     expect(rows[0]!.prevHash).not.toBeNull();
     // Internal links remain coherent.
+    for (let i = 1; i < rows.length; i++) {
+      expect(Buffer.compare(rows[i]!.prevHash!, rows[i - 1]!.selfHash)).toBe(0);
+    }
+  }, 30_000);
+
+  it('per-tenant strand under runInTenant chains coherently (#113)', async () => {
+    // Documents + locks the multi-strand reality: under
+    // `runInTenant(tenantA)` the `panorama_app` role's RLS policy
+    // filters the chain-head read to (tenantA + NULL). The strand the
+    // tenant observes back is what verification tooling will see at
+    // audit time, so it must be internally coherent: every row's
+    // prev_hash links to the previous row's self_hash within the same
+    // batch.
+    //
+    // This does NOT assert linkage to the global super-admin strand —
+    // those are separate strands by design (see AuditService docstring).
+    const tenant = await createTenantForTest(adminDb, {
+      slug: 'audit-chain-tenantA',
+      name: 'Audit Chain Tenant A',
+      displayName: 'Audit Chain Tenant A',
+    });
+
+    await prisma.runInTenant(tenant.id, async (tx) => {
+      for (let i = 0; i < 3; i++) {
+        await audit.recordWithin(tx, {
+          action: `panorama.audit_chain_test.tenant_strand_${i}`,
+          resourceType: 'audit_chain_test',
+          resourceId: `tenant-row-${i}`,
+          tenantId: tenant.id,
+          actorUserId: null,
+          metadata: { i, strand: 'tenant' },
+        });
+      }
+    });
+
+    // Read back via the admin client (BYPASSRLS) so the test is not
+    // itself constrained by the tenant's RLS view; the assertion is
+    // about the rows we wrote, not about what the tenant can see.
+    const rows = (await adminDb.auditEvent.findMany({
+      where: { tenantId: tenant.id },
+      orderBy: { id: 'asc' },
+      select: {
+        action: true,
+        prevHash: true,
+        selfHash: true,
+        tenantId: true,
+      },
+    })) as unknown as Array<{
+      action: string;
+      prevHash: Buffer | null;
+      selfHash: Buffer;
+      tenantId: string | null;
+    }>;
+
+    expect(rows).toHaveLength(3);
+    for (const r of rows) {
+      expect(r.tenantId).toBe(tenant.id);
+    }
+    // Internal chain coherence within the tenant strand.
+    expect(rows[0]!.prevHash).not.toBeNull();
     for (let i = 1; i < rows.length; i++) {
       expect(Buffer.compare(rows[i]!.prevHash!, rows[i - 1]!.selfHash)).toBe(0);
     }


### PR DESCRIPTION
## Summary

Closes #113 via Option 1 (document the multi-strand reality). The
chain is per-tenant for `runInTenant` writes and global for
super-admin / SECURITY DEFINER trigger writes — that's a property
of RLS visibility under `panorama_app`, not a bug.

## What changed

- **`AuditService.recordWithin` docstring** — adds a "Multi-strand
  semantics (#113 / RLS-01)" section covering the strand
  partitioning, why it exists (RLS isolation), and how verification
  tooling should walk strands.
- **`audit-chain-integrity.e2e.test.ts`** — third test case under
  `runInTenant(tenantA, …)` locks per-tenant strand internal
  coherence (was previously only super-admin strand).

## Why Option 1 not Option 2

Option 2 (SECURITY DEFINER helper for chain-head reads) would force
a single linear chain at the cost of weakening RLS — every tenant
write would touch `audit_events_tenant_read` with super-admin
visibility momentarily. The append-only verification benefit
doesn't outweigh the isolation cost for the current threat model.

If compliance-grade verification becomes load-bearing later,
revisit Option 2.

## Test plan

- [x] `pnpm --filter @panorama/core-api test` — **395/395** (was 394;
      +1 per-tenant strand test)
- [x] `pnpm lint` — 7/7 packages green
- [x] No schema / migration changes