### PR TITLE
fix(audit): trigger digest reproducibility — ms-truncate now() (#96)

### DIFF
--- a/apps/core-api/prisma/migrations/20260428080000_0020_audit_trigger_digest_ms_truncate/ROLLBACK.md
+++ b/apps/core-api/prisma/migrations/20260428080000_0020_audit_trigger_digest_ms_truncate/ROLLBACK.md
@@ -1,0 +1,19 @@
+# Rollback — migration 0020 (audit trigger digest ms-truncate)
+
+```sql
+-- Restore the pre-#96 functions (microsecond `now()` directly,
+-- exposing the rounding/truncation mismatch documented in
+-- migration.sql).
+\\i ../20260426094000_0015_audit_wave1_data_layer_corrections/migration.sql
+```
+
+Rollback restores the divergent-digest behaviour. Don't roll back
+unless verifier tooling regresses — the fix is forward-compatible
+with all prior fires (verifiers that handle the rounding ambiguity
+keep working) and uniquely deterministic from this point on.
+
+The cutover marker emitted at apply time (`panorama.audit.chain_repair`
+with `metadata.migration = '0020'`) is left in place on rollback
+— it's an audit event documenting that the fix WAS applied and
+later reverted. Verifier tooling should treat the marker as a
+historical waypoint regardless of whether it's still in force.

--- a/apps/core-api/prisma/migrations/20260428080000_0020_audit_trigger_digest_ms_truncate/migration.sql
+++ b/apps/core-api/prisma/migrations/20260428080000_0020_audit_trigger_digest_ms_truncate/migration.sql
@@ -1,0 +1,263 @@
+-- Migration 0020 — Audit trigger digest reproducibility fix (#96).
+--
+-- Problem
+-- -------
+-- Both SECURITY DEFINER audit triggers landed in migration 0015
+-- declared `occurred timestamptz := now()` (microsecond precision)
+-- and used the same value in two places:
+--
+--   1. `to_char(occurred AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`
+--      → built into the digest payload. `to_char` with `MS` truncates
+--      to 3 digits.
+--   2. `INSERT INTO audit_events (..., "occurredAt", ...) VALUES (..., occurred, ...)`
+--      → the column is `timestamp(3) without time zone`, which ROUNDS
+--      to ms.
+--
+-- For ~50% of trigger fires (those where now() lands in
+-- `[.xxx500, .yyy000)`), the to_char output uses `.xxx` while the
+-- column rounds to `.yyy`. Verification tooling reading the row
+-- can't recompute the digest because the original sub-millisecond
+-- value is lost — the column-stored `occurredAt` differs from the
+-- value to_char fed into the digest.
+--
+-- The chain itself is unaffected (prev_hash links are well-formed);
+-- only the per-row digest verifiability is broken.
+--
+-- Fix
+-- ---
+-- Pre-truncate `occurred` to millisecond precision via
+-- `date_trunc('milliseconds', now())`. Both the to_char output and
+-- the column-stored value then use the SAME truncated value, so a
+-- verifier reading the row can recompute the digest deterministically.
+--
+-- Pre-existing rows
+-- -----------------
+-- Rows written by the buggy version remain. Their digests are
+-- internally consistent (the trigger and the verifier-of-the-time
+-- both saw the same timestamptz), but a new verifier reading the
+-- column-stored `occurredAt` cannot match them with certainty for
+-- the rounded-up cases. The fix is forward-looking: from this
+-- migration onward, rows are uniquely verifiable. Verifiers
+-- inspecting historical rows should accept either
+-- `(stored_ms, stored_ms - 1ms)` as candidate digest inputs and
+-- match either.
+--
+-- Apply-time chain marker emitted at the bottom so verifier tooling
+-- can locate the cutover.
+
+-- ---------------------------------------------------------------------
+-- Recreate emit_notification_tamper_audit with date_trunc'd occurred.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION emit_notification_tamper_audit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    -- #96: ms-truncate at declaration so to_char and the column INSERT
+    -- both see the SAME value. Pre-#96 we declared `now()` directly
+    -- (µs precision); to_char(MS) truncated to ms while the column
+    -- rounded to ms, breaking digest reproducibility for ~50% of fires.
+    occurred      timestamptz := date_trunc('milliseconds', now());
+    payload_text  text;
+    payload_bytes bytea;
+    prev_hash     bytea;
+    self_hash     bytea;
+BEGIN
+    IF NOT (
+        (OLD."status" = 'PENDING'     AND NEW."status" = 'DISPATCHED') OR
+        (OLD."status" = 'DEAD')                                        OR
+        (OLD."status" = 'DISPATCHED'  AND NEW."status" <> 'DISPATCHED')
+    ) THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT "selfHash" INTO prev_hash
+      FROM audit_events
+      ORDER BY id DESC
+      LIMIT 1;
+
+    payload_text := json_build_object(
+        'action',       'panorama.notification.status_tampered',
+        'resourceType', 'notification_event',
+        'resourceId',   NEW.id::text,
+        'tenantId',     NEW."tenantId"::text,
+        'actorUserId',  NULL,
+        'metadata',     json_build_object(
+                            'fromStatus', OLD."status"::text,
+                            'toStatus',   NEW."status"::text,
+                            'eventType',  NEW."eventType"
+                        ),
+        'occurredAt',   to_char(occurred AT TIME ZONE 'UTC',
+                                'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    )::text;
+    payload_bytes := convert_to(payload_text, 'UTF8');
+
+    IF prev_hash IS NOT NULL THEN
+        self_hash := digest(prev_hash || payload_bytes, 'sha256');
+    ELSE
+        self_hash := digest(payload_bytes, 'sha256');
+    END IF;
+
+    INSERT INTO audit_events (
+        "tenantId", "actorUserId", action, "resourceType", "resourceId",
+        metadata, "occurredAt", "prevHash", "selfHash"
+    ) VALUES (
+        NEW."tenantId",
+        NULL,
+        'panorama.notification.status_tampered',
+        'notification_event',
+        NEW.id::text,
+        json_build_object(
+            'fromStatus', OLD."status"::text,
+            'toStatus',   NEW."status"::text,
+            'eventType',  NEW."eventType"
+        ),
+        occurred,
+        prev_hash,
+        self_hash
+    );
+
+    RETURN NEW;
+END;
+$$;
+
+-- ---------------------------------------------------------------------
+-- Recreate emit_pat_resurrected_audit with date_trunc'd occurred.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION emit_pat_resurrected_audit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    prev_hash     bytea;
+    -- See emit_notification_tamper_audit comment for rationale.
+    occurred      timestamptz := date_trunc('milliseconds', now());
+    payload_text  text;
+    payload_bytes bytea;
+    self_hash     bytea;
+BEGIN
+    IF TG_OP <> 'UPDATE' THEN
+        RETURN NEW;
+    END IF;
+    IF OLD."revokedAt" IS NULL OR NEW."revokedAt" IS NOT NULL THEN
+        RETURN NEW;
+    END IF;
+
+    SELECT "selfHash" INTO prev_hash
+      FROM audit_events
+      ORDER BY id DESC
+      LIMIT 1;
+
+    payload_text := json_build_object(
+        'action',       'panorama.pat.resurrected',
+        'resourceType', 'personal_access_token',
+        'resourceId',   NEW.id::text,
+        'tenantId',     NEW."tenantId"::text,
+        'actorUserId',  NULL,
+        'metadata',     json_build_object(
+                            'tokenId',     NEW.id::text,
+                            'tokenPrefix', NEW."tokenPrefix",
+                            'userId',      NEW."userId"::text,
+                            'previousRevokedAt', to_char(OLD."revokedAt" AT TIME ZONE 'UTC',
+                                                         'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+                        ),
+        'occurredAt',   to_char(occurred AT TIME ZONE 'UTC',
+                                'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    )::text;
+    payload_bytes := convert_to(payload_text, 'UTF8');
+
+    IF prev_hash IS NOT NULL THEN
+        self_hash := digest(prev_hash || payload_bytes, 'sha256');
+    ELSE
+        self_hash := digest(payload_bytes, 'sha256');
+    END IF;
+
+    INSERT INTO audit_events (
+        "tenantId", "actorUserId", action, "resourceType", "resourceId",
+        metadata, "occurredAt", "prevHash", "selfHash"
+    ) VALUES (
+        NEW."tenantId",
+        NULL,
+        'panorama.pat.resurrected',
+        'personal_access_token',
+        NEW.id::text,
+        json_build_object(
+            'tokenId',     NEW.id::text,
+            'tokenPrefix', NEW."tokenPrefix",
+            'userId',      NEW."userId"::text,
+            'previousRevokedAt', to_char(OLD."revokedAt" AT TIME ZONE 'UTC',
+                                         'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+        ),
+        occurred,
+        prev_hash,
+        self_hash
+    );
+
+    RETURN NEW;
+END;
+$$;
+
+-- ---------------------------------------------------------------------
+-- Cutover marker (apply-time, single insert, links into the global
+-- chain so verifier tooling can find the rounding-fix boundary).
+-- ---------------------------------------------------------------------
+DO $$
+DECLARE
+    occurred       timestamptz := date_trunc('milliseconds', now());
+    metadata_json  jsonb;
+    payload_text   text;
+    payload_bytes  bytea;
+    prev_hash      bytea;
+    self_hash      bytea;
+BEGIN
+    metadata_json := jsonb_build_object(
+        'migration', '0020',
+        'fixes', jsonb_build_array(
+                     'emit_notification_tamper_audit timestamptz_ms_truncate',
+                     'emit_pat_resurrected_audit timestamptz_ms_truncate'
+                 ),
+        'reason', 'digest_reproducibility_rounding_vs_truncation_mismatch'
+    );
+
+    SELECT "selfHash" INTO prev_hash
+      FROM audit_events
+      ORDER BY id DESC
+      LIMIT 1;
+
+    payload_text := json_build_object(
+        'action',       'panorama.audit.chain_repair',
+        'resourceType', 'audit_chain',
+        'resourceId',   NULL,
+        'tenantId',     NULL,
+        'actorUserId',  NULL,
+        'metadata',     metadata_json,
+        'occurredAt',   to_char(occurred AT TIME ZONE 'UTC',
+                                'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    )::text;
+    payload_bytes := convert_to(payload_text, 'UTF8');
+
+    IF prev_hash IS NOT NULL THEN
+        self_hash := digest(prev_hash || payload_bytes, 'sha256');
+    ELSE
+        self_hash := digest(payload_bytes, 'sha256');
+    END IF;
+
+    INSERT INTO audit_events (
+        "tenantId", "actorUserId", action, "resourceType", "resourceId",
+        metadata, "occurredAt", "prevHash", "selfHash"
+    ) VALUES (
+        NULL,
+        NULL,
+        'panorama.audit.chain_repair',
+        'audit_chain',
+        NULL,
+        metadata_json,
+        occurred,
+        prev_hash,
+        self_hash
+    );
+END $$;

--- a/apps/core-api/prisma/migrations/20260428080000_0020_audit_trigger_digest_ms_truncate/rls.sql
+++ b/apps/core-api/prisma/migrations/20260428080000_0020_audit_trigger_digest_ms_truncate/rls.sql
@@ -1,0 +1,13 @@
+-- Migration 0020 — no RLS surface change.
+--
+-- Recreates two SECURITY DEFINER trigger functions to fix digest
+-- reproducibility (#96 rounding-vs-truncation mismatch). The
+-- functions retain SECURITY DEFINER + owner = panorama, so the
+-- chain-is-global property from migration 0015 is preserved.
+-- Audit_events RLS policies (migration 0001) continue to apply
+-- unchanged.
+--
+-- Placeholder kept for grep-greppability of the per-migration RLS
+-- audit pattern.
+
+SELECT 1;

--- a/apps/core-api/test/migration-0015-corrections.test.ts
+++ b/apps/core-api/test/migration-0015-corrections.test.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { PrismaClient } from '@prisma/client';
+import { createHash } from 'node:crypto';
 import { resetTestDb } from './_reset-db.js';
 import { createTenantForTest } from './_create-tenant.js';
 
@@ -221,6 +222,79 @@ describe('migration 0015 — Wave 1 corrections', () => {
     expect(row?.prevHash).toEqual(tail.selfHash);
   });
 
+  it('#41 / #96 — trigger digest: selfHash = sha256(prev_hash || utf8(canonical_payload))', async () => {
+    // Pins the trigger function's hash math, not just its row-finding.
+    // The chain-is-global test above proves the SECURITY DEFINER
+    // SELECT walks audit_events without RLS scope; this test
+    // recomputes the resulting selfHash byte-for-byte from the
+    // payload Postgres builds via `json_build_object(...)::text`.
+    //
+    // Locks the digest contract against future trigger refactors:
+    // any change to (a) the JSON payload key set, (b) the
+    // occurredAt format string, or (c) the prepend-prev-hash byte
+    // order would diverge the recomputed hash.
+    //
+    // Read `row.prevHash` AS WRITTEN by the trigger (whatever was
+    // the global tail at fire time) and feed THAT into the
+    // recomputation — no pre-condition on which row is the tail,
+    // because vitest parallelism means another test file can race
+    // an audit insert in between our seed and our fire.
+    const dedupKey = `digest-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const created = await admin.notificationEvent.create({
+      data: {
+        tenantId,
+        eventType: 'panorama.test.digest_target',
+        dedupKey,
+        payload: { kind: 'digest-target' },
+        status: 'PENDING',
+      },
+    });
+    // Disallowed transition fires the trigger.
+    await admin.notificationEvent.update({
+      where: { id: created.id },
+      data: { status: 'DISPATCHED' },
+    });
+
+    const row = await admin.auditEvent.findFirstOrThrow({
+      where: { action: 'panorama.notification.status_tampered', resourceId: created.id },
+      orderBy: { id: 'desc' },
+    });
+
+    // Reconstruct the canonical payload Postgres built via
+    // `json_build_object(...)::text`. Postgres emits `json` output
+    // with whitespace around separators — `{"k" : v, "k2" : v2}` —
+    // NOT the ECMA-404 compact form `JSON.stringify` produces. The
+    // hash math is byte-sensitive, so the reconstruction has to
+    // match that whitespace exactly.
+    //
+    // The occurredAt format mirrors the trigger's
+    // `to_char(... 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')` which is the
+    // same shape `Date.toISOString()` emits. The trigger metadata
+    // uses `json_build_object(fromStatus, toStatus, eventType)` —
+    // key order is the SQL argument order, reproduced here.
+    const payload = {
+      action: 'panorama.notification.status_tampered',
+      resourceType: 'notification_event',
+      resourceId: created.id,
+      tenantId,
+      actorUserId: null,
+      metadata: {
+        fromStatus: 'PENDING',
+        toStatus: 'DISPATCHED',
+        eventType: 'panorama.test.digest_target',
+      },
+      occurredAt: row.occurredAt.toISOString(),
+    };
+    const payloadBytes = Buffer.from(pgJsonStringify(payload), 'utf8');
+
+    const expected = createHash('sha256');
+    if (row.prevHash) expected.update(row.prevHash);
+    expected.update(payloadBytes);
+    const expectedDigest = expected.digest();
+
+    expect(row.selfHash.equals(expectedDigest)).toBe(true);
+  });
+
   // The cutover marker (panorama.audit.chain_repair, action key) is
   // emitted at migration apply time. resetTestDb wipes audit_events
   // before every test run, so the marker is not present in the
@@ -230,3 +304,28 @@ describe('migration 0015 — Wave 1 corrections', () => {
   // (its DO $$ block runs once when the migration applies); a
   // vitest assertion here would not survive resetTestDb's wipe.
 });
+
+/**
+ * Postgres-compatible JSON serializer (#96). Postgres `json_build_object`
+ * emits text with whitespace around separators:
+ *   {"key" : "value", "k2" : null}
+ * The trigger digests over those exact bytes, so reconstruction has
+ * to match. ECMA-404 / `JSON.stringify` produces compact output
+ * `{"key":"value","k2":null}` — different bytes, different sha256.
+ *
+ * Limited surface: handles the shapes the audit triggers emit
+ * (strings, null, plain objects, no arrays/numbers/booleans). Not a
+ * general-purpose serializer; throw on anything else so the test
+ * fails loud if the trigger payload shape grows.
+ */
+function pgJsonStringify(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    const pairs = Object.entries(value).map(
+      ([k, v]) => `${JSON.stringify(k)} : ${pgJsonStringify(v)}`,
+    );
+    return `{${pairs.join(', ')}}`;
+  }
+  throw new Error(`pgJsonStringify: unsupported value type ${typeof value}`);
+}


### PR DESCRIPTION
## Summary

Closes #96. The original ask was a behavioural test that recomputes
the trigger's `selfHash` Node-side and asserts byte-equality. Writing
that test surfaced a real digest-verifiability bug: pre-this-PR,
audit_events rows from the SECURITY DEFINER triggers couldn't be
verified for ~50% of fires.

## The bug

Migration 0015's triggers declared `occurred timestamptz := now()`
(µs precision) and used it twice:

1. `to_char(occurred AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')`
   — `MS` truncates µs to 3 digits.
2. `INSERT INTO audit_events ("occurredAt") VALUES (occurred)` —
   column is `timestamp(3)`, which ROUNDS µs to ms.

For `now()` values in `[.xxx500, .yyy000)`, to_char emits `.xxx`
while the column stores `.yyy`. The digest payload sees `.xxx`,
the verifier reads `.yyy` from the column → mismatch. Chain links
remained intact; only per-row digest verifiability broke.

## The fix

Migration 0020 (this PR) recreates both trigger functions with
`occurred timestamptz := date_trunc('milliseconds', now())`. Both
to_char and the column INSERT now use the same truncated value.
A `panorama.audit.chain_repair` cutover marker is emitted at apply
time with `metadata.migration = '0020'` so verifier tooling can
locate the boundary.

Pre-existing rows: digest-internally-consistent, but a verifier
reading the stored `occurredAt` cannot match the rounded-up cases.
Forward-looking fix; historical rows need verifier tooling to try
both `(stored_ms, stored_ms - 1ms)` candidates.

## The test (the issue's original ask)

`audit-trigger digest behavioural test` lives in
`migration-0015-corrections.test.ts`. Fires the trigger, reads the
row, recomputes selfHash via:

- New `pgJsonStringify` helper that matches `json_build_object()::text`
  whitespace (`{"k" : "v", "k2" : null}`, NOT ECMA-404 compact form
  that `JSON.stringify` produces — different bytes, different
  sha256).
- `prev_hash || utf8(payload)` digest, byte-equal assertion.

## Test plan

- [x] Backend: **397/397** (was 396; +1 digest test)
- [x] Migration applied locally; tests pass in isolation AND full
      suite (the test was flaky pre-fix under file-level parallelism
      due to the bug; now deterministic)
- [x] `pnpm lint` — 7/7 packages green
- [x] `pnpm rls:allowlist-check` — 29/12 unchanged