### PR TITLE
feat(auth): OIDC follow-ups bundle — domain validation + audit registry + login event (#89/#90/#91)

### DIFF
--- a/apps/core-api/src/modules/audit/audit-actions.ts
+++ b/apps/core-api/src/modules/audit/audit-actions.ts
@@ -1,0 +1,54 @@
+/**
+ * Typed registry of audit actions Panorama emits (#90 / follow-up #28).
+ *
+ * Audit-action strings are public contract for downstream consumers
+ * (alert rules, retention policies, SIEM filters). Without a registry,
+ * authors pick sibling names by coin-flip and the namespace fragments.
+ * The convention is `panorama.<domain>.<verb>` — this file is the
+ * single source of truth for which `<domain>.<verb>` pairs exist.
+ *
+ * Initial seed scope: `panorama.auth.*`. Other domains
+ * (reservation / inspection / maintenance / invitation / blackout /
+ * pat / boot / notification / tenant / audit) currently use string
+ * literals at call sites. Migrating those is a sibling cleanup PR;
+ * this registry is the destination, the call sites move to it as
+ * touched.
+ *
+ * To add a new action:
+ *   1. Add the entry below in `panorama.<domain>.<verb>` shape.
+ *   2. Use `PanoramaAuditAction.<MemberName>` at the call site (NOT
+ *      a string literal).
+ *   3. If the action is per-tenant, document the tenant scope in the
+ *      JSDoc comment.
+ */
+export const PanoramaAuditAction = {
+  // -------- panorama.auth.* --------
+  /**
+   * OIDC login refused. Cluster-wide event (`tenantId=null`) per
+   * ADR-0003's NULL-strand convention: every tenant admin in the
+   * cluster sees this row. Metadata MUST NOT carry per-tenant
+   * context. Reasons: `email_not_verified` / `hd_not_allowlisted` /
+   * `hd_iss_mismatch` / `hd_email_mismatch` /
+   * `oidc_account_link_requires_verified_email`.
+   */
+  AuthOidcRefused: 'panorama.auth.oidc_refused',
+  /**
+   * OIDC login succeeded. Cluster-wide event (`tenantId=null`) —
+   * visible to every tenant admin. Metadata carries `emailDomain`
+   * + `hd` (the corporate IdP domain), which is information about
+   * the LOGGED-IN user's organisation that propagates outside that
+   * tenant. Considered acceptable because (a) refusals already do
+   * the same and (b) the corporate domain is semi-public anyway.
+   * Pre-pilot, single-cluster Panorama deployments make this a
+   * non-issue; revisit if cross-tenant cluster sharing emerges.
+   *
+   * Metadata: `provider`, `pathTaken` (`existing_identity` /
+   * `email_link` / `new_user`), `viaHdOverride`, `emailDomain`,
+   * `hd`, `subjectHash`, `iss`. `actorUserId` populated post-
+   * resolution (see #91 / follow-up #28).
+   */
+  AuthOidcLogin: 'panorama.auth.oidc_login',
+} as const;
+
+export type PanoramaAuditAction =
+  (typeof PanoramaAuditAction)[keyof typeof PanoramaAuditAction];

--- a/apps/core-api/src/modules/auth/auth.config.ts
+++ b/apps/core-api/src/modules/auth/auth.config.ts
@@ -85,7 +85,10 @@ export class AuthConfigService {
       if (process.env.OIDC_GOOGLE_HOSTED_DOMAIN) {
         google.hostedDomainHint = process.env.OIDC_GOOGLE_HOSTED_DOMAIN;
       }
-      const trusted = parseDomainList(process.env.OIDC_GOOGLE_TRUSTED_HD_DOMAINS);
+      const trusted = parseDomainList(
+        process.env.OIDC_GOOGLE_TRUSTED_HD_DOMAINS,
+        this.log,
+      );
       if (trusted.length > 0) {
         google.trustedHdDomains = trusted;
       }
@@ -131,12 +134,57 @@ export class AuthConfigService {
   }
 }
 
-function parseDomainList(raw: string | undefined): string[] {
+/**
+ * DNS label syntax (RFC 1035 letter/digit/hyphen rules) — anchors
+ * forbid wildcards, paths, ports, double dots, leading/trailing
+ * hyphens. Permits multi-label domains (`acme.example`,
+ * `foo.bar.example.com`) and IDN A-labels (`xn--tnq.xn--p1ai`),
+ * which is correct because Workspace `hd` claims arrive in
+ * punycode form.
+ *
+ * The regex alone does NOT reject all-digit labels: `127.0.0.1`
+ * matches the multi-label shape. The companion `/[a-z]/` check
+ * in `parseDomainList` excludes IP-literals while keeping mixed
+ * digit/letter labels (`1foo.bar`).
+ */
+const DNS_LABEL_RE =
+  /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+
+/**
+ * Parse a comma-separated DNS-domain list (e.g.
+ * `OIDC_GOOGLE_TRUSTED_HD_DOMAINS`). Lowercased + trimmed +
+ * deduplicated. Entries that don't match `DNS_LABEL_RE` are
+ * filtered out and logged at warn level (#89 / follow-up #28).
+ *
+ * Silent fail-closed for malformed entries was the prior behaviour
+ * — correct direction (refuse logins) but the wrong signal
+ * (operator chases the IdP side instead of finding a typo in their
+ * env var). Logging at warn lets the boot trace surface the typo.
+ *
+ * Logger arg is optional so tests / callers without a logger can
+ * still use the parser; in production the AuthConfigService
+ * passes `this.log` so the warnings land in pino.
+ */
+function parseDomainList(raw: string | undefined, log?: Logger): string[] {
   if (!raw) return [];
-  return raw
-    .split(',')
-    .map((d) => d.trim().toLowerCase())
-    .filter((d) => d.length > 0);
+  const accepted: string[] = [];
+  for (const part of raw.split(',')) {
+    const candidate = part.trim().toLowerCase();
+    if (candidate.length === 0) continue;
+    // DNS_LABEL_RE alone admits all-digit labels (e.g. `127.0.0.1` matches
+    // the multi-label shape), so we require at least one letter to
+    // reject IP literals while still accepting `acme.example` /
+    // `1foo.bar`-style shapes.
+    if (!DNS_LABEL_RE.test(candidate) || !/[a-z]/.test(candidate)) {
+      log?.warn(
+        { entry: candidate, source: 'OIDC_GOOGLE_TRUSTED_HD_DOMAINS' },
+        'auth_config_invalid_domain_entry_ignored',
+      );
+      continue;
+    }
+    accepted.push(candidate);
+  }
+  return accepted;
 }
 
 /**

--- a/apps/core-api/src/modules/auth/auth.service.ts
+++ b/apps/core-api/src/modules/auth/auth.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 import type { Prisma } from '@prisma/client';
 import { createHash } from 'node:crypto';
 import { AuditService } from '../audit/audit.service.js';
+import { PanoramaAuditAction } from '../audit/audit-actions.js';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { AuthConfigService } from './auth.config.js';
 import type { OidcUserInfo } from './oidc.service.js';
@@ -150,6 +151,11 @@ export class AuthService {
     // sentinel keeps the gate decision contiguous and the audit
     // emission happens exactly once, after the closure has cleanly
     // exited with no writes.
+    //
+    // `pathTaken` captures which of the three resolution branches
+    // fired — the post-success audit (#91) carries it so tenant
+    // admins can see whether a Workspace-override login linked to an
+    // existing identity, linked by email, or created a new user.
     const resolution = await this.prisma.runAsSuperAdmin(
       async (tx) => {
         // Subject is IdP-unique; use it as the strongest key.
@@ -161,7 +167,11 @@ export class AuthService {
             where: { id: existing.id },
             data: { lastUsedAt: new Date(), emailAtLink: email },
           });
-          return { kind: 'ok' as const, userId: existing.userId };
+          return {
+            kind: 'ok' as const,
+            userId: existing.userId,
+            pathTaken: 'existing_identity' as const,
+          };
         }
 
         // Second chance: link this OIDC identity to an existing User with
@@ -184,7 +194,11 @@ export class AuthService {
               lastUsedAt: new Date(),
             },
           });
-          return { kind: 'ok' as const, userId: byEmail.id };
+          return {
+            kind: 'ok' as const,
+            userId: byEmail.id,
+            pathTaken: 'email_link' as const,
+          };
         }
 
         // Brand new — create the global User + the OIDC identity linking it.
@@ -205,7 +219,11 @@ export class AuthService {
             lastUsedAt: new Date(),
           },
         });
-        return { kind: 'ok' as const, userId: created.id };
+        return {
+          kind: 'ok' as const,
+          userId: created.id,
+          pathTaken: 'new_user' as const,
+        };
       },
       { reason: 'oidc find-or-create' },
     );
@@ -225,6 +243,24 @@ export class AuthService {
       );
       throw new UnauthorizedException(reason);
     }
+
+    // #91 — symmetric success-path audit. Tenant admins want to see
+    // who actually authenticated via the trusted-`hd` override path,
+    // not just who got refused. The audit row commits in its own
+    // tx after the identity tx already committed, so a crash between
+    // the two leaves the identity write without an audit row — the
+    // dispatcher's eventual DEAD-letter audit + the
+    // `oidc_login_audit_write_failed` log are the operator-visible
+    // backstops.
+    await this.recordOidcLogin(
+      provider,
+      userInfo,
+      email,
+      resolution.userId,
+      resolution.pathTaken,
+      gate.viaHdOverride,
+      context,
+    );
 
     return this.buildSessionForUser(resolution.userId, provider);
   }
@@ -276,7 +312,7 @@ export class AuthService {
     // transitions on tenant data, not to pre-tenant cluster events.
     try {
       await this.audit.record({
-        action: 'panorama.auth.oidc_refused',
+        action: PanoramaAuditAction.AuthOidcRefused,
         resourceType: 'auth_identity',
         resourceId: null,
         tenantId: null,
@@ -297,6 +333,52 @@ export class AuthService {
       // happens immediately after this call. Log loudly so the gap is
       // detectable.
       this.log.error({ err: String(err) }, 'oidc_refusal_audit_write_failed');
+    }
+  }
+
+  /**
+   * #91 — symmetric success-path audit for OIDC logins. Same shape
+   * as `recordOidcRefusal` (cluster-wide, own-transaction, audit-
+   * write failure does not block the auth chain) so the two surfaces
+   * read consistently in the audit log.
+   *
+   * `actorUserId` is populated post-resolution because we know the
+   * userId at this point — the refusal sibling can't because the
+   * refusal happens BEFORE user resolution.
+   */
+  private async recordOidcLogin(
+    provider: 'google' | 'microsoft',
+    userInfo: OidcUserInfo,
+    normalisedEmail: string,
+    userId: string,
+    pathTaken: 'existing_identity' | 'email_link' | 'new_user',
+    viaHdOverride: boolean,
+    context: { ipAddress?: string | null; userAgent?: string | null },
+  ): Promise<void> {
+    try {
+      await this.audit.record({
+        action: PanoramaAuditAction.AuthOidcLogin,
+        resourceType: 'auth_identity',
+        resourceId: null,
+        tenantId: null,
+        actorUserId: userId,
+        ipAddress: context.ipAddress ?? null,
+        userAgent: context.userAgent ?? null,
+        metadata: {
+          provider,
+          pathTaken,
+          viaHdOverride,
+          emailDomain: emailDomain(normalisedEmail),
+          hd: userInfo.hd,
+          subjectHash: hashSubject(provider, userInfo.subject),
+          iss: userInfo.iss,
+        },
+      });
+    } catch (err) {
+      // Symmetric to refusal handling: audit-log failure logs error
+      // but does not block the auth flow — the user-create / identity-
+      // link writes already committed in the prior runAsSuperAdmin tx.
+      this.log.error({ err: String(err) }, 'oidc_login_audit_write_failed');
     }
   }
 

--- a/apps/core-api/test/auth-oidc-email-verification.test.ts
+++ b/apps/core-api/test/auth-oidc-email-verification.test.ts
@@ -403,3 +403,218 @@ describe('AuthService.loginWithOidc — hd-override account-link refusal (B3)', 
     expect(create).toHaveBeenCalledOnce();
   });
 });
+
+describe('AuthService.loginWithOidc — success-path audit (#91)', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('emits panorama.auth.oidc_login on new-user create (strict mode)', async () => {
+    const { svc, runAsSuperAdmin, auditRecord } = makeService();
+    // First runAsSuperAdmin = find-or-create resolution (returns ok+new_user).
+    runAsSuperAdmin.mockImplementationOnce(async (fn: any) => {
+      const tx = {
+        authIdentity: {
+          findUnique: vi.fn(async () => null),
+          create: vi.fn(),
+          update: vi.fn(),
+        },
+        user: {
+          findUnique: vi.fn(async () => null),
+          create: vi.fn(async () => ({
+            id: 'new-user-id-42',
+            email: 'alice@acme.example',
+            displayName: 'Alice Driver',
+          })),
+        },
+      };
+      return fn(tx);
+    });
+    // Second runAsSuperAdmin = buildSessionForUser; stop here so the
+    // oidc_login audit emission is the last observable side effect.
+    runAsSuperAdmin.mockRejectedValueOnce(new Error('stop_after_login_audit'));
+
+    await expect(
+      svc.loginWithOidc('google', makeUserInfo({ emailVerified: true })),
+    ).rejects.toThrow('stop_after_login_audit');
+
+    expect(auditRecord).toHaveBeenCalledOnce();
+    expect(lastAuditEvent(auditRecord)).toMatchObject({
+      action: 'panorama.auth.oidc_login',
+      actorUserId: 'new-user-id-42',
+      tenantId: null,
+      resourceType: 'auth_identity',
+    });
+    expect(lastAuditMetadata(auditRecord)).toMatchObject({
+      provider: 'google',
+      pathTaken: 'new_user',
+      viaHdOverride: false,
+      emailDomain: 'acme.example',
+    });
+  });
+
+  it('emits oidc_login with pathTaken=existing_identity on returning user', async () => {
+    const { svc, runAsSuperAdmin, auditRecord } = makeService();
+    runAsSuperAdmin.mockImplementationOnce(async (fn: any) => {
+      const tx = {
+        authIdentity: {
+          findUnique: vi.fn(async () => ({
+            id: 'existing-identity-id',
+            userId: 'returning-user-id',
+          })),
+          create: vi.fn(),
+          update: vi.fn(),
+        },
+        user: { findUnique: vi.fn(), create: vi.fn() },
+      };
+      return fn(tx);
+    });
+    runAsSuperAdmin.mockRejectedValueOnce(new Error('stop_after_login_audit'));
+
+    await expect(
+      svc.loginWithOidc('google', makeUserInfo({ emailVerified: true })),
+    ).rejects.toThrow('stop_after_login_audit');
+
+    expect(lastAuditMetadata(auditRecord)).toMatchObject({
+      pathTaken: 'existing_identity',
+      viaHdOverride: false,
+    });
+  });
+
+  it('emits oidc_login with viaHdOverride=true on hd-override new-user path', async () => {
+    const { svc, runAsSuperAdmin, auditRecord } = makeService({
+      OIDC_GOOGLE_TRUSTED_HD_DOMAINS: 'acme.example',
+    });
+    runAsSuperAdmin.mockImplementationOnce(async (fn: any) => {
+      const tx = {
+        authIdentity: {
+          findUnique: vi.fn(async () => null),
+          create: vi.fn(),
+          update: vi.fn(),
+        },
+        user: {
+          findUnique: vi.fn(async () => null),
+          create: vi.fn(async () => ({
+            id: 'workspace-user-id',
+            email: 'alice@acme.example',
+            displayName: 'Alice Driver',
+          })),
+        },
+      };
+      return fn(tx);
+    });
+    runAsSuperAdmin.mockRejectedValueOnce(new Error('stop_after_login_audit'));
+
+    await expect(
+      svc.loginWithOidc(
+        'google',
+        makeUserInfo({
+          email: 'alice@acme.example',
+          emailVerified: false,
+          hd: 'acme.example',
+        }),
+      ),
+    ).rejects.toThrow('stop_after_login_audit');
+
+    expect(lastAuditEvent(auditRecord)).toMatchObject({
+      action: 'panorama.auth.oidc_login',
+      actorUserId: 'workspace-user-id',
+    });
+    expect(lastAuditMetadata(auditRecord)).toMatchObject({
+      pathTaken: 'new_user',
+      viaHdOverride: true,
+      hd: 'acme.example',
+    });
+  });
+
+  it('audit-write failure on success path does NOT mask the resolution', async () => {
+    // Symmetric to the refusal handling: the user-create / identity-link
+    // already committed in runAsSuperAdmin. Audit failure logs at error
+    // but doesn't undo the auth.
+    const { svc, runAsSuperAdmin, auditRecord } = makeService();
+    runAsSuperAdmin.mockImplementationOnce(async (fn: any) => {
+      const tx = {
+        authIdentity: {
+          findUnique: vi.fn(async () => null),
+          create: vi.fn(),
+          update: vi.fn(),
+        },
+        user: {
+          findUnique: vi.fn(async () => null),
+          create: vi.fn(async () => ({
+            id: 'audit-fail-user-id',
+            email: 'alice@acme.example',
+            displayName: 'Alice Driver',
+          })),
+        },
+      };
+      return fn(tx);
+    });
+    auditRecord.mockRejectedValueOnce(new Error('audit_db_unreachable'));
+    runAsSuperAdmin.mockRejectedValueOnce(new Error('stop_after_login_audit'));
+
+    await expect(
+      svc.loginWithOidc('google', makeUserInfo({ emailVerified: true })),
+    ).rejects.toThrow('stop_after_login_audit');
+    // Confirms the buildSessionForUser path was reached (= audit
+    // failure didn't short-circuit the flow).
+    expect(auditRecord).toHaveBeenCalledOnce();
+  });
+});
+
+describe('AuthConfigService — OIDC_GOOGLE_TRUSTED_HD_DOMAINS validation (#89)', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('SESSION_SECRET', 'a'.repeat(32));
+    vi.stubEnv('OIDC_GOOGLE_CLIENT_ID', 'fake-google-id');
+    vi.stubEnv('OIDC_GOOGLE_CLIENT_SECRET', 'fake-google-secret');
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function trustedDomains(envValue: string | undefined): string[] {
+    if (envValue === undefined) {
+      vi.stubEnv('OIDC_GOOGLE_TRUSTED_HD_DOMAINS', '');
+    } else {
+      vi.stubEnv('OIDC_GOOGLE_TRUSTED_HD_DOMAINS', envValue);
+    }
+    const cfg = new AuthConfigService();
+    return cfg.config.providers.google?.trustedHdDomains ?? [];
+  }
+
+  it('accepts valid multi-label domains (lowercased + trimmed)', () => {
+    expect(trustedDomains('acme.example, beta.example, foo.bar.example.com')).toEqual([
+      'acme.example',
+      'beta.example',
+      'foo.bar.example.com',
+    ]);
+  });
+
+  it('lowercases mixed-case entries', () => {
+    expect(trustedDomains('Acme.Example')).toEqual(['acme.example']);
+  });
+
+  it('rejects wildcard, path, port, IP, single-label, and empty entries', () => {
+    // Each malformed entry filters out silently in the parsed list;
+    // the warn log lands via the Logger (not asserted at unit level).
+    // Surviving entries: only the valid one.
+    expect(
+      trustedDomains(
+        '*.example, acme.example/foo, 127.0.0.1, localhost, acme.example, ' +
+          ' , -bad.example, bad-.example',
+      ),
+    ).toEqual(['acme.example']);
+  });
+
+  it('rejects entries with double dots / leading dots', () => {
+    expect(trustedDomains('..acme.example, .acme.example, acme..example')).toEqual([]);
+  });
+
+  it('returns empty when env var is absent', () => {
+    expect(trustedDomains(undefined)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Three follow-ups from PR #88's review (#28 SEC-01) bundled because
they're tightly related and all S effort.

| # | Closes | Surface |
|---|---|---|
| #89 | DNS-label validation on `OIDC_GOOGLE_TRUSTED_HD_DOMAINS` | `auth.config.ts` |
| #90 | Typed `panorama.auth.*` audit-action registry | new `audit-actions.ts` |
| #91 | Symmetric `panorama.auth.oidc_login` success audit | `auth.service.ts` |

## #89 — silent fail-closed → loud-at-boot

Pre-this PR, malformed entries (`*.example`, `acme/foo`,
`127.0.0.1`) survived `parseDomainList` and would never match
real Workspace `hd` claims. Now: regex + `/[a-z]/` IP-literal
exclusion + `auth_config_invalid_domain_entry_ignored` warn-log
per rejected entry.

The two-stage check admits IDN A-labels (`xn--…` punycode) — that's
correct because Workspace `hd` claims arrive in punycode form.

## #90 — registry as pattern, not flag day

New `audit-actions.ts` with `PanoramaAuditAction` typed const.
Initial seed: `AuthOidcRefused` + `AuthOidcLogin`. Other domains
keep string literals at call sites; the registry is the migration
target as call sites get touched.

Per security-reviewer's note: fully closing the 61-action surface
needs an `eslint no-restricted-syntax` rule banning bare `'panorama.…'`
literals. Filed as sibling cleanup; not in scope here.

## #91 — symmetric success audit

`recordOidcLogin` private helper, called after the find-or-create
resolution. Metadata: `provider`, `pathTaken`
(existing_identity / email_link / new_user), `viaHdOverride`,
`emailDomain`, `hd`, `subjectHash`, `iss`. `actorUserId` populated
post-resolution. Cluster-wide (`tenantId=null`) per the existing
`oidc_refused` shape.

Audit-write failure on success path logs at error but doesn't block
auth — intentionally asymmetric to refusal: refusal that fails to
audit still refuses; success that fails to audit still succeeds.
Fail-closed-on-audit-infra-outage would lock authenticated users
out under transient DB hiccups (worse than a missed row).

## Reviews

**security-reviewer**: APPROVE-WITH-NITS. Threat model + PII surface
confirmed clean; nits (JSDoc tightening + NULL-strand visibility
note + tx-ordering comment phrasing) all folded in pre-push.

## Test plan

- [x] 9 new tests (15 → 24 in auth-oidc-email-verification.test.ts):
  - 4 success-path audit tests
  - 5 domain-validation tests
- [x] Backend: **406/406** (was 397; +9 net)
- [x] `pnpm lint` — 7/7 packages green
- [x] `pnpm rls:allowlist-check` — 29/12 unchanged