### PR TITLE
feat(notification): compile-time eventType + plugin-sdk ↔ registry sync (#59 + #61)

### DIFF
--- a/apps/core-api/src/modules/notification/notification.service.ts
+++ b/apps/core-api/src/modules/notification/notification.service.ts
@@ -4,6 +4,7 @@ import { AuditService } from '../audit/audit.service.js';
 import {
   NOTIFICATION_PAYLOAD_SCHEMAS,
   isRegisteredEventType,
+  type NotificationEventType,
 } from './notification-events.schema.js';
 
 /**
@@ -29,8 +30,15 @@ import {
 const SENSITIVE_FIELD_RE = /token|secret|password|authorization/i;
 const REDACTED = '<redacted>';
 
+/**
+ * Public emit-side input for `enqueueWithin`. `eventType` is a
+ * union of registered keys (#61) — a typo or unregistered name now
+ * fails at compile time instead of waiting for the runtime
+ * `unknown_event_type` audit. The runtime check stays as
+ * defence-in-depth against escape hatches like `as` casts.
+ */
 export interface NotificationEventInput {
-  eventType: string;
+  eventType: NotificationEventType;
   tenantId?: string | null;
   payload: Record<string, unknown>;
   dedupKey?: string;
@@ -59,7 +67,16 @@ export class NotificationService {
     // back, so audit.recordWithin would roll back with it and the
     // signal would disappear. The audit for "your domain write
     // tried to enqueue a bogus event" MUST survive the rollback.
+    //
+    // #61 narrowed `event.eventType` to the registered union at the
+    // type level, so the typecheck-side compile-time view of this
+    // branch is `never` — but the runtime check stays as
+    // defence-in-depth against `as` casts that bypass the
+    // type-system gate at the call site. The `string` cast on the
+    // metadata + throw template is the explicit acknowledgement
+    // that, at runtime, the value can be any string.
     if (!isRegisteredEventType(event.eventType)) {
+      const rawEventType = event.eventType as string;
       await this.audit.record({
         action: 'panorama.notification.payload_rejected',
         resourceType: 'notification_event',
@@ -68,10 +85,10 @@ export class NotificationService {
         actorUserId: null,
         metadata: {
           reason: 'unknown_event_type',
-          eventType: event.eventType,
+          eventType: rawEventType,
         },
       });
-      throw new Error(`unknown_event_type:${event.eventType}`);
+      throw new Error(`unknown_event_type:${rawEventType}`);
     }
 
     const schema = NOTIFICATION_PAYLOAD_SCHEMAS[event.eventType];

--- a/apps/core-api/test/notification-bus.integration.test.ts
+++ b/apps/core-api/test/notification-bus.integration.test.ts
@@ -166,11 +166,15 @@ describe('notification bus integration', () => {
   // ---- enqueueWithin: validation paths --------------------------
 
   it('unknown eventType → throws + emits panorama.notification.payload_rejected', async () => {
+    // #61 — `eventType` is now typed to the registered union at the
+    // call site, so this path can only be reached via an `as` cast
+    // (untrusted input or test escape hatch). The runtime check
+    // stays as defence-in-depth against exactly that.
     await expect(
       prisma.runAsSuperAdmin(
         (tx) =>
           notifications.enqueueWithin(tx, {
-            eventType: 'not.a.real.type',
+            eventType: 'not.a.real.type' as never,
             tenantId,
             payload: {},
           }),

--- a/apps/core-api/test/notification-event-registry-sync.test.ts
+++ b/apps/core-api/test/notification-event-registry-sync.test.ts
@@ -1,0 +1,34 @@
+import 'reflect-metadata';
+import { describe, it, expect } from 'vitest';
+import { PANORAMA_EVENT_NAMES } from '@panorama/plugin-sdk';
+import { NOTIFICATION_PAYLOAD_SCHEMAS } from '../src/modules/notification/notification-events.schema.js';
+
+/**
+ * Sync gate (#59 follow-up). The plugin SDK's
+ * `PanoramaEventName` / `PANORAMA_EVENT_NAMES` is the public-facing
+ * list of events plugins can subscribe to. The notification bus's
+ * `NOTIFICATION_PAYLOAD_SCHEMAS` is the runtime registry —
+ * unregistered events are rejected at enqueue time, so any name in
+ * the SDK's list that isn't in the schemas is a guaranteed
+ * plugin-author footgun (the typecheck is happy but the event
+ * never fires).
+ *
+ * Pre-#59 the SDK shipped 7 entries; only 2 were wired through the
+ * bus. This test fails loud if a future contributor adds an event
+ * to one surface without adding it to the other.
+ */
+describe('notification event registry — plugin-sdk ↔ bus sync (#59)', () => {
+  it('every PanoramaEventName has a registered Zod schema', () => {
+    const registered = new Set(Object.keys(NOTIFICATION_PAYLOAD_SCHEMAS));
+    const sdkNames = [...PANORAMA_EVENT_NAMES];
+    const orphans = sdkNames.filter((n) => !registered.has(n));
+    expect(orphans).toEqual([]);
+  });
+
+  it('every registered schema has a PanoramaEventName entry', () => {
+    const sdkSet = new Set<string>(PANORAMA_EVENT_NAMES);
+    const registered = Object.keys(NOTIFICATION_PAYLOAD_SCHEMAS);
+    const ghosts = registered.filter((n) => !sdkSet.has(n));
+    expect(ghosts).toEqual([]);
+  });
+});

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -10,14 +10,37 @@
  * deprecation cycle per semantic versioning of @panorama/plugin-sdk.
  */
 
-export type PanoramaEventName =
-  | 'panorama.asset.checked_out'
-  | 'panorama.asset.checked_in'
-  | 'panorama.reservation.created'
-  | 'panorama.reservation.approved'
-  | 'panorama.reservation.rejected'
-  | 'panorama.reservation.missed'
-  | 'panorama.maintenance.flagged';
+/**
+ * Events plugins can subscribe to. **MUST stay in sync** with
+ * `NOTIFICATION_PAYLOAD_SCHEMAS` in
+ * `apps/core-api/src/modules/notification/notification-events.schema.ts`
+ * — the runtime registry is the source of truth for which events are
+ * actually deliverable through the bus.
+ *
+ * Drift between this list and the registry is a guaranteed plugin-author
+ * footgun: authors get a happy typecheck for an event that will never
+ * fire. The CI check at
+ * `apps/core-api/test/notification-bus.integration.test.ts`
+ * (#59 sync test) asserts the two lists match.
+ *
+ * Pre-#59 this list had 4 ghost events (`asset.checked_out`,
+ * `asset.checked_in`, `reservation.missed`, `maintenance.flagged`) +
+ * 1 audit-only event (`reservation.created`) that never entered the
+ * bus. Plugin authors who keyed on those would never see them fire.
+ */
+/**
+ * Runtime enumeration of plugin-subscribable events. Tests + tooling
+ * iterate this; the type alias below is `(typeof PANORAMA_EVENT_NAMES)[number]`
+ * so the two surfaces can't drift.
+ */
+export const PANORAMA_EVENT_NAMES = [
+  'panorama.reservation.approved',
+  'panorama.reservation.rejected',
+  'panorama.reservation.checked_in_with_damage',
+  'panorama.inspection.completed',
+] as const;
+
+export type PanoramaEventName = (typeof PANORAMA_EVENT_NAMES)[number];
 
 export interface PanoramaEvent<T = unknown> {
   name: PanoramaEventName;


### PR DESCRIPTION
## Summary

Two NOTIF-bus follow-ups bundled because they share the runtime
registry as source of truth.

## #61 NOTIF-07 — compile-time check on enqueue

`NotificationEventInput.eventType` was `string`. A typo or
unregistered name failed at runtime via the
\`panorama.notification.payload_rejected\` audit + throw — defence-
in-depth that worked but only post-hit. Now typed to
\`NotificationEventType\` (the union of registered keys); typos
fail at `tsc` time. Runtime check stays as belt-and-braces against
`as`-cast escape hatches.

## #59 NOTIF-02 — drop plugin-sdk ghost events + sync test

Pre-this PR `packages/plugin-sdk` shipped 7 events; only 2 were
wired through the bus. Plugin authors keying on a ghost event got
a happy typecheck and zero delivery. Now:

- `PanoramaEventName` lists exactly the 4 events the bus actually
  delivers (reservation.approved/rejected, inspection.completed,
  reservation.checked_in_with_damage)
- New `PANORAMA_EVENT_NAMES` const for runtime iteration; the type
  alias is `(typeof PANORAMA_EVENT_NAMES)[number]` so the two
  surfaces can't drift internally
- New cross-package sync test
  (\`notification-event-registry-sync.test.ts\`) fails loud if a
  future contributor adds to one surface without the other

## Test plan

- [x] Backend: **408/408** (was 406; +2 sync tests)
- [x] `pnpm lint` — 7/7 packages green
- [x] `pnpm --filter @panorama/plugin-sdk build` — clean

## Out of scope

#60 NOTIF-04 (content-expansion: damage alerts / invitation bounces /
reservation reminders / SLA / maintenance schemas) stays open as a
separate scoped follow-up.