### PR TITLE
chore(deps): bump pino 9 → 10 + drop unused pino dep from core-api (#123)

### DIFF
--- a/apps/core-api/package.json
+++ b/apps/core-api/package.json
@@ -47,7 +47,6 @@
     "nestjs-i18n": "^10.8.1",
     "nodemailer": "^8.0.5",
     "openid-client": "^5.7.1",
-    "pino": "^9.5.0",
     "prisma": "5.22.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/packages/migrator/package.json
+++ b/packages/migrator/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@panorama/shared": "workspace:*",
     "commander": "^14.0.3",
-    "pino": "^9.5.0",
+    "pino": "^10.3.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,9 +120,6 @@ importers:
       openid-client:
         specifier: ^5.7.1
         version: 5.7.1
-      pino:
-        specifier: ^9.5.0
-        version: 9.14.0
       prisma:
         specifier: 5.22.0
         version: 5.22.0
@@ -239,8 +236,8 @@ importers:
         specifier: ^14.0.3
         version: 14.0.3
       pino:
-        specifier: ^9.5.0
-        version: 9.14.0
+        specifier: ^10.3.1
+        version: 10.3.1
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -4502,14 +4499,14 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  pino-abstract-transport@2.0.0:
-    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
 
   pino-std-serializers@7.1.0:
     resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
 
-  pino@9.14.0:
-    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
 
   playwright-core@1.59.1:
@@ -5023,8 +5020,9 @@ packages:
     resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
     engines: {node: '>=18'}
 
-  thread-stream@3.1.0:
-    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -10294,25 +10292,25 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  pino-abstract-transport@2.0.0:
+  pino-abstract-transport@3.0.0:
     dependencies:
       split2: 4.2.0
 
   pino-std-serializers@7.1.0: {}
 
-  pino@9.14.0:
+  pino@10.3.1:
     dependencies:
       '@pinojs/redact': 0.4.0
       atomic-sleep: 1.0.0
       on-exit-leak-free: 2.1.2
-      pino-abstract-transport: 2.0.0
+      pino-abstract-transport: 3.0.0
       pino-std-serializers: 7.1.0
       process-warning: 5.0.0
       quick-format-unescaped: 4.0.4
       real-require: 0.2.0
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
-      thread-stream: 3.1.0
+      thread-stream: 4.0.0
 
   playwright-core@1.59.1:
     optional: true
@@ -10916,7 +10914,7 @@ snapshots:
       glob: 10.5.0
       minimatch: 10.2.5
 
-  thread-stream@3.1.0:
+  thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
 


### PR DESCRIPTION
## Summary

Lowest-risk row from #123 umbrella. Pino has a small surface (3
import sites in `@panorama/migrator`; nothing in core-api or web).
Pino 10's breaking changes are around the transport API + a
handful of deprecated config keys per the v10 changelog — neither
path is exercised in this codebase. Migrator's usage is the basic
factory shape, unchanged across the major.

## What changed

- `apps/core-api/package.json` — dropped unused `"pino": "^9.5.0"`
  (no imports anywhere in core-api; carried since 0.1).
- `packages/migrator/package.json` — `^9.5.0` → `^10.3.1`.
- Lockfile reflects the dedup.

## Test plan

- [x] `pnpm --filter @panorama/migrator build` — clean
- [x] `pnpm --filter @panorama/migrator test` — 6/6 (the SnipeIt
      client tests use migrator's pino logger)
- [x] `pnpm --filter @panorama/core-api test` — **408/408**
- [x] `pnpm lint` — 7/7 packages green