### PR TITLE
chore(deps): clear 3 pre-existing CJS/ESM typecheck errors (#123 prep)

### DIFF
--- a/apps/core-api/src/modules/photo-pipeline/photo-pipeline.service.ts
+++ b/apps/core-api/src/modules/photo-pipeline/photo-pipeline.service.ts
@@ -7,7 +7,11 @@ import sharp from 'sharp';
 // resolves to the ESM exports lazily. The cost is one async hop on
 // the first call inside `process()`; the import is cached after.
 // The static type-only import below preserves the type signature.
-import type { fileTypeFromBuffer as fileTypeFromBufferType } from 'file-type';
+// `with { 'resolution-mode': 'import' }` tells TS to resolve the
+// type as if from an ESM context, which is required because the
+// surrounding file is CJS but file-type ships ESM-only `.d.ts`.
+// The runtime side uses `await import('file-type')` above.
+import type { fileTypeFromBuffer as fileTypeFromBufferType } from 'file-type' with { 'resolution-mode': 'import' };
 let fileTypeFromBuffer: typeof fileTypeFromBufferType | undefined;
 async function loadFileType(): Promise<typeof fileTypeFromBufferType> {
   if (!fileTypeFromBuffer) {

--- a/packages/migrator/package.json
+++ b/packages/migrator/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "description": "CLI that reads Snipe-IT (API) + SnipeScheduler-FleetManager (MySQL dump) and produces Panorama fixtures.",
   "license": "AGPL-3.0-or-later",
-  "type": "module",
   "main": "dist/index.js",
   "bin": {
     "panorama-migrate": "./dist/cli.js"
@@ -13,7 +12,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "dev": "tsx src/cli.ts",
     "cli": "tsx src/cli.ts",
     "test": "vitest run",

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,14 +1,16 @@
 {
   "name": "@panorama/plugin-sdk",
   "version": "0.0.0",
-  "description": "Panorama plugin SDK — typed event contract (types-only at 0.3 per ADR-0006).",
+  "description": "Panorama plugin SDK \u2014 typed event contract (types-only at 0.3 per ADR-0006).",
   "license": "AGPL-3.0-or-later",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "build": "tsc",
-    "test": "echo 'plugin-sdk — runtime + tests land with first plugin in 0.4'",
+    "build": "tsc -b",
+    "test": "echo 'plugin-sdk \u2014 runtime + tests land with first plugin in 0.4'",
     "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "clean": "rimraf dist"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,13 +4,14 @@
   "private": true,
   "description": "Shared domain types, DTOs, Zod schemas used across core-api and frontends.",
   "license": "AGPL-3.0-or-later",
-  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "build": "tsc",
-    "test": "echo 'shared — types only, no runtime tests yet'",
+    "build": "tsc -b",
+    "test": "echo 'shared \u2014 types only, no runtime tests yet'",
     "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "clean": "rimraf dist"

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -7,10 +7,12 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
-    "build": "tsc",
-    "test": "echo 'ui-kit — scaffold only, first components land in 0.2'",
+    "build": "tsc -b",
+    "test": "echo 'ui-kit \u2014 scaffold only, first components land in 0.2'",
     "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "clean": "rimraf dist"


### PR DESCRIPTION
## Summary

The three errors documented in every handoff since 0.3 prep:

```
src/modules/import/import.service.ts(15,8)
  TS1479 — '@panorama/shared' resolves as ESM, current file is CJS
src/modules/photo-pipeline/photo-pipeline.service.ts(10,67)
  TS1541 — type-only import of ESM file-type from CJS context
test/import-roundtrip.e2e.test.ts(9,28)
  TS1479 — '@panorama/migrator' resolves as ESM, current file is CJS
```

All cleared. core-api now typechecks with **zero errors** — first
time since the 0.3 prep series. Unblocks the TypeScript 6 row of
#123 (the umbrella's sequencing recommendation calls this PR out
explicitly: "First — TypeScript 6 (after fixing the 3 pre-existing
CJS/ESM errors)").

## What changed

- `packages/shared/package.json` — dropped `"type": "module"`. The
  package's tsconfig comment already said "Emit CommonJS so
  consumers can require this package without needing type: module";
  the field was inconsistent with that. Now NodeNext + no type
  field = CJS emit.
- `packages/migrator/package.json` — same fix.
- `packages/{shared,migrator,plugin-sdk,ui-kit}/package.json` —
  build script `tsc` → `tsc -b`. With `composite: true` from the
  base tsconfig, plain `tsc` is a silent no-op (project is a
  buildable unit; `-b` required to emit). Earlier builds appeared
  to work because dist artifacts persisted from prior runs; a
  fresh checkout would have failed.
- `apps/core-api/src/modules/photo-pipeline/photo-pipeline.service.ts:10`
  — added `with { 'resolution-mode': 'import' }` on the `file-type`
  type-only import (file-type@21 is ESM-only).

## Test plan

- [x] `tsc --noEmit` — **0 errors** (was 3)
- [x] Backend: **408/408**
- [x] `pnpm lint` — 7/7 green
- [x] Workspace packages rebuild from clean state