### PR TITLE
chore(deps): openid-client 5 → 6 (#123)

### DIFF
--- a/apps/core-api/package.json
+++ b/apps/core-api/package.json
@@ -46,7 +46,7 @@
     "iron-session": "^8.0.4",
     "nestjs-i18n": "^10.8.4",
     "nodemailer": "^8.0.7",
-    "openid-client": "^5.7.1",
+    "openid-client": "^6.8.4",
     "prisma": "5.22.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/apps/core-api/src/modules/auth/oidc.service.ts
+++ b/apps/core-api/src/modules/auth/oidc.service.ts
@@ -1,5 +1,49 @@
 import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
-import { generators, Issuer, type Client } from 'openid-client';
+// `openid-client` is ESM-only since v6 (no CJS export). Static `import`
+// from our compiled CJS module would fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`
+// at runtime. Dynamic import works in CJS via Node's interop and resolves
+// to the ESM exports lazily; cached after first use. The type-only static
+// import below uses `with { 'resolution-mode': 'import' }` so TS resolves
+// the types as if from an ESM context (required because the surrounding
+// file is CJS but openid-client ships ESM-only `.d.ts`).
+// Same shape as photo-pipeline's `file-type` shim landed in #163.
+import type {
+  authorizationCodeGrant as authorizationCodeGrantType,
+  buildAuthorizationUrl as buildAuthorizationUrlType,
+  calculatePKCECodeChallenge as calculatePKCECodeChallengeType,
+  Configuration,
+  discovery as discoveryType,
+  randomNonce as randomNonceType,
+  randomPKCECodeVerifier as randomPKCECodeVerifierType,
+  randomState as randomStateType,
+} from 'openid-client' with { 'resolution-mode': 'import' };
+
+interface OidcModule {
+  authorizationCodeGrant: typeof authorizationCodeGrantType;
+  buildAuthorizationUrl: typeof buildAuthorizationUrlType;
+  calculatePKCECodeChallenge: typeof calculatePKCECodeChallengeType;
+  discovery: typeof discoveryType;
+  randomNonce: typeof randomNonceType;
+  randomPKCECodeVerifier: typeof randomPKCECodeVerifierType;
+  randomState: typeof randomStateType;
+}
+
+let oidcModule: OidcModule | undefined;
+async function loadOidc(): Promise<OidcModule> {
+  if (!oidcModule) {
+    const mod = await import('openid-client');
+    oidcModule = {
+      authorizationCodeGrant: mod.authorizationCodeGrant,
+      buildAuthorizationUrl: mod.buildAuthorizationUrl,
+      calculatePKCECodeChallenge: mod.calculatePKCECodeChallenge,
+      discovery: mod.discovery,
+      randomNonce: mod.randomNonce,
+      randomPKCECodeVerifier: mod.randomPKCECodeVerifier,
+      randomState: mod.randomState,
+    };
+  }
+  return oidcModule;
+}
 import { AuthConfigService, type OidcProviderConfig } from './auth.config.js';
 
 export interface OidcStartParams {
@@ -50,9 +94,9 @@ export interface OidcUserInfo {
 }
 
 /**
- * Thin wrapper around `openid-client` (v5) that:
+ * Thin wrapper around `openid-client` (v6) that:
  *   * Discovers the IdP's metadata from its issuer URL on first use
- *   * Caches the resulting Client so subsequent calls don't re-discover
+ *   * Caches the resulting Configuration so subsequent calls don't re-discover
  *   * Implements PKCE + nonce for every flow (no implicit grant, no plain)
  *
  * Controllers call `start()` to get an authorise URL + the state/verifier
@@ -62,7 +106,7 @@ export interface OidcUserInfo {
 @Injectable()
 export class OidcService {
   private readonly log = new Logger('OidcService');
-  private readonly clientsCache = new Map<string, Promise<Client>>();
+  private readonly configCache = new Map<string, Promise<Configuration>>();
 
   constructor(private readonly cfg: AuthConfigService) {}
 
@@ -70,40 +114,48 @@ export class OidcService {
     return `${this.cfg.config.baseUrl}/auth/oidc/${provider}/callback`;
   }
 
-  private async client(provider: 'google' | 'microsoft'): Promise<Client> {
+  private async config(provider: 'google' | 'microsoft'): Promise<Configuration> {
     const cfg = this.cfg.config.providers[provider];
     if (!cfg) throw new Error(`OIDC provider "${provider}" not configured`);
-    if (!this.clientsCache.has(provider)) {
-      this.clientsCache.set(provider, this.buildClient(provider, cfg));
+    if (!this.configCache.has(provider)) {
+      this.configCache.set(provider, this.buildConfig(provider, cfg));
     }
-    return this.clientsCache.get(provider)!;
+    return this.configCache.get(provider)!;
   }
 
-  private async buildClient(
+  private async buildConfig(
     provider: 'google' | 'microsoft',
     cfg: OidcProviderConfig,
-  ): Promise<Client> {
-    const issuer = await Issuer.discover(cfg.issuer);
-    this.log.log({ provider, issuer: issuer.metadata.issuer }, 'oidc_client_ready');
-    return new issuer.Client({
-      client_id: cfg.clientId,
-      client_secret: cfg.clientSecret,
-      redirect_uris: [this.redirectUri(provider)],
-      response_types: ['code'],
-    });
+  ): Promise<Configuration> {
+    const { discovery } = await loadOidc();
+    const config = await discovery(new URL(cfg.issuer), cfg.clientId, cfg.clientSecret);
+    this.log.log(
+      { provider, issuer: config.serverMetadata().issuer },
+      'oidc_client_ready',
+    );
+    return config;
   }
 
   async start(params: OidcStartParams): Promise<OidcStartResult> {
-    const client = await this.client(params.provider);
-    const state = generators.state();
-    const nonce = generators.nonce();
-    const codeVerifier = generators.codeVerifier();
-    const codeChallenge = generators.codeChallenge(codeVerifier);
+    const {
+      buildAuthorizationUrl,
+      calculatePKCECodeChallenge,
+      randomNonce,
+      randomPKCECodeVerifier,
+      randomState,
+    } = await loadOidc();
+
+    const config = await this.config(params.provider);
+    const state = randomState();
+    const nonce = randomNonce();
+    const codeVerifier = randomPKCECodeVerifier();
+    const codeChallenge = await calculatePKCECodeChallenge(codeVerifier);
     const providerCfg = this.cfg.config.providers[params.provider]!;
 
     const scopes = ['openid', 'email', 'profile', ...(providerCfg.extraScopes ?? [])];
 
-    const url = client.authorizationUrl({
+    const url = buildAuthorizationUrl(config, {
+      redirect_uri: this.redirectUri(params.provider),
       scope: scopes.join(' '),
       state,
       nonce,
@@ -113,25 +165,41 @@ export class OidcService {
       ...(params.tenantHint ? { login_hint: params.tenantHint } : {}),
     });
 
-    return { url, state, codeVerifier, nonce };
+    return { url: url.href, state, codeVerifier, nonce };
   }
 
   async callback(params: OidcCallbackParams): Promise<OidcUserInfo> {
-    const client = await this.client(params.provider);
+    const { authorizationCodeGrant } = await loadOidc();
+    const config = await this.config(params.provider);
+
+    // v6 takes the inbound URL (with code+state in the query string) and
+    // validates state internally. Reconstruct it from the redirect URI
+    // we registered + the params the controller extracted.
+    const currentUrl = new URL(this.redirectUri(params.provider));
+    currentUrl.searchParams.set('code', params.code);
+    currentUrl.searchParams.set('state', params.state);
+
     let tokens;
     try {
-      tokens = await client.callback(
-        this.redirectUri(params.provider),
-        { code: params.code, state: params.state },
-        { state: params.expectedState, nonce: params.expectedNonce, code_verifier: params.codeVerifier },
-      );
+      tokens = await authorizationCodeGrant(config, currentUrl, {
+        expectedState: params.expectedState,
+        expectedNonce: params.expectedNonce,
+        pkceCodeVerifier: params.codeVerifier,
+      });
     } catch (err) {
       this.log.warn({ err: String(err), provider: params.provider }, 'oidc_callback_failed');
       throw new UnauthorizedException('oidc_exchange_failed');
     }
 
     const claims = tokens.claims();
-    if (!claims.email) throw new UnauthorizedException('oidc_missing_email');
+    if (!claims) throw new UnauthorizedException('oidc_missing_id_token');
+    // `email` claim is `JsonValue | undefined` in v6's type. Narrow to a
+    // non-empty string explicitly — anything else (number, array, object)
+    // means the IdP is misconfigured and we'd otherwise stringify garbage.
+    const rawEmail = claims['email'];
+    if (typeof rawEmail !== 'string' || rawEmail.length === 0) {
+      throw new UnauthorizedException('oidc_missing_email');
+    }
     // `sub` is mandatory per RFC 7519. If it's missing or non-string,
     // the (provider, subject) tuple we use as the strongest identity
     // key would degrade to `(provider, 'undefined')` and start
@@ -148,10 +216,10 @@ export class OidcService {
 
     return {
       subject: claims.sub,
-      email: String(claims.email).toLowerCase().trim(),
-      firstName: (claims['given_name']) ?? null,
-      lastName: (claims['family_name']) ?? null,
-      displayName: (claims['name']) ?? null,
+      email: rawEmail.toLowerCase().trim(),
+      firstName: typeof claims['given_name'] === 'string' ? claims['given_name'] : null,
+      lastName: typeof claims['family_name'] === 'string' ? claims['family_name'] : null,
+      displayName: typeof claims['name'] === 'string' ? claims['name'] : null,
       emailVerified: claims['email_verified'] === true,
       hd,
       iss: typeof claims.iss === 'string' && claims.iss.length > 0 ? claims.iss : null,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
         specifier: ^8.0.7
         version: 8.0.7
       openid-client:
-        specifier: ^5.7.1
-        version: 5.7.1
+        specifier: ^6.8.4
+        version: 6.8.4
       prisma:
         specifier: 5.22.0
         version: 5.22.0
@@ -3806,8 +3806,8 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
 
-  jose@4.15.9:
-    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -3952,10 +3952,6 @@ packages:
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
-
-  lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
 
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
@@ -4218,13 +4214,12 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  oauth4webapi@3.8.6:
+    resolution: {integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  object-hash@2.2.0:
-    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
-    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -4254,10 +4249,6 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
-  oidc-token-hash@5.2.0:
-    resolution: {integrity: sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==}
-    engines: {node: ^10.13.0 || >=12.0.0}
-
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
@@ -4273,8 +4264,8 @@ packages:
   oniguruma-to-es@3.1.1:
     resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
 
-  openid-client@5.7.1:
-    resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
+  openid-client@6.8.4:
+    resolution: {integrity: sha512-QSw0BA08piujetEwfZsHoTrDpMEha7GDZDicQqVwX4u0ChCjefvjDB++TZ8BTg76UpwhzIQgdvvfgfl3HpCSAw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -5283,9 +5274,6 @@ packages:
   xml-naming@0.1.0:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
     engines: {node: '>=16.0.0'}
-
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@2.8.4:
     resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
@@ -9419,7 +9407,7 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jose@4.15.9: {}
+  jose@6.2.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -9553,10 +9541,6 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.3.5: {}
-
-  lru-cache@6.0.0:
-    dependencies:
-      yallist: 4.0.0
 
   luxon@3.7.2: {}
 
@@ -9799,9 +9783,9 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
-  object-assign@4.1.1: {}
+  oauth4webapi@3.8.6: {}
 
-  object-hash@2.2.0: {}
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -9843,8 +9827,6 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  oidc-token-hash@5.2.0: {}
-
   on-exit-leak-free@2.1.2: {}
 
   on-finished@2.4.1:
@@ -9861,12 +9843,10 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openid-client@5.7.1:
+  openid-client@6.8.4:
     dependencies:
-      jose: 4.15.9
-      lru-cache: 6.0.0
-      object-hash: 2.2.0
-      oidc-token-hash: 5.2.0
+      jose: 6.2.3
+      oauth4webapi: 3.8.6
 
   optionator@0.9.4:
     dependencies:
@@ -11161,8 +11141,6 @@ snapshots:
       strip-ansi: 7.2.0
 
   xml-naming@0.1.0: {}
-
-  yallist@4.0.0: {}
 
   yaml@2.8.4: {}
 


### PR DESCRIPTION
## Summary

`openid-client` v6 is a complete API redesign — class-based (`Issuer.discover()` → `new issuer.Client()`) → function-based (`discovery()` → `buildAuthorizationUrl()` / `authorizationCodeGrant()`). `OidcService` internals fully rewritten; **the public surface (`start()`, `callback()`, `OidcUserInfo`) is unchanged** so `AuthService` and the controller are untouched.

## Mapping

| v5 | v6 |
|---|---|
| `generators.state()` | `randomState()` |
| `generators.nonce()` | `randomNonce()` |
| `generators.codeVerifier()` | `randomPKCECodeVerifier()` |
| `generators.codeChallenge(v)` | `await calculatePKCECodeChallenge(v)` (now async) |
| `Issuer.discover(url)` | `discovery(new URL(url), id, secret)` |
| `client.authorizationUrl(params)` | `buildAuthorizationUrl(config, params)` |
| `client.callback(uri, params, checks)` | `authorizationCodeGrant(config, currentUrl, checks)` |

## CJS/ESM

`openid-client` v6 is ESM-only; `core-api` is CJS. Same shim shape that #163 landed for `file-type`:
- named-type imports with `with { 'resolution-mode': 'import' }`
- dynamic `import()` + cached lazy initializer
- no `"type": "module"` flip

## Side effect — claim narrowing tightened

v6 types ID-token claims as `JsonValue | undefined`. The previous `if (!claims.email)` accepted truthy non-strings (would have stringified to `[object Object]` before lowercase). Now rejects non-string explicitly with `oidc_missing_email`. Same hardening on `given_name` / `family_name` / `name`. **Strictly safer**, but tracked in PR description so it shows up if any IdP misbehaves post-deploy.

## Verification

- `pnpm typecheck` — 0 errors
- `pnpm lint` — clean
- `pnpm test --force` — 408/408 (core-api)
- security-reviewer agent: APPROVE WITH NOTES, no blockers

## ⚠️ NOT verified — staging smoke-test required

The existing test suite mocks at the `OidcUserInfo` boundary; nothing exercises the openid-client functions themselves. **Smoke-test Google + Microsoft login in staging** before promoting to canary.

## Follow-ups (security-reviewer concerns, non-blocking)

Tracked in companion issue #172:
- `currentUrl` is reconstructed from `redirectUri + code + state` — drops `iss` (RFC 9207) and `error` query params if IdP sends them. Pass `req.url` through.
- `OidcCallbackParams.expectedState` should reject empty string (defence in depth).
- `oidc_callback_failed` log uses `String(err)` — v6 errors sometimes embed the auth-response URL with `code`. Sanitize before logging.
- Generic `missing_code_or_state` from controller swallows IdP-returned `?error=access_denied`; user sees nothing useful (pre-existing).

## Test plan

- [ ] CI green (lint + typecheck + unit + i18n + community-flows + Trivy + CodeQL)
- [ ] Post-merge: Google OIDC login round-trip in staging
- [ ] Post-merge: Microsoft OIDC login round-trip in staging