### PR TITLE
chore(deps): sync ui-kit React peer + dev deps to 19 (#123)

### DIFF
--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -18,13 +18,13 @@
     "clean": "rimraf dist"
   },
   "peerDependencies": {
-    "react": "^18",
-    "react-dom": "^18"
+    "react": "^19",
+    "react-dom": "^19"
   },
   "devDependencies": {
-    "@types/react": "^18.3.16",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "@types/react": "^19.2.14",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
     "typescript": "^6.0.3",
     "vitest": "^2.1.8"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,14 +280,14 @@ importers:
   packages/ui-kit:
     devDependencies:
       '@types/react':
-        specifier: ^18.3.16
-        version: 18.3.28
+        specifier: ^19.2.14
+        version: 19.2.14
       react:
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.2.6
+        version: 19.2.6
       react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -7328,7 +7328,8 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
-  '@types/prop-types@15.7.15': {}
+  '@types/prop-types@15.7.15':
+    optional: true
 
   '@types/qs@6.15.0': {}
 
@@ -7342,6 +7343,7 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+    optional: true
 
   '@types/react@19.2.14':
     dependencies:
@@ -10051,6 +10053,7 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+    optional: true
 
   react-dom@19.2.6(react@19.2.6):
     dependencies:
@@ -10062,6 +10065,7 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+    optional: true
 
   react@19.2.6: {}
 
@@ -10223,6 +10227,7 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+    optional: true
 
   scheduler@0.27.0: {}
 


### PR DESCRIPTION
## Summary

\`@panorama/ui-kit\` was on React 18 while \`@panorama/web\` (its sole consumer today) is on React 19. Bring ui-kit to 19 to:

- close the two-React-types resolution that shimmered into typecheck failures during the prior dep-bump series
- remove ambiguity for future ui-kit components that use React 19 features (Actions, \`use()\`, etc.)

| field | from | to |
|---|---|---|
| peerDependencies.react | ^18 | ^19 |
| peerDependencies.react-dom | ^18 | ^19 |
| devDependencies.@types/react | ^18.3.16 | ^19.2.14 |
| devDependencies.react | ^18.3.1 | ^19.2.6 |
| devDependencies.react-dom | ^18.3.1 | ^19.2.6 |

ui-kit currently has no shipped components (still scaffold per its own test stub: *"ui-kit — scaffold only, first components land in 0.2"*) so no migration risk in components themselves. The bump is to keep types and peers consistent before that lands.

## Verification

- \`pnpm typecheck\` — 0 errors
- \`pnpm lint\` — clean
- \`pnpm test --force\` — 408 core-api + 6 migrator + scaffold suites; all pass

## Test plan

- [ ] CI green