### PR TITLE
chore(deps): zod 3 → 4 (#123)

### DIFF
--- a/apps/core-api/package.json
+++ b/apps/core-api/package.json
@@ -51,7 +51,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "sharp": "^0.34.0",
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9",

--- a/apps/core-api/src/modules/auth/auth.controller.ts
+++ b/apps/core-api/src/modules/auth/auth.controller.ts
@@ -38,7 +38,7 @@ const DiscoverySchema = z.object({
 });
 
 const SwitchTenantSchema = z.object({
-  tenantId: z.string().uuid(),
+  tenantId: z.guid(),
 });
 
 const OidcProviderSchema = z.enum(['google', 'microsoft']);

--- a/apps/core-api/src/modules/inspection/inspection-snapshot.schema.ts
+++ b/apps/core-api/src/modules/inspection/inspection-snapshot.schema.ts
@@ -17,7 +17,7 @@ export const InspectionItemTypeEnum = z.enum(['BOOLEAN', 'TEXT', 'NUMBER', 'PHOT
 
 export const InspectionSnapshotItemSchema = z
   .object({
-    id: z.string().uuid(),
+    id: z.guid(),
     position: z.number().int().min(0).max(10_000),
     label: z.string().min(1).max(200),
     itemType: InspectionItemTypeEnum,

--- a/apps/core-api/src/modules/inspection/inspection-template.dto.ts
+++ b/apps/core-api/src/modules/inspection/inspection-template.dto.ts
@@ -61,7 +61,7 @@ export const CreateInspectionTemplateSchema = z
     name: z.string().min(1).max(200),
     description: z.string().max(1000).nullable().optional(),
     categoryKind: CategoryKindSchema.nullable().optional(),
-    categoryId: z.string().uuid().nullable().optional(),
+    categoryId: z.guid().nullable().optional(),
     displayOrder: z.number().int().min(0).max(10_000).default(0),
     items: z
       .array(InspectionTemplateItemInputSchema)
@@ -82,7 +82,7 @@ export const UpdateInspectionTemplateSchema = z
     name: z.string().min(1).max(200).optional(),
     description: z.string().max(1000).nullable().optional(),
     categoryKind: CategoryKindSchema.nullable().optional(),
-    categoryId: z.string().uuid().nullable().optional(),
+    categoryId: z.guid().nullable().optional(),
     displayOrder: z.number().int().min(0).max(10_000).optional(),
     /**
      * When provided, items are FULLY REPLACED inside one transaction
@@ -115,7 +115,7 @@ export type UpdateInspectionTemplateInput = z.infer<
 
 export const ListInspectionTemplatesSchema = z.object({
   /** Filter to templates that match this asset's category (resolved server-side). */
-  assetId: z.string().uuid().optional(),
+  assetId: z.guid().optional(),
   /** Filter by category kind directly — admin browsing. */
   categoryKind: CategoryKindSchema.optional(),
   /** Include archived templates in the result (admin view). */

--- a/apps/core-api/src/modules/inspection/inspection.dto.ts
+++ b/apps/core-api/src/modules/inspection/inspection.dto.ts
@@ -9,11 +9,11 @@ import { z } from 'zod';
 
 export const StartInspectionSchema = z
   .object({
-    assetId: z.string().uuid(),
+    assetId: z.guid(),
     /** Optional reservation tether — pre-trip from the reservation page. */
-    reservationId: z.string().uuid().nullable().optional(),
+    reservationId: z.guid().nullable().optional(),
     /** Optional explicit template — when omitted, server resolves by category. */
-    templateId: z.string().uuid().optional(),
+    templateId: z.guid().optional(),
   })
   .strict();
 export type StartInspectionInput = z.infer<typeof StartInspectionSchema>;
@@ -21,7 +21,7 @@ export type StartInspectionInput = z.infer<typeof StartInspectionSchema>;
 export const RespondSchema = z
   .object({
     /** Anchor in the inspection's templateSnapshot.items[*].id. */
-    snapshotItemId: z.string().uuid(),
+    snapshotItemId: z.guid(),
     booleanValue: z.boolean().nullable().optional(),
     textValue: z.string().max(2000).nullable().optional(),
     numberValue: z.number().nullable().optional(),
@@ -72,8 +72,8 @@ export const ListInspectionsSchema = z.object({
   outcome: z.enum(['PASS', 'FAIL', 'NEEDS_MAINTENANCE', 'all']).default('all'),
   /** Admin review queue: unreviewed COMPLETED rows only. */
   needsReview: z.coerce.boolean().default(false),
-  assetId: z.string().uuid().optional(),
-  reservationId: z.string().uuid().optional(),
+  assetId: z.guid().optional(),
+  reservationId: z.guid().optional(),
   limit: z.coerce.number().int().min(1).max(200).default(50),
 });
 export type ListInspectionsInput = z.infer<typeof ListInspectionsSchema>;

--- a/apps/core-api/src/modules/invitation/invitation.dto.ts
+++ b/apps/core-api/src/modules/invitation/invitation.dto.ts
@@ -8,7 +8,7 @@ import { z } from 'zod';
  */
 
 export const CreateInvitationSchema = z.object({
-  tenantId: z.string().uuid(),
+  tenantId: z.guid(),
   email: z
     .string()
     .email()
@@ -20,7 +20,7 @@ export const CreateInvitationSchema = z.object({
 export type CreateInvitationInput = z.infer<typeof CreateInvitationSchema>;
 
 export const ListInvitationsSchema = z.object({
-  tenantId: z.string().uuid(),
+  tenantId: z.guid(),
   status: z.enum(['open', 'accepted', 'revoked', 'expired', 'all']).optional(),
   limit: z.coerce.number().int().min(1).max(200).optional(),
 });

--- a/apps/core-api/src/modules/maintenance/maintenance.dto.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance.dto.ts
@@ -20,13 +20,13 @@ export const MAINTENANCE_TYPE_ALLOWLIST = [
 export type MaintenanceTypeName = (typeof MAINTENANCE_TYPE_ALLOWLIST)[number];
 
 export const OpenTicketSchema = z.object({
-  assetId: z.string().uuid(),
+  assetId: z.guid(),
   maintenanceType: z.enum(MAINTENANCE_TYPE_ALLOWLIST),
   title: z.string().trim().min(3, 'title_too_short').max(200),
   severity: z.string().trim().max(40).optional(),
-  triggeringReservationId: z.string().uuid().optional(),
-  triggeringInspectionId: z.string().uuid().optional(),
-  assigneeUserId: z.string().uuid().optional(),
+  triggeringReservationId: z.guid().optional(),
+  triggeringInspectionId: z.guid().optional(),
+  assigneeUserId: z.guid().optional(),
   supplierName: z.string().trim().max(200).optional(),
   mileageAtService: z.number().int().nonnegative().optional(),
   expectedReturnAt: z.string().datetime().optional(),
@@ -38,10 +38,10 @@ export type OpenTicketInput = z.infer<typeof OpenTicketSchema>;
 
 export const ListTicketsSchema = z.object({
   status: z.enum(['OPEN', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED']).optional(),
-  assetId: z.string().uuid().optional(),
-  assigneeUserId: z.string().uuid().optional(),
+  assetId: z.guid().optional(),
+  assigneeUserId: z.guid().optional(),
   limit: z.coerce.number().int().positive().max(200).optional(),
-  cursor: z.string().uuid().optional(),
+  cursor: z.guid().optional(),
 });
 export type ListTicketsInput = z.infer<typeof ListTicketsSchema>;
 

--- a/apps/core-api/src/modules/notification/notification-events.schema.ts
+++ b/apps/core-api/src/modules/notification/notification-events.schema.ts
@@ -21,10 +21,10 @@ import { z } from 'zod';
 export const NOTIFICATION_PAYLOAD_SCHEMAS = {
   'panorama.reservation.approved': z
     .object({
-      reservationId: z.string().uuid(),
-      assetId: z.string().uuid().nullable(),
-      requesterUserId: z.string().uuid(),
-      approverUserId: z.string().uuid(),
+      reservationId: z.guid(),
+      assetId: z.guid().nullable(),
+      requesterUserId: z.guid(),
+      approverUserId: z.guid(),
       startAt: z.string().datetime(),
       endAt: z.string().datetime(),
       note: z.string().max(500).optional(),
@@ -33,10 +33,10 @@ export const NOTIFICATION_PAYLOAD_SCHEMAS = {
 
   'panorama.reservation.rejected': z
     .object({
-      reservationId: z.string().uuid(),
-      assetId: z.string().uuid().nullable(),
-      requesterUserId: z.string().uuid(),
-      approverUserId: z.string().uuid(),
+      reservationId: z.guid(),
+      assetId: z.guid().nullable(),
+      requesterUserId: z.guid(),
+      approverUserId: z.guid(),
       startAt: z.string().datetime(),
       endAt: z.string().datetime(),
       note: z.string().max(500).optional(),
@@ -49,10 +49,10 @@ export const NOTIFICATION_PAYLOAD_SCHEMAS = {
   // (audit + future subscribers) without firing email.
   'panorama.inspection.completed': z
     .object({
-      inspectionId: z.string().uuid(),
-      assetId: z.string().uuid(),
-      reservationId: z.string().uuid().nullable(),
-      startedByUserId: z.string().uuid(),
+      inspectionId: z.guid(),
+      assetId: z.guid(),
+      reservationId: z.guid().nullable(),
+      startedByUserId: z.guid(),
       outcome: z.enum(['PASS', 'FAIL', 'NEEDS_MAINTENANCE']),
       photoCount: z.number().int().min(0).max(50),
       responseCount: z.number().int().min(0).max(100),
@@ -68,10 +68,10 @@ export const NOTIFICATION_PAYLOAD_SCHEMAS = {
   // emitted until the auto-suggest slice landed.
   'panorama.reservation.checked_in_with_damage': z
     .object({
-      reservationId: z.string().uuid(),
-      assetId: z.string().uuid(),
-      requesterUserId: z.string().uuid(),
-      checkedInByUserId: z.string().uuid(),
+      reservationId: z.guid(),
+      assetId: z.guid(),
+      requesterUserId: z.guid(),
+      checkedInByUserId: z.guid(),
       checkedInAt: z.string().datetime(),
       mileageIn: z.number().int().nonnegative(),
       // Free-text driver note describing the damage — bounded so payload

--- a/apps/core-api/src/modules/object-storage/object-storage.keys.ts
+++ b/apps/core-api/src/modules/object-storage/object-storage.keys.ts
@@ -15,7 +15,7 @@ import { z } from 'zod';
 export const INSPECTION_PHOTO_KEY_REGEX =
   /^tenants\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/inspections\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/photos\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jpg$/;
 
-const UuidSchema = z.string().uuid();
+const UuidSchema = z.guid();
 
 /**
  * Build the S3 key for a photo. Every argument is runtime-validated

--- a/apps/core-api/src/modules/reservation/reservation.dto.ts
+++ b/apps/core-api/src/modules/reservation/reservation.dto.ts
@@ -2,8 +2,8 @@ import { z } from 'zod';
 
 export const CreateReservationSchema = z
   .object({
-    assetId: z.string().uuid().nullable().optional(),
-    onBehalfUserId: z.string().uuid().optional(),
+    assetId: z.guid().nullable().optional(),
+    onBehalfUserId: z.guid().optional(),
     startAt: z.string().datetime(),
     endAt: z.string().datetime(),
     purpose: z.string().max(2000).optional(),
@@ -16,8 +16,8 @@ export type CreateReservationInput = z.infer<typeof CreateReservationSchema>;
 
 export const CreateBasketSchema = z
   .object({
-    assetIds: z.array(z.string().uuid()).min(1).max(20),
-    onBehalfUserId: z.string().uuid().optional(),
+    assetIds: z.array(z.guid()).min(1).max(20),
+    onBehalfUserId: z.guid().optional(),
     startAt: z.string().datetime(),
     endAt: z.string().datetime(),
     purpose: z.string().max(2000).optional(),
@@ -60,7 +60,7 @@ export const ApprovalDecisionSchema = z.object({
 // the web layer maps to a user-facing string.
 export const RejectionDecisionSchema = z.object({
   note: z
-    .string({ required_error: 'note_required', invalid_type_error: 'note_required' })
+    .string({ error: 'note_required' })
     .trim()
     .min(1, 'note_required')
     .max(500),
@@ -76,7 +76,7 @@ export type BasketBatchDecisionInput = z.infer<typeof BasketBatchDecisionSchema>
 // in a multi-asset basket get the same "why" surface as solo bookings.
 export const BasketBatchRejectionSchema = z.object({
   note: z
-    .string({ required_error: 'note_required', invalid_type_error: 'note_required' })
+    .string({ error: 'note_required' })
     .trim()
     .min(1, 'note_required')
     .max(500),
@@ -89,7 +89,7 @@ export const BasketBatchRejectionSchema = z.object({
 // maintenance scheduling chain.
 export const CheckoutSchema = z.object({
   mileage: z
-    .number({ required_error: 'mileage_required', invalid_type_error: 'mileage_required' })
+    .number({ error: 'mileage_required' })
     .int()
     .nonnegative('mileage_required'),
   condition: z.string().max(2000).optional(),
@@ -101,7 +101,7 @@ export type CheckoutInput = z.infer<typeof CheckoutSchema>;
 // PM-due cron depends on it being a real number, not NULL.
 export const CheckinSchema = z.object({
   mileage: z
-    .number({ required_error: 'mileage_required', invalid_type_error: 'mileage_required' })
+    .number({ error: 'mileage_required' })
     .int()
     .nonnegative('mileage_required'),
   condition: z.string().max(2000).optional(),
@@ -112,7 +112,7 @@ export type CheckinInput = z.infer<typeof CheckinSchema>;
 
 export const CreateBlackoutSchema = z
   .object({
-    assetId: z.string().uuid().nullable().optional(),
+    assetId: z.guid().nullable().optional(),
     title: z.string().min(1).max(200),
     startAt: z.string().datetime(),
     endAt: z.string().datetime(),
@@ -127,7 +127,7 @@ export type CreateBlackoutInput = z.infer<typeof CreateBlackoutSchema>;
 export const ListBlackoutsSchema = z.object({
   from: z.string().datetime().optional(),
   to: z.string().datetime().optional(),
-  assetId: z.string().uuid().optional(),
+  assetId: z.guid().optional(),
   limit: z.coerce.number().int().min(1).max(200).default(100),
 });
 export type ListBlackoutsInput = z.infer<typeof ListBlackoutsSchema>;

--- a/apps/core-api/src/modules/snipeit-compat/snipeit-compat.controller.ts
+++ b/apps/core-api/src/modules/snipeit-compat/snipeit-compat.controller.ts
@@ -22,14 +22,14 @@ const ListQuerySchema = z.object({
   search: z.string().max(200).optional(),
 });
 const HardwareListQuerySchema = ListQuerySchema.extend({
-  category_id: z.string().uuid().optional(),
+  category_id: z.guid().optional(),
   requestable: z
     .string()
     .optional()
     .transform((v) => (v === '1' || v === 'true' ? true : v === '0' || v === 'false' ? false : undefined)),
 });
 const ModelsListQuerySchema = ListQuerySchema.extend({
-  category_id: z.string().uuid().optional(),
+  category_id: z.guid().optional(),
 });
 
 /**

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,7 +21,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "server-only": "^0.0.1",
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.19.17",

--- a/packages/migrator/package.json
+++ b/packages/migrator/package.json
@@ -24,7 +24,7 @@
     "@panorama/shared": "workspace:*",
     "commander": "^14.0.3",
     "pino": "^10.3.1",
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.19.17",

--- a/packages/migrator/src/types.ts
+++ b/packages/migrator/src/types.ts
@@ -53,7 +53,7 @@ export const SnipeItAssetSchema = z.object({
   company: NestedRefSchema,
   rtd_location: NestedRefSchema,
   assigned_to: z.unknown().nullable().optional(),
-  custom_fields: z.record(z.unknown()).nullable().optional(),
+  custom_fields: z.record(z.string(), z.unknown()).nullable().optional(),
 });
 export type SnipeItAsset = z.infer<typeof SnipeItAssetSchema>;
 
@@ -65,7 +65,7 @@ export const PaginatedResponseSchema = z.object({
 export const InventoryReportSchema = z.object({
   snipeitUrl: z.string().url(),
   generatedAt: z.string().datetime({ offset: true }),
-  counts: z.record(z.number().int()),
+  counts: z.record(z.string(), z.number().int()),
   flags: z.object({
     duplicateEmails: z.array(z.string()),
     unknownStatusLabels: z.array(z.string()),

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,7 +17,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/packages/shared/src/migration-fixtures.ts
+++ b/packages/shared/src/migration-fixtures.ts
@@ -26,7 +26,7 @@ export const ManifestSchema = z.object({
   source: FixtureSourceSchema,
   sourceUrl: z.string().url().nullable(),
   generatedAt: z.string().datetime({ offset: true }),
-  counts: z.record(z.number().int().nonnegative()),
+  counts: z.record(z.string(), z.number().int().nonnegative()),
 });
 export type Manifest = z.infer<typeof ManifestSchema>;
 
@@ -111,7 +111,7 @@ export const AssetFixtureSchema = z.object({
   serial: z.string().nullable().optional(),
   status: z.enum(['READY', 'IN_USE', 'RESERVED', 'MAINTENANCE', 'RETIRED']).default('READY'),
   bookable: z.boolean().default(false),
-  customFields: z.record(z.unknown()).default({}),
+  customFields: z.record(z.string(), z.unknown()).default({}),
 });
 export type AssetFixture = z.infer<typeof AssetFixtureSchema>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
         specifier: ^0.34.0
         version: 0.34.5
       zod:
-        specifier: ^3.23.8
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/js':
         specifier: ^9
@@ -203,8 +203,8 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
       zod:
-        specifier: ^3.23.8
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^22.19.17
@@ -239,8 +239,8 @@ importers:
         specifier: ^10.3.1
         version: 10.3.1
       zod:
-        specifier: ^3.23.8
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^22.19.17
@@ -267,8 +267,8 @@ importers:
   packages/shared:
     dependencies:
       zod:
-        specifier: ^3.23.8
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       typescript:
         specifier: ^6.0.3
@@ -5288,8 +5288,8 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -8609,8 +8609,8 @@ snapshots:
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@6.0.3)
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4)
       eslint-plugin-react: 7.37.5(eslint@9.39.4)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4)
@@ -8629,7 +8629,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8640,22 +8640,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4)(typescript@6.0.3)
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -8666,7 +8666,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint@9.39.4))(eslint@9.39.4))(eslint@9.39.4)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11153,6 +11153,6 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod@3.25.76: {}
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary

\`zod\` v4 is a substantial API rework. Bump touches all four packages that depend on zod (core-api, web, shared, migrator). Applied the minimal mechanical migration to keep runtime behaviour identical to v3.

## Schema changes

| change | scope |
|---|---|
| \`z.record(V)\` → \`z.record(K, V)\` (single-arg form removed) | shared/migration-fixtures.ts (×2), migrator/types.ts (×2) |
| \`z.string({ required_error, invalid_type_error })\` → \`z.string({ error })\` | core-api reservation.dto.ts (×4) |
| \`z.string().uuid()\` → \`z.guid()\` | 45 call sites across core-api |

## Why \`z.guid()\` instead of \`z.uuid()\`

v4's \`z.uuid()\` is now strict **RFC 9562** — it rejects the nil UUID and any 8-4-4-4-12 hex string that doesn't encode a valid version + variant in the right nibbles. \`z.guid()\` is the v3-equivalent permissive validator: any 8-4-4-4-12 hex passes.

Switched all 45 sites to \`z.guid()\` because production rows include UUIDs migrated from Snipe-IT / FleetManager upstreams (pre-RFC-9562). Tightening to strict \`z.uuid()\` would start rejecting real production data — out of scope for a dep-bump PR. **Tracked as a follow-up** after a data audit confirms no legacy UUID would fail.

## What did NOT change

- \`.strict()\` on \`z.object()\` — deprecated in v4 but still works; left in place at 20+ call sites. Migration to \`z.strictObject()\` is a separate refactor.
- \`z.string().datetime()\`, \`z.string().url()\` — also deprecated chain forms but functional; left as-is.
- \`result.error.issues\` — code already used the v4-compatible field name (\`.issues\`, not \`.errors\`).

## Verification

- \`pnpm typecheck\` — 0 errors
- \`pnpm lint\` — clean
- \`pnpm test --force\` — 408 core-api + 6 migrator (cache-busted)

  Note: notification-bus integration tests initially failed with \`payload_schema_failed:panorama.reservation.approved\` because they use placeholder UUIDs like \`00000000-0000-0000-0000-000000000099\` which the new strict \`z.uuid()\` rejects. Switched the schema to \`z.guid()\` (preserving v3 behaviour) — tests pass.

## Test plan

- [ ] CI green