### PR TITLE
fix(web): clear two Next 16 boot warnings — serverActions + proxy rename

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -20,14 +20,20 @@ const nextConfig = {
   },
   // Transpile our workspace packages so Next's SWC picks up the TS source.
   transpilePackages: ['@panorama/shared', '@panorama/ui-kit'],
-  // Server Actions are stable since Next 14.2 — config hoisted out of
-  // `experimental` per Next 15. allowedOrigins is the CSRF gate against
-  // cross-site Server Action invocations; bodySizeLimit caps the
-  // request payload (default 1MB; raised here for the photo-upload
-  // action which posts JPEGs after the photo-pipeline downsizes).
-  serverActions: {
-    allowedOrigins: ['localhost:3000', 'panorama.vitormr.dev'],
-    bodySizeLimit: '8mb',
+  // Server Actions are stable, but Next 16 moved the config key BACK
+  // under `experimental` (top-level was the Next 15 shape; reverted in
+  // 16 — surfaces as `Unrecognized key(s) in object: 'serverActions'`
+  // boot warning if left at top-level, which silently drops bodySizeLimit
+  // back to the 1MB default and breaks photo upload).
+  // allowedOrigins is the CSRF gate against cross-site Server Action
+  // invocations; bodySizeLimit caps the request payload (raised for the
+  // photo-upload action which posts JPEGs after the photo-pipeline
+  // downsizes).
+  experimental: {
+    serverActions: {
+      allowedOrigins: ['localhost:3000', 'panorama.vitormr.dev'],
+      bodySizeLimit: '8mb',
+    },
   },
 };
 

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -12,7 +12,7 @@ import { NextResponse, type NextRequest } from 'next/server';
  */
 const PUBLIC_PATHS = ['/login', '/invitations/accept'];
 
-export function middleware(req: NextRequest): NextResponse {
+export function proxy(req: NextRequest): NextResponse {
   const { pathname } = req.nextUrl;
   if (PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`))) {
     return NextResponse.next();


### PR DESCRIPTION
## Summary

Caught during the post-#180 local smoke test. Two warnings fired at boot of \`next dev\`:

\`\`\`
⚠ Invalid next.config.mjs options detected:
    Unrecognized key(s) in object: 'serverActions'
⚠ The "middleware" file convention is deprecated. Please use "proxy" instead.
\`\`\`

## 1. \`serverActions\` back under \`experimental\`

Next 15 hoisted \`serverActions\` to top-level. **Next 16 reverted that** — the key belongs back under \`experimental\`. Top-level placement silently falls back to defaults, which means our \`bodySizeLimit: '8mb'\` would NOT have applied → photo-upload Server Actions would hit the 1MB default and fail. The PR moves the block back inside \`experimental: { ... }\`.

After the fix the boot log shows:
\`\`\`
- Experiments (use with caution):
  · serverActions
\`\`\`
…confirming the key is recognised again.

## 2. \`middleware.ts\` → \`proxy.ts\`

Next 16 deprecates the \`middleware\` file convention in favour of \`proxy\`. Same runtime semantics, new name. The old shape still works (build labels it \`Proxy (Middleware)\`) but the warning is intentional pressure to rename. Mechanical change: file + exported function name; same \`NextRequest\` / \`NextResponse\` import surface.

## Verification

- Boot warnings: **both cleared**
- \`pnpm --filter @panorama/web typecheck\` — 0 errors
- \`pnpm --filter @panorama/web lint\` — clean
- \`pnpm --filter @panorama/web build\` — 17 routes emit; \`Proxy (Middleware)\` label still appears in route table (it's the runtime concept, not the filename)
- Runtime probe with both core-api + web on dev:
  | route | status |
  |---|---|
  | GET /login | 200 |
  | GET / | 307 (proxy redirects unauthenticated) |
  | GET /api/auth/me | 401 (proxied → core-api, rejected) |

## Test plan

- [ ] CI green