### PR TITLE
fix(prisma): make migrations + bootstrap portable for managed PG (Supabase)

### DIFF
--- a/apps/core-api/prisma/migrations/20260418100000_0011_notification_events/migration.sql
+++ b/apps/core-api/prisma/migrations/20260418100000_0011_notification_events/migration.sql
@@ -156,7 +156,17 @@ BEGIN
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
 
-GRANT CONNECT ON DATABASE panorama TO panorama_notification_dispatcher;
+-- Parametric on database name — `panorama` on self-hosted (per
+-- infra/docker/postgres-init.sql) and `postgres` on Supabase / other
+-- managed PG. Hardcoded literal would fail on any non-self-hosted
+-- target (caught during the 2026-05-09 staging bring-up).
+DO $$
+BEGIN
+  EXECUTE format(
+    'GRANT CONNECT ON DATABASE %I TO panorama_notification_dispatcher',
+    current_database()
+  );
+END $$;
 GRANT USAGE ON SCHEMA public TO panorama_notification_dispatcher;
 GRANT SELECT, UPDATE ON "notification_events" TO panorama_notification_dispatcher;
 GRANT INSERT ON "audit_events"                  TO panorama_notification_dispatcher;

--- a/apps/core-api/prisma/supabase-bootstrap.sql
+++ b/apps/core-api/prisma/supabase-bootstrap.sql
@@ -1,0 +1,63 @@
+-- Pre-migration bootstrap for Postgres targets where
+-- infra/docker/postgres-init.sql NEVER runs — i.e. managed Postgres
+-- (Supabase, Neon, RDS, …). Idempotent: safe to re-run; safe to run
+-- on self-hosted too (the IF NOT EXISTS guards mean it's a no-op
+-- there because postgres-init already created the roles).
+--
+-- Apply BEFORE `prisma migrate deploy` against a fresh managed-PG
+-- database. Run as the privileged user (Supabase: `postgres` via the
+-- DIRECT connection on port 5432, NOT the pooler).
+--
+-- Surfaced during 2026-05-09 staging bring-up: migration 0011 +
+-- subsequent ones GRANT TO `panorama_app` / `panorama_super_admin`,
+-- which only existed on self-hosted.
+
+-- 1. Roles. NOLOGIN — they're not authentication identities; they're
+--    permission containers that the connecting user (e.g. `postgres`
+--    on Supabase) `SET ROLE`s into per-request, matching the
+--    ADR-0015 v2 two-client pattern (privileged + appClient).
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'panorama_app') THEN
+    CREATE ROLE panorama_app NOLOGIN NOBYPASSRLS;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'panorama_super_admin') THEN
+    CREATE ROLE panorama_super_admin NOLOGIN BYPASSRLS;
+  END IF;
+END $$;
+
+-- 2. Grant the connecting user (postgres on Supabase, panorama on
+--    self-hosted) membership of both roles so SET ROLE can switch
+--    in. Required by PrismaService's two-client design and by the
+--    runbook's "SET LOCAL ROLE panorama_app" verification step.
+DO $$
+BEGIN
+  EXECUTE format('GRANT panorama_app TO %I', current_user);
+  EXECUTE format('GRANT panorama_super_admin TO %I', current_user);
+END $$;
+
+-- 3. CONNECT on the current database — parametric so this script is
+--    portable. Self-hosted = `panorama`; Supabase = `postgres`.
+DO $$
+BEGIN
+  EXECUTE format(
+    'GRANT CONNECT ON DATABASE %I TO panorama_app, panorama_super_admin',
+    current_database()
+  );
+END $$;
+
+-- 4. Schema USAGE on public so the GRANTs in subsequent migrations
+--    (SELECT/INSERT/UPDATE on tables) actually take effect.
+GRANT USAGE ON SCHEMA public TO panorama_app, panorama_super_admin;
+
+-- 5. Extensions migrations rely on. Supabase usually has these
+--    pre-installed, but `IF NOT EXISTS` makes this a no-op when
+--    they're already present.
+CREATE EXTENSION IF NOT EXISTS citext;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS btree_gist;

--- a/apps/core-api/scripts/apply-migrations.sh
+++ b/apps/core-api/scripts/apply-migrations.sh
@@ -29,6 +29,18 @@ ADMIN_URL="${DATABASE_PRIVILEGED_URL:-$DATABASE_URL}"
 
 cd "$(dirname "$0")/.."
 
+# Pre-migration bootstrap (idempotent). Creates panorama_app +
+# panorama_super_admin roles, grants membership to the connecting user,
+# and ensures required extensions. On self-hosted this is a no-op via
+# IF NOT EXISTS guards (postgres-init.sql ran first on container init).
+# On managed PG (Supabase, Neon, RDS, …) this is the prereq for the
+# role GRANTs in subsequent migrations to resolve. Surfaced 2026-05-09
+# during the first Supabase staging bring-up.
+if [ -f prisma/supabase-bootstrap.sql ]; then
+  echo ">> pre-migration bootstrap (prisma/supabase-bootstrap.sql)"
+  psql "$ADMIN_URL" -v ON_ERROR_STOP=1 -f prisma/supabase-bootstrap.sql
+fi
+
 echo ">> prisma migrate deploy"
 node ./node_modules/.bin/prisma migrate deploy
 


### PR DESCRIPTION
## Summary

Surfaced 2026-05-09 during the first **Supabase staging bring-up**. Two gaps blocked \`prisma migrate deploy\` against a fresh Supabase project; both fixed here. Staging is now up.

## What blocked

### 1. Hardcoded \`DATABASE panorama\` in migration 0011

\`\`\`sql
GRANT CONNECT ON DATABASE panorama TO panorama_notification_dispatcher
\`\`\`

Hardcoded the self-hosted DB name (set by \`infra/docker/postgres-init.sql\`). Supabase always names its DB \`postgres\` — migration P3018 failed with \`database "panorama" does not exist\`.

### 2. Missing \`panorama_app\` + \`panorama_super_admin\` roles on Supabase

These roles are created by \`infra/docker/postgres-init.sql\` (Compose initdb hook) — only runs on self-hosted. Without them, every \`GRANT … TO panorama_app\` in subsequent migrations would fail.

## What this PR ships

| change | file |
|---|---|
| Parametric \`current_database()\` in DB-name GRANT | \`apps/core-api/prisma/migrations/20260418100000_0011_notification_events/migration.sql\` |
| New idempotent bootstrap (creates roles + extensions, GRANT TO current_user) | \`apps/core-api/prisma/supabase-bootstrap.sql\` (NEW) |
| Auto-runs bootstrap before \`prisma migrate deploy\` | \`apps/core-api/scripts/apply-migrations.sh\` |

The bootstrap is **idempotent on self-hosted** (\`IF NOT EXISTS\` guards make it a no-op when postgres-init.sql ran first), and is the **prereq on managed PG**. Same script, both worlds.

## Drift warning on dev

Editing migration 0011 changes its checksum. Dev DBs that already applied the original file will see "drift detected" in \`prisma migrate dev\` / \`migrate diff\`. \`migrate deploy\` ignores this (deploy mode is checksum-warning only, not error). 417/417 tests still pass against dev locally.

## Verification on staging

Applied tonight to Supabase project \`tuswqzeytiobqfkxgkbe\` (Free tier, us-east-1):

- 20 schema migrations applied via \`prisma migrate deploy\` (with \`DATABASE_URL\` overridden to the direct URL — Supabase pooler doesn't support the session-level operations Prisma uses)
- 17 rls.sql files applied via the existing loop in \`apply-migrations.sh\`
- Smoke checks (all green):
  - 24 tables in \`public\`, 11/11 expected core tables present
  - RLS enabled + forced on 7/7 tenant-scoped tables
  - 3 \`panorama_*\` roles, BYPASSRLS correct (super_admin=t, app=f, dispatcher=f)
  - \`panorama_enable_bypass_rls()\` exists with SECURITY DEFINER (ADR-0015 v2 bridge)
  - \`SET ROLE panorama_app\` works via \`postgres\` membership; rolbypassrls=false on the resulting role (RLS WILL enforce)

## Implications

- Closes the BYPASSRLS-on-Supabase compatibility gap mentioned in ADR-0015 v2's "postgres user on Supabase" path.
- The staging runbook (\`docs/runbooks/setup-supabase-staging.md\`) Step 3 ("apply migrations one-by-one in SQL Editor") is now collapsed to a single \`./apps/core-api/scripts/apply-migrations.sh\` command. Doc update can be a follow-up — the runbook still works as-is.
- Future managed-PG deploys (Neon, RDS, …) get the same bootstrap path for free.

## NOT in this PR

- Doc update to \`docs/runbooks/setup-supabase-staging.md\` reflecting the simplified flow → follow-up
- The 0.3 canaries (FEATURE_INSPECTIONS / FEATURE_MAINTENANCE flag flips) → separate decision once you observe staging

## Test plan

- [ ] CI green
- [ ] (already done) Real Supabase apply: 20/20 migrations, 17/17 rls.sql, 6/6 smoke checks pass