### PR TITLE
feat(auth): OIDC end-to-end test against in-process stub IdP (closes #92)

### DIFF
--- a/apps/core-api/package.json
+++ b/apps/core-api/package.json
@@ -63,6 +63,7 @@
     "@types/nodemailer": "^8.0.0",
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.16.0",
+    "jose": "^6",
     "tsx": "^4.19.2",
     "typescript-eslint": "^8.59.2",
     "unplugin-swc": "^1.5.9",

--- a/apps/core-api/src/modules/auth/auth.config.ts
+++ b/apps/core-api/src/modules/auth/auth.config.ts
@@ -79,7 +79,14 @@ export class AuthConfigService {
       const google: OidcProviderConfig = {
         clientId: process.env.OIDC_GOOGLE_CLIENT_ID,
         clientSecret: process.env.OIDC_GOOGLE_CLIENT_SECRET ?? '',
-        issuer: 'https://accounts.google.com',
+        // Issuer override exists for two narrow use cases:
+        //   1. e2e tests with an in-process stub IdP (#92).
+        //   2. self-hosted OIDC mirrors that pass Google's discovery
+        //      shape but on a different origin (rare).
+        // Default = production Google. NEVER set in production unless
+        // you know exactly what you're doing — the issuer string also
+        // becomes the value v6 validates ID-token `iss` against.
+        issuer: process.env.OIDC_GOOGLE_ISSUER ?? 'https://accounts.google.com',
         extraScopes: [],
       };
       if (process.env.OIDC_GOOGLE_HOSTED_DOMAIN) {

--- a/apps/core-api/src/modules/auth/oidc.service.ts
+++ b/apps/core-api/src/modules/auth/oidc.service.ts
@@ -8,6 +8,7 @@ import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
 // file is CJS but openid-client ships ESM-only `.d.ts`).
 // Same shape as photo-pipeline's `file-type` shim landed in #163.
 import type {
+  allowInsecureRequests as allowInsecureRequestsType,
   authorizationCodeGrant as authorizationCodeGrantType,
   buildAuthorizationUrl as buildAuthorizationUrlType,
   calculatePKCECodeChallenge as calculatePKCECodeChallengeType,
@@ -19,6 +20,7 @@ import type {
 } from 'openid-client' with { 'resolution-mode': 'import' };
 
 interface OidcModule {
+  allowInsecureRequests: typeof allowInsecureRequestsType;
   authorizationCodeGrant: typeof authorizationCodeGrantType;
   buildAuthorizationUrl: typeof buildAuthorizationUrlType;
   calculatePKCECodeChallenge: typeof calculatePKCECodeChallengeType;
@@ -33,6 +35,7 @@ async function loadOidc(): Promise<OidcModule> {
   if (!oidcModule) {
     const mod = await import('openid-client');
     oidcModule = {
+      allowInsecureRequests: mod.allowInsecureRequests,
       authorizationCodeGrant: mod.authorizationCodeGrant,
       buildAuthorizationUrl: mod.buildAuthorizationUrl,
       calculatePKCECodeChallenge: mod.calculatePKCECodeChallenge,
@@ -140,8 +143,32 @@ export class OidcService {
     provider: 'google' | 'microsoft',
     cfg: OidcProviderConfig,
   ): Promise<Configuration> {
-    const { discovery } = await loadOidc();
-    const config = await discovery(new URL(cfg.issuer), cfg.clientId, cfg.clientSecret);
+    const { discovery, allowInsecureRequests } = await loadOidc();
+    // openid-client v6 refuses non-HTTPS issuers by default — for both
+    // the discovery fetch itself AND every subsequent request. The
+    // `OIDC_ALLOW_INSECURE_ISSUER=true` env-gated escape hatch exists
+    // for in-process stub IdPs (e2e tests, #92) and rare self-hosted
+    // mirror configurations. NEVER set in production — security
+    // depends on the IdP origin being authenticated by TLS.
+    //
+    // The opt-in must be passed via the `execute` array on the 5th
+    // arg of discovery — the wrapper applies it BEFORE the discovery
+    // fetch (otherwise discovery itself rejects HTTP and never gets
+    // to the post-call `allowInsecureRequests(config)` form).
+    const allowInsecure = process.env.OIDC_ALLOW_INSECURE_ISSUER === 'true';
+    if (allowInsecure) {
+      this.log.warn(
+        { provider, issuer: cfg.issuer },
+        'oidc_insecure_issuer_allowed',
+      );
+    }
+    const config = await discovery(
+      new URL(cfg.issuer),
+      cfg.clientId,
+      cfg.clientSecret,
+      undefined,
+      allowInsecure ? { execute: [allowInsecureRequests] } : undefined,
+    );
     this.log.log(
       { provider, issuer: config.serverMetadata().issuer },
       'oidc_client_ready',

--- a/apps/core-api/test/auth-oidc.e2e.test.ts
+++ b/apps/core-api/test/auth-oidc.e2e.test.ts
@@ -1,0 +1,333 @@
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { Test } from '@nestjs/testing';
+import type { INestApplication } from '@nestjs/common';
+import http from 'node:http';
+import { createHash } from 'node:crypto';
+import { exportJWK, generateKeyPair, type JWK, type KeyObject, SignJWT } from 'jose';
+import { PrismaClient } from '@prisma/client';
+
+// IMPORTANT: env vars MUST be set before any module that reads them
+// loads. AppModule's transitive imports (AuthConfigService) read
+// process.env at module-construction time, which happens during
+// `Test.createTestingModule({ imports: [AppModule] }).compile()`.
+const STUB_PORT = 4321;
+const STUB_ISSUER = `http://localhost:${STUB_PORT}`;
+const TEST_EMAIL = 'oidc-e2e@example.com';
+const CLIENT_ID = 'test-client-id';
+
+process.env.OIDC_GOOGLE_ISSUER = STUB_ISSUER;
+process.env.OIDC_GOOGLE_CLIENT_ID = CLIENT_ID;
+process.env.OIDC_GOOGLE_CLIENT_SECRET = 'test-client-secret';
+process.env.OIDC_ALLOW_INSECURE_ISSUER = 'true';
+process.env.APP_BASE_URL = process.env.APP_BASE_URL ?? 'http://localhost:4000';
+
+// AppModule import must come AFTER the env writes above. The
+// `import/order` rule isn't configured in this project, so no
+// suppression needed; this comment exists so future readers don't
+// "fix" the import grouping.
+import { AppModule } from '../src/app.module.js';
+import { resetTestDb } from './_reset-db.js';
+import { createTenantForTest } from './_create-tenant.js';
+
+/**
+ * #92 — End-to-end OIDC integration test driving the controller through
+ * the openid-client v6 happy path against an in-process stub IdP. Closes
+ * the long-standing "OIDC NOT verified end-to-end" caveat from PRs
+ * #171 (v6 migration) and #183 (v6 hardening).
+ *
+ * Topology:
+ *   test process ──fetch──→ Nest core-api ──HTTP──→ stub IdP (in-process)
+ *
+ * The stub speaks just enough OpenID Connect Discovery + Authorization
+ * Code Flow + JWKS to satisfy v6's validation. ID-token is RS256-signed
+ * with a freshly-generated keypair; the public JWK is served at /jwks.
+ */
+
+const HOST = process.env.PG_HOST ?? 'localhost';
+const PORT = process.env.PG_PORT ?? '5432';
+const DB = process.env.PG_DB ?? 'panorama';
+const ADMIN_URL = `postgres://panorama_super_admin:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+
+interface CodeRecord {
+  codeChallenge: string;
+  nonce: string;
+  redirectUri: string;
+}
+
+function base64urlSha256(input: string): string {
+  return createHash('sha256').update(input).digest('base64url');
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk: Buffer) => {
+      data += chunk.toString('utf8');
+    });
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+function extractCookie(res: Response): string | null {
+  const raw = res.headers.get('set-cookie');
+  if (!raw) return null;
+  return raw
+    .split(',')
+    .map((part) => part.trim().split(';')[0])
+    .filter(Boolean)
+    .join('; ');
+}
+
+describe('OIDC end-to-end (stubbed Google IdP) — #92', () => {
+  let app: INestApplication;
+  let url: string;
+  let admin: PrismaClient;
+  let stub: http.Server;
+  let tenantId: string;
+  let userId: string;
+  // jose exports KeyObject (Node) as the runtime type returned by
+  // generateKeyPair on Node. Avoids depending on the DOM `CryptoKey`
+  // global which @types/node doesn't declare.
+  let signingKey: KeyObject;
+  let publicJwk: JWK;
+  const KID = 'stub-key-1';
+
+  // (code) → captured PKCE / nonce / redirectUri at /authorize, consumed
+  // at /token.
+  const codeStore = new Map<string, CodeRecord>();
+
+  beforeAll(async () => {
+    // 1. Generate RSA keypair for id_token signing.
+    const { publicKey, privateKey } = await generateKeyPair('RS256', {
+      extractable: true,
+    });
+    signingKey = privateKey;
+    publicJwk = { ...(await exportJWK(publicKey)), kid: KID, use: 'sig', alg: 'RS256' };
+
+    // 2. Stand up the stub IdP.
+    stub = http.createServer((req, res) => {
+      void (async () => {
+        try {
+          const reqUrl = new URL(req.url ?? '/', STUB_ISSUER);
+
+          if (reqUrl.pathname === '/.well-known/openid-configuration') {
+            res.setHeader('content-type', 'application/json');
+            res.end(
+              JSON.stringify({
+                issuer: STUB_ISSUER,
+                authorization_endpoint: `${STUB_ISSUER}/authorize`,
+                token_endpoint: `${STUB_ISSUER}/token`,
+                userinfo_endpoint: `${STUB_ISSUER}/userinfo`,
+                jwks_uri: `${STUB_ISSUER}/jwks`,
+                response_types_supported: ['code'],
+                subject_types_supported: ['public'],
+                id_token_signing_alg_values_supported: ['RS256'],
+                code_challenge_methods_supported: ['S256'],
+              }),
+            );
+            return;
+          }
+
+          if (reqUrl.pathname === '/jwks') {
+            res.setHeader('content-type', 'application/json');
+            res.end(JSON.stringify({ keys: [publicJwk] }));
+            return;
+          }
+
+          if (reqUrl.pathname === '/authorize') {
+            const params = reqUrl.searchParams;
+            const state = params.get('state');
+            const codeChallenge = params.get('code_challenge');
+            const redirectUri = params.get('redirect_uri');
+            if (!state || !codeChallenge || !redirectUri) {
+              res.statusCode = 400;
+              res.end('missing required authorize params');
+              return;
+            }
+            const code = `code-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+            codeStore.set(code, {
+              codeChallenge,
+              nonce: params.get('nonce') ?? '',
+              redirectUri,
+            });
+            const back = new URL(redirectUri);
+            back.searchParams.set('code', code);
+            back.searchParams.set('state', state);
+            // RFC 9207 — Authorization Server Issuer Identifier.
+            back.searchParams.set('iss', STUB_ISSUER);
+            res.statusCode = 302;
+            res.setHeader('location', back.href);
+            res.end();
+            return;
+          }
+
+          if (reqUrl.pathname === '/token' && req.method === 'POST') {
+            const body = await readBody(req);
+            const params = new URLSearchParams(body);
+            const code = params.get('code') ?? '';
+            const codeVerifier = params.get('code_verifier') ?? '';
+            const stored = codeStore.get(code);
+            if (!stored) {
+              res.statusCode = 400;
+              res.setHeader('content-type', 'application/json');
+              res.end(JSON.stringify({ error: 'invalid_grant', error_description: 'unknown code' }));
+              return;
+            }
+            // Verify PKCE — S256 = base64url(sha256(code_verifier)).
+            const expected = base64urlSha256(codeVerifier);
+            if (expected !== stored.codeChallenge) {
+              res.statusCode = 400;
+              res.setHeader('content-type', 'application/json');
+              res.end(
+                JSON.stringify({ error: 'invalid_grant', error_description: 'pkce mismatch' }),
+              );
+              return;
+            }
+            // Single-use code.
+            codeStore.delete(code);
+            // Build a properly-signed id_token. Includes the nonce
+            // captured at /authorize so v6's expectedNonce check passes.
+            const idToken = await new SignJWT({
+              email: TEST_EMAIL,
+              email_verified: true,
+              given_name: 'E2E',
+              family_name: 'Tester',
+              name: 'E2E Tester',
+              nonce: stored.nonce,
+            })
+              .setProtectedHeader({ alg: 'RS256', kid: KID })
+              .setIssuer(STUB_ISSUER)
+              .setSubject('e2e-test-user-001')
+              .setAudience(CLIENT_ID)
+              .setIssuedAt()
+              .setExpirationTime('5m')
+              .sign(signingKey);
+            res.setHeader('content-type', 'application/json');
+            res.end(
+              JSON.stringify({
+                access_token: 'fake-access-token',
+                token_type: 'Bearer',
+                expires_in: 3600,
+                id_token: idToken,
+              }),
+            );
+            return;
+          }
+
+          res.statusCode = 404;
+          res.end();
+        } catch (err) {
+          res.statusCode = 500;
+          res.end(String(err));
+        }
+      })();
+    });
+    await new Promise<void>((resolve) => stub.listen(STUB_PORT, resolve));
+
+    // 3. Reset DB + seed tenant + user (whose email matches the stub's
+    //    id_token claim — so loginWithOidc takes the email-link path).
+    admin = new PrismaClient({ datasources: { db: { url: ADMIN_URL } } });
+    await resetTestDb(admin);
+    const tenant = await createTenantForTest(admin, {
+      slug: 'oidc-e2e',
+      name: 'OIDC E2E',
+      displayName: 'OIDC E2E',
+      allowedEmailDomains: ['example.com'],
+    });
+    tenantId = tenant.id;
+    const user = await admin.user.create({
+      data: { email: TEST_EMAIL, displayName: 'Pre-seeded', status: 'ACTIVE' },
+    });
+    userId = user.id;
+    await admin.tenantMembership.create({
+      data: { userId, tenantId, role: 'member', status: 'active' },
+    });
+
+    // 4. Boot the Nest app.
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleRef.createNestApplication({ logger: ['error', 'warn'] });
+    await app.init();
+    await app.listen(0);
+    url = await app.getUrl();
+  }, 60_000);
+
+  afterAll(async () => {
+    await admin?.$disconnect();
+    await app?.close();
+    if (stub) {
+      await new Promise<void>((resolve, reject) =>
+        stub.close((err) => (err ? reject(err) : resolve())),
+      );
+    }
+  }, 30_000);
+
+  it('full happy path — /start → /authorize → /callback → /me', async () => {
+    // Step 1 — /start. App generates state+nonce+PKCE, stashes in cookie,
+    // redirects to the stub IdP's /authorize.
+    const startRes = await fetch(`${url}/auth/oidc/google/start`, { redirect: 'manual' });
+    expect(startRes.status).toBe(302);
+    const oauthCookie = extractCookie(startRes);
+    expect(oauthCookie).toBeTruthy();
+
+    const authUrl = new URL(startRes.headers.get('location')!);
+    expect(authUrl.origin).toBe(STUB_ISSUER);
+    expect(authUrl.pathname).toBe('/authorize');
+    expect(authUrl.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(authUrl.searchParams.get('state')?.length).toBeGreaterThan(0);
+    expect(authUrl.searchParams.get('nonce')?.length).toBeGreaterThan(0);
+    expect(authUrl.searchParams.get('client_id')).toBe(CLIENT_ID);
+    expect(authUrl.searchParams.get('scope')).toContain('openid');
+
+    // Step 2 — simulate user "logging in" at the IdP. Hit /authorize
+    // directly; stub returns 302 to the app's callback URL with code.
+    const idpRes = await fetch(authUrl.href, { redirect: 'manual' });
+    expect(idpRes.status).toBe(302);
+    const callbackBack = new URL(idpRes.headers.get('location')!);
+    expect(callbackBack.pathname).toBe('/auth/oidc/google/callback');
+    expect(callbackBack.searchParams.get('code')?.length).toBeGreaterThan(0);
+    expect(callbackBack.searchParams.get('iss')).toBe(STUB_ISSUER);
+
+    // Step 3 — /callback with the IdP's code+state+iss. Cookie carries
+    // the OAuth state so v6 can validate state+nonce+pkce.
+    const callbackRes = await fetch(
+      `${url}/auth/oidc/google/callback?${callbackBack.searchParams.toString()}`,
+      {
+        headers: { cookie: oauthCookie! },
+        redirect: 'manual',
+      },
+    );
+    expect(callbackRes.status).toBe(302);
+    expect(callbackRes.headers.get('location')).toBe('/');
+    const sessionCookie = extractCookie(callbackRes);
+    expect(sessionCookie).toBeTruthy();
+    expect(sessionCookie).toMatch(/panorama_session=/);
+
+    // Step 4 — /auth/me with the freshly-issued session cookie.
+    const meRes = await fetch(`${url}/auth/me`, { headers: { cookie: sessionCookie! } });
+    expect(meRes.status).toBe(200);
+    const me = (await meRes.json()) as {
+      userId: string;
+      email: string;
+      provider: string;
+      currentTenantId: string;
+      currentRole: string;
+    };
+    expect(me.userId).toBe(userId);
+    expect(me.email).toBe(TEST_EMAIL);
+    expect(me.provider).toBe('google');
+    expect(me.currentTenantId).toBe(tenantId);
+    expect(me.currentRole).toBe('member');
+
+    // Step 5 — confirm the new AuthIdentity row was created with the
+    // IdP's `sub` as the lookup key (per #187: subject = sub for OIDC,
+    // NOT the email).
+    const identity = await admin.authIdentity.findFirst({
+      where: { userId, provider: 'google' },
+    });
+    expect(identity).toBeTruthy();
+    expect(identity?.subject).toBe('e2e-test-user-001');
+    expect(identity?.emailAtLink).toBe(TEST_EMAIL);
+  }, 30_000);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       eslint:
         specifier: ^9.16.0
         version: 9.39.4(jiti@2.7.0)
+      jose:
+        specifier: ^6
+        version: 6.2.3
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -9054,7 +9057,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -9087,7 +9090,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -9101,7 +9104,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Summary

Closes the long-standing **"OIDC NOT verified end-to-end"** caveat called out in PRs #171 (openid-client v6 migration) and #183 (v6 hardening).

Drives the full Authorization Code Flow through the controller against an in-process HTTP stub IdP that speaks just enough OpenID Connect to satisfy openid-client v6.

## Topology

\`\`\`
test process ──fetch──→ Nest core-api ──HTTP──→ stub IdP (in-process)
\`\`\`

## What the stub does

| endpoint | purpose |
|---|---|
| \`/.well-known/openid-configuration\` | discovery metadata |
| \`/jwks\` | single RSA public key (RS256) |
| \`/authorize\` | records (state, nonce, PKCE); 302 back with \`code+state+iss\` |
| \`/token\` | verifies PKCE code_verifier; returns RS256-signed id_token with the captured nonce |

## What the test asserts (5 ordered checks)

1. \`/start\` returns 302 to stub \`/authorize\` with state + nonce + PKCE
2. Stub \`/authorize\` returns 302 to \`/callback\` with code + state + **iss** (RFC 9207 — exercises #172's iss-forwarding fix)
3. \`/callback\` exchanges code → token, validates id_token signature against \`/jwks\`, validates nonce + state, sets session cookie
4. \`/auth/me\` with the session cookie returns the right user shape
5. \`AuthIdentity\` row created with \`subject = IdP \`sub\`\` (per #187)

## Two small enabling changes

| file | change |
|---|---|
| \`auth.config.ts\` | New \`OIDC_GOOGLE_ISSUER\` env override (default unchanged: prod Google). Lets the test point at the stub. NEVER set in production. |
| \`oidc.service.ts\` | New \`OIDC_ALLOW_INSECURE_ISSUER=true\` env-gated opt-in for HTTP issuers. v6 refuses HTTP for the discovery fetch itself; passes via the \`execute: [allowInsecureRequests]\` option on the 5th arg of \`discovery()\` so the relaxation applies **before** the fetch (post-discovery \`allowInsecureRequests(config)\` is too late). NEVER set in production. |

## New dependency

\`jose@^6\` added to \`apps/core-api\` devDependencies for JWT signing + JWK export in the stub. Was already transitively present via openid-client (which uses jose internally); now it's explicit.

## Verification

- \`pnpm typecheck\` — 0 errors
- \`pnpm lint\` — clean
- \`pnpm test --force\` (core-api) — **418/418** (was 417; +1 new e2e)
- New test runs in ~830ms

## NOT in scope (separate follow-ups if anyone wants them)

- IdP error path (\`?error=access_denied\`) — controller-level guards already covered by \`oidc-callback-validation.test.ts\` (#172).
- Microsoft provider — same code path; one provider proves the wiring.
- Negative tests (state mismatch, expired token, missing nonce, wrong iss). Easy to add by mutating the stub's responses; not needed to close #92.

Closes #92.

## Test plan

- [ ] CI green