### PR TITLE
docs(readme): align trilingual READMEs with public-preview pivot

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,8 +1,8 @@
 # Panorama
 
-> Plataforma open-source unificada para **gestión de activos de TI + gestión operativa de flota**.
-> Sucesor de ejecutar [Snipe-IT](https://snipeitapp.com) junto con un overlay de reservas a medida —
-> un solo sistema, trilingüe, auto-hospedable, API-first.
+> Una plataforma open-source para **activos de TI + flota operativa** — notebooks, vehículos, licencias, equipos, en un solo panel.
+> Postgres RLS multi-tenant, OIDC, registro de auditoría con hash-chain, trilingüe EN/PT-BR/ES.
+> AGPL-3.0 (fork-friendly). Vista previa hospedada gratuita próximamente.
 
 <p align="center">
   <em>Un solo panel para notebooks, licencias, móviles, montacargas, furgonetas — y todo lo demás.</em>
@@ -20,20 +20,31 @@
 
 ## ¿Por qué Panorama?
 
-Hoy, las flotas que también manejan inventario de TI terminan cosiendo dos sistemas:
+Los equipos que gestionan tanto activos de TI (notebooks, licencias, móviles) como equipos
+operativos (vehículos, montacargas, herramientas) terminan corriendo dos sistemas separados —
+dos bases de datos, dos superficies de autenticación, dos pistas de auditoría, usuarios
+duplicados y una integración frágil entre ellos.
 
-- **Snipe-IT** (Laravel, AGPL-3.0) — excelente para TI, débil en reservas con antelación, débil en campos específicos de vehículo
-- **Un overlay hecho a medida** como [SnipeScheduler-FleetManager](https://github.com/VitorMRodovalho/SnipeScheduler-FleetManager) — atornillado sobre Snipe-IT para reservas, inspecciones, capacitación del conductor, particionado multi-entidad
-
-Correr los dos significa: dos bases de datos, dos superficies de autenticación, dos
-pistas de auditoría, usuarios duplicados, dos caminos de upgrade y una frontera HTTP
-frágil entre ambos. Panorama absorbe ambos conjuntos de funcionalidades en un solo modelo
-de dominio, un solo plano de datos y una sola superficie de administración.
+Panorama es una sola plataforma para ambos. Modelo de dominio único, plano de datos único,
+superficie de administración única. Multi-tenant por construcción (Postgres RLS forzado en
+cada tabla scoped por tenant). Auditoría hash-chained, con detección de manipulación. UI
+trilingüe desde el día 1 (EN/PT-BR/ES). Auto-hospédalo o usa la vista previa hospedada.
 
 ## Estado
 
-🚧 **Pre-alpha — greenfield.** Inicio 2026-04-17. Arquitectura y nombre abiertos a revisión.
-Ver [`docs/adr/`](./docs/adr/) para las decisiones registradas hasta hoy.
+🚧 **Acceso anticipado — abierto al uso, esperá aristas.** Inicio 2026-04-17.
+
+- **Backend:** listo para producción (NestJS 11 + Prisma 6 + Postgres RLS + OIDC probado
+  end-to-end vía [#92](https://github.com/VitorMRodovalho/panorama/issues/92)). Dependencias
+  al día hasta 2026-05-09 ([#123](https://github.com/VitorMRodovalho/panorama/issues/123)).
+- **App web:** en construcción activa. ~10% de la superficie de funcionalidades hoy;
+  navegación + CRUD de activos + formularios de checkout en proceso
+  ([#52](https://github.com/VitorMRodovalho/panorama/issues/52)).
+- **Vista previa hospedada:** abre cuando la [Wave 0 readiness](./docs/audits/HANDOFF-2026-05-09-session-end.md)
+  cierre (Privacy + ToS + status page + fix de audit chain + endpoint de export de datos).
+
+Decisiones de arquitectura en [`docs/adr/`](./docs/adr/); estado actual + plan de olas en
+[`docs/audits/HANDOFF-2026-05-09-session-end.md`](./docs/audits/HANDOFF-2026-05-09-session-end.md).
 
 ## Ediciones
 
@@ -41,29 +52,32 @@ Ver [`docs/adr/`](./docs/adr/) para las decisiones registradas hasta hoy.
 |---------------|---------------|------------|----------------------------------------------------------------------|
 | **Community** | AGPL-3.0      | Este repo  | Auto-hospedaje completo para cualquier tamaño, sin feature gating en el core |
 | **Enterprise**| Comercial     | Repositorio privado `panorama-enterprise` (tomado en build time) | Conectores SSO especializados, paquetes de auditoría SOC-2, white-label, soporte 24×7 |
-| **Cloud**     | SaaS gestionado | Operado por nosotros | Onboarding rápido, Postgres + backups + parches a nuestra cuenta |
+| **Vista previa hospedada** | Gratis (acceso anticipado) | Operado por nosotros | Instancia hospedada gratis para evaluación; abre cuando la Wave 0 readiness cierre (ver handoff) |
 
 La edición **Community** es la implementación de referencia — todo en ella debe funcionar
 extremo-a-extremo sin código Enterprise. Enterprise es **aditivo**, nunca sustractivo.
 
 ## Pilares de funcionalidades
 
-| Pilar | De Snipe-IT mantenemos | De FleetManager mantenemos | Panorama añade |
-|-------|------------------------|-----------------------------|----------------|
-| **Activos** | Hardware/Licencia/Accesorio/Consumible/Componente/Kits, Categorías, Fabricantes, Modelos, Proveedores, Estados, Campos/Fieldsets personalizados, Eventos de ciclo de vida, Depreciación, Aceptación/EULA | Modelo vehículo-first, validación de VIN/placa duplicada, prefijo de etiqueta por empresa | Abstracción `assetable` unificada: cualquier tipo de activo puede ser reservable |
-| **Reservas** | — | Reserva con antelación + workflow de aprobación, reservas recurrentes, blackouts, exigencia de capacitación, auto-aprobación VIP, carrito multi-activo | Calendario de primera clase, detección de conflicto con `FOR UPDATE`, matrices de aprobación configurables |
-| **Inspecciones** | — | Checklist configurable (Quick 4 / Full 50 ítems / Off), foto, strip de EXIF, comparación antes/después | Checklists arbitrarios por tipo de activo, captura de firma, offline-first en móvil |
-| **Mantenimiento** | Mantenimientos de activo | Flag al devolver, alertas por KM/tiempo | Alertas predictivas, calendarios por tipo, portal de proveedor |
-| **Personas** | Usuarios, Grupos, Departamentos, Ubicaciones, Empresas, Permisos | Validez de capacitación del conductor, sync OAuth por e-mail | SCIM 2.0, mapeo de grupo vía IdP, matriz RBAC por empresa |
-| **Multi-tenancy**| Empresas (row-level), flag de permiso por empresa | Filtrado por empresa en vehículos/reservas | Tenancy estricto a nivel de consulta + claves de caché tenant-aware |
-| **Autenticación**| LDAP, SAML, OAuth Google/Microsoft, tokens API Passport, 2FA | OAuth para web, token para CLI | OIDC, SAML, provisioning SCIM, mapeo de grupo por IdP, WebAuthn, API keys de corta duración |
-| **Notificaciones**| E-mail, Slack, Teams, Google Chat | SMTP + Teams por evento, recordatorios de atraso, expiración de capacitación | Webhooks, PagerDuty, event bus configurable (`panorama.asset.checked_out`), entrega por cola |
-| **Reportes**| 20+ reportes nativos, exportación CSV | Utilización, compliance, analítica de conductor | ReportTemplate 2.0: guardar-como-vista, programar, enviar por mail; export CSV/XLSX/PDF |
-| **Etiquetas/Códigos**| PDFs QR + 1D vía TCPDF | — | Renderizado SVG en servidor, plantillas por tenant |
-| **Importadores**| CSV para toda entidad principal | — | CSV idempotente con preview dry-run, CLI `panorama migrate-from-snipeit` |
-| **API**| REST v1 (1.379 rutas), tokens OAuth 2 Passport | — | REST + OpenAPI 3.1 tipado, GraphQL opcional, webhooks con firma HMAC |
-| **Observabilidad**| Log de actividad, backups Spatie | Log de actividad, monitor de salud de CRON | Trazas OpenTelemetry, métricas Prometheus, logs JSON estructurados |
-| **i18n**| 50+ traducciones de la comunidad | Solo inglés | EN / PT-BR / ES de primera clase, framework para añadir más idiomas |
+> Listo = funciona end-to-end hoy. En construcción = desarrollo activo para 0.3.
+> Planeado = en el roadmap (0.4+).
+
+| Pilar | Estado |
+|-------|--------|
+| **Activos** | **Listo:** schema core, Categorías, Fabricantes, Modelos, prefijo de tag, campos vehiculares. **Planeado (0.4+):** Custom Fields & Fieldsets, Proveedores, Depreciación, Status Labels, Aceptación/EULA. |
+| **Reservas** | **Listo:** reserva con antelación + workflow de aprobación, carrito (multi-activo), blackouts, detección de conflicto bajo `FOR UPDATE` SERIALIZABLE. **En construcción:** UI de gestión de blackouts, sweep de detección de atraso + señal en UI. **Planeado (0.4+):** reservas recurrentes, gating de compliance de capacitación, matrices de aprobación configurables. |
+| **Inspecciones** | **Listo:** templates configurables (por tenant), evidencia fotográfica con strip de EXIF, versionado de ítems vía snapshot, workflow FAIL-review, sweep de retención de fotos. **Planeado (0.4+):** captura de firma, offline-first en móvil, comparación antes/después. |
+| **Mantenimiento** | **En construcción:** apertura/listado/cierre manual de ticket + flip de estado del activo. **Planeado (0.4+):** auto-sugerencia desde inspección FAIL o flag de damage, alertas predictivas por KM/tiempo, portal del proveedor. |
+| **Personas** | **Listo:** Usuarios, TenantMembership con role + status, OIDC + auth e-mail/contraseña, flujo de invitación. **Planeado (0.4+):** SCIM 2.0, mapeo de grupo vía IdP. SAML/LDAP fuera del roadmap pre-1.0. |
+| **Multi-tenancy** | **Listo:** Postgres RLS en la capa de query, GUC `panorama.current_tenant` enforced vía `runInTenant`, FORCE RLS en cada tabla scoped por tenant, trigger de FK cross-tenant. |
+| **Autenticación** | **Listo:** OIDC (Google + Microsoft Entra) con gate `email_verified` + override Workspace `hd`, e-mail/contraseña con argon2id, Personal Access Tokens. **Planeado (0.4+):** SAML, WebAuthn. |
+| **Notificaciones** | **Listo:** event bus interno (`panorama.*.*`), registry de canal por evento, audit hash-chained de manipulación, canal de e-mail de invitación. **Planeado (0.4+):** conectores Slack/Teams/PagerDuty, entrega por webhook con HMAC, e-mails de ciclo de vida de reserva. |
+| **Reportes** | **Planeado (0.4+):** guardar-como-vista, programar, enviar por mail; export CSV/XLSX/PDF. Nada listo hoy. |
+| **Etiquetas/Códigos** | **Planeado (0.4+):** renderizado SVG en servidor, plantillas por tenant. Nada listo hoy. |
+| **Importadores** | **Listo:** CSV importer + CLI `panorama-migrator` con adapters para sistemas upstream de TI/flota. |
+| **API** | **Listo:** REST bajo NestJS, OpenAPI tipado auto-generado, shim de compatibilidad autenticado por PAT para clientes legacy de TI. **Planeado (0.4+):** webhooks con HMAC. GraphQL **no** está en el roadmap. |
+| **Observabilidad** | **Listo:** logs JSON estructurados vía Pino, audit hash chain, threshold de coverage de vitest. **Planeado (0.4+):** trazas OpenTelemetry, métricas Prometheus. |
+| **i18n** | **Listo:** framework EN/PT-BR/ES + gate de CI (cada clave debe existir en los tres locales). **En construcción:** ~80% de las strings web aún hardcoded en inglés; migración a UI completamente traducida ocurre durante prep del pilot. |
 
 ## Arquitectura en una pantalla
 
@@ -108,5 +122,5 @@ Ver [LICENSE](./LICENSE) y [docs/es/licenciamiento.md](./docs/es/licenciamiento.
 
 ## Créditos
 
-- Derivado del trabajo en [SnipeScheduler-FleetManager](https://github.com/VitorMRodovalho/SnipeScheduler-FleetManager) por Vitor Rodovalho, a su vez un fork de [SnipeScheduler](https://github.com/JSY-Ben/SnipeScheduler) de Ben Pirozzolo.
-- Cobertura de funcionalidades mapeada contra [Snipe-IT](https://github.com/grokability/snipe-it) (AGPL-3.0, © Grokability Inc.).
+- Atribución de la cadena de fork por obligación AGPL — ver [README.md](./README.md) sección Credits.
+- Agradecimientos a los proyectos OSS que usamos — ver `THIRD_PARTY_NOTICES.md` al momento del release.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Panorama
 
-> Unified open-source platform for **IT asset management + operational fleet management**.
-> The successor to running [Snipe-IT](https://snipeitapp.com) plus a bespoke scheduling overlay —
-> one system, trilingual, self-hostable, API-first.
+> One open-source platform for **IT assets + operational fleet** — laptops, vehicles, licenses, equipment, in one pane.
+> Multi-tenant Postgres RLS, OIDC, hash-chained audit trail, trilingual EN/PT-BR/ES.
+> AGPL-3.0 (fork-friendly). Free hosted preview coming.
 
 <p align="center">
   <em>One pane of glass for laptops, licences, phones, forklifts, vans, and everything in between.</em>
@@ -20,27 +20,41 @@
 
 ## Why Panorama?
 
-Today, fleets that also have IT inventory tend to stitch together:
+Most teams that manage both IT assets (laptops, licenses, phones) and operational equipment
+(vehicles, forklifts, tools) end up running two separate systems — two databases, two auth
+surfaces, two audit trails, duplicate users, and a brittle integration between them.
 
-- **Snipe-IT** (Laravel, AGPL-3.0) — excellent IT asset management, weak on advance reservation workflows, weak on vehicle-specific fields
-- **A custom overlay** like [SnipeScheduler-FleetManager](https://github.com/VitorMRodovalho/SnipeScheduler-FleetManager) — bolted on top of Snipe-IT to handle reservations, inspections, driver training, multi-entity partitioning
-
-Running both means two databases, two auth surfaces, two audit trails, duplicate users,
-two upgrade paths, and a brittle HTTP boundary between them. Panorama absorbs both sets of
-features into a single domain model, a single data plane, and a single admin surface.
+Panorama is one platform for both. Single domain model, single data plane, single admin surface.
+Multi-tenant from construction (Postgres RLS forced at every tenant-scoped table). Hash-chained,
+tamper-detected audit log. Trilingual UI from day one (EN/PT-BR/ES). Self-host or use the
+hosted preview.
 
 ## Status
 
-🚧 **Pre-alpha — greenfield.** Bootstrapped 2026-04-17. Architecture and name open to review.
-See [`docs/adr/`](./docs/adr/) for the decisions recorded so far.
+🚧 **Early access — open for use, expect rough edges.** Bootstrapped 2026-04-17.
+
+- **Backend:** production-ready (NestJS 11 + Prisma 6 + Postgres RLS + OIDC end-to-end tested
+  via [#92](https://github.com/VitorMRodovalho/panorama/issues/92)). Dependency surface current
+  through 2026-05-09 ([#123](https://github.com/VitorMRodovalho/panorama/issues/123)).
+- **Web app:** in active build. ~10% of feature surface today; nav + asset CRUD + checkout
+  forms in flight ([#52](https://github.com/VitorMRodovalho/panorama/issues/52)).
+- **Hosted preview:** opening when [Wave 0 readiness](./docs/audits/HANDOFF-2026-05-09-session-end.md)
+  closes (Privacy + ToS + status page + audit-chain fix + data-export endpoint).
+
+Architecture decisions in [`docs/adr/`](./docs/adr/); current state + wave plan in
+[`docs/audits/HANDOFF-2026-05-09-session-end.md`](./docs/audits/HANDOFF-2026-05-09-session-end.md).
 
 ## Project health & audit trail
 
 A three-wave QA/QC audit was completed on 2026-04-23 covering security, architecture, data,
-UX, ops, product strategy, supply-chain, and AI/MCP exposure. 126 findings documented, 61 open
-as labelled GitHub issues. **Start at [`docs/audits/HANDOFF-2026-04-23.md`](./docs/audits/HANDOFF-2026-04-23.md)**
-for the prioritised action list. Wave reports under [`docs/audits/`](./docs/audits/); filter
-issues by [`audit:wave-1`](https://github.com/VitorMRodovalho/panorama/issues?q=is%3Aissue+label%3Aaudit%3Awave-1),
+UX, ops, product strategy, supply-chain, and AI/MCP exposure. 126 findings documented; most
+high/medium-priority items resolved across the audit-resolution sprint and the 2026-05-09
+deps + Supabase staging session.
+
+**Latest handoff** with current wave plan: [`docs/audits/HANDOFF-2026-05-09-session-end.md`](./docs/audits/HANDOFF-2026-05-09-session-end.md)
+**Original audit punch list:** [`docs/audits/HANDOFF-2026-04-23.md`](./docs/audits/HANDOFF-2026-04-23.md).
+Wave reports under [`docs/audits/`](./docs/audits/); filter open issues by
+[`audit:wave-1`](https://github.com/VitorMRodovalho/panorama/issues?q=is%3Aissue+label%3Aaudit%3Awave-1),
 [`audit:wave-2`](https://github.com/VitorMRodovalho/panorama/issues?q=is%3Aissue+label%3Aaudit%3Awave-2),
 or [`audit:wave-3`](https://github.com/VitorMRodovalho/panorama/issues?q=is%3Aissue+label%3Aaudit%3Awave-3).
 
@@ -50,7 +64,7 @@ or [`audit:wave-3`](https://github.com/VitorMRodovalho/panorama/issues?q=is%3Ais
 |---------------|---------------|------------|----------------------------------------------------------------------|
 | **Community** | AGPL-3.0      | This repo  | Full self-hosting for any size team, no feature gating on core flows |
 | **Enterprise**| Commercial    | Private repo `panorama-enterprise` (pulled at build time) | SSO connectors for niche IdPs, SOC-2 audit packs, white-label, 24×7 support |
-| **Cloud**     | Managed SaaS  | Run by us  | Fastest onboarding, vendor-run Postgres + backups + patching         |
+| **Hosted preview** | Free (early access) | Run by us | Free hosted instance for evaluation; opening when Wave 0 readiness closes (see latest handoff) |
 
 The **Community** edition is the reference implementation — everything in it must work
 end-to-end without Enterprise code. Enterprise is **additive**, never subtractive.
@@ -72,8 +86,8 @@ end-to-end without Enterprise code. Enterprise is **additive**, never subtractiv
 | **Notifications** | **Shipped:** internal event bus (`panorama.*.*`), per-event channel registry, hash-chained tamper-audit, invitation email channel. **Planned (0.4+):** Slack/Teams/PagerDuty connectors, webhook delivery with HMAC, reservation lifecycle emails. |
 | **Reports** | **Planned (0.4+):** save-as-view, schedule, email; CSV/XLSX/PDF export. Nothing shipped today. |
 | **Labels/Barcodes** | **Planned (0.4+):** server-side SVG rendering, per-tenant templates. Nothing shipped today. |
-| **Importers** | **Shipped:** CSV importer + `panorama-migrator` CLI for Snipe-IT API + SnipeScheduler-FleetManager MySQL dump → fixtures. |
-| **API** | **Shipped:** REST under NestJS, typed OpenAPI auto-generated, Snipe-IT compat shim with PAT auth. **Planned (0.4+):** webhooks with HMAC. GraphQL is **not** on the roadmap — REST + OpenAPI is the contract. |
+| **Importers** | **Shipped:** CSV importer + `panorama-migrator` CLI with adapters for upstream IT-asset and fleet systems. |
+| **API** | **Shipped:** REST under NestJS, typed OpenAPI auto-generated. PAT-authenticated compatibility shim for legacy IT-asset clients. **Planned (0.4+):** webhooks with HMAC. GraphQL is **not** on the roadmap — REST + OpenAPI is the contract. |
 | **Observability** | **Shipped:** structured JSON logging via Pino, audit-event hash chain, vitest coverage threshold. **Planned (0.4+):** OpenTelemetry tracing, Prometheus metrics, slow-query baseline runner. |
 | **i18n** | **Shipped:** EN/PT-BR/ES framework + CI gate (every key must exist in all three locales). **Building:** ~80% of web strings still hardcoded English; the migration to fully-translated UI lands during pilot prep. |
 
@@ -141,22 +155,15 @@ any AI tool with MCP servers configured against this repo, read
 before running anything. The runbook lists the verified MCP server
 allowlist and the incident-response path.
 
-## Migrating from Snipe-IT or SnipeScheduler-FleetManager
+## Importing data from another system
 
-A migration CLI lives in `packages/migrator`. It reads from a running Snipe-IT v8+
-instance via API (no direct DB access required) and, optionally, a
-SnipeScheduler-FleetManager MySQL dump, and produces Panorama fixtures.
+If you're coming from another IT-asset or fleet system, Panorama ships a CSV importer plus
+a `panorama-migrator` CLI in `packages/migrator` that adapts common upstream shapes
+(API + MySQL dump readers) into Panorama fixtures. Existing integrations can keep working
+during transition via the PAT-authenticated compatibility API shim.
 
-```bash
-pnpm --filter @panorama/migrator cli \
-  --snipeit-url https://snipe.example.com \
-  --snipeit-token $SNIPEIT_API_TOKEN \
-  --fleetmanager-dump ./snipescheduler_backup.sql \
-  --out ./migrated
-```
-
-This is **not** a one-way trapdoor. Panorama also ships a Snipe-IT–compatible API
-shim so existing integrations keep working while you migrate.
+See [`packages/migrator/README.md`](./packages/migrator/README.md) for the current adapter
+list and CLI flags.
 
 ## Contributing
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -1,8 +1,8 @@
 # Panorama
 
-> Plataforma open-source unificada para **gestão de ativos de TI + gestão operacional de frota**.
-> O sucessor de rodar [Snipe-IT](https://snipeitapp.com) junto com um overlay de agendamento
-> feito à mão — um sistema só, trilíngue, auto-hospedável, API-first.
+> Uma plataforma open-source para **ativos de TI + frota operacional** — notebooks, veículos, licenças, equipamentos, em um único painel.
+> Postgres RLS multi-tenant, OIDC, trilha de auditoria com hash-chain, trilíngue EN/PT-BR/ES.
+> AGPL-3.0 (fork-friendly). Preview hospedado gratuito chegando.
 
 <p align="center">
   <em>Um único painel para notebooks, licenças, celulares, empilhadeiras, vans — e tudo no meio do caminho.</em>
@@ -20,20 +20,31 @@
 
 ## Por que Panorama?
 
-Hoje, frotas que também têm inventário de TI acabam costurando dois sistemas:
+Times que gerenciam tanto ativos de TI (notebooks, licenças, celulares) quanto equipamento
+operacional (veículos, empilhadeiras, ferramentas) acabam rodando dois sistemas separados —
+dois bancos, duas superfícies de autenticação, duas trilhas de auditoria, usuários duplicados
+e uma integração frágil entre eles.
 
-- **Snipe-IT** (Laravel, AGPL-3.0) — excelente para TI, fraco em reservas agendadas, fraco em campos específicos de veículo
-- **Um overlay customizado** como o [SnipeScheduler-FleetManager](https://github.com/VitorMRodovalho/SnipeScheduler-FleetManager) — parafusado em cima do Snipe-IT para lidar com reservas, inspeções, treinamento de motorista, particionamento multi-entidade
-
-Rodar os dois significa: dois bancos, duas superfícies de autenticação, duas trilhas de
-auditoria, usuários duplicados, dois caminhos de upgrade e uma fronteira HTTP frágil entre
-eles. O Panorama absorve ambos os conjuntos de funcionalidades em um único modelo de domínio,
-um único plano de dados e uma única superfície de administração.
+O Panorama é uma plataforma só pra ambos. Modelo de domínio único, plano de dados único,
+superfície de admin única. Multi-tenant por construção (Postgres RLS forçado em cada tabela
+escopada por tenant). Auditoria hash-chained, com detecção de adulteração. UI trilíngue desde
+o dia 1 (EN/PT-BR/ES). Auto-hospede ou use o preview hospedado.
 
 ## Situação
 
-🚧 **Pré-alpha — greenfield.** Iniciado em 2026-04-17. Arquitetura e nome abertos à revisão.
-Veja [`docs/adr/`](./docs/adr/) para as decisões já registradas.
+🚧 **Acesso antecipado — aberto pra uso, contém arestas.** Iniciado em 2026-04-17.
+
+- **Backend:** pronto pra produção (NestJS 11 + Prisma 6 + Postgres RLS + OIDC testado
+  end-to-end via [#92](https://github.com/VitorMRodovalho/panorama/issues/92)). Dependências
+  atualizadas até 2026-05-09 ([#123](https://github.com/VitorMRodovalho/panorama/issues/123)).
+- **App web:** em construção ativa. ~10% da superfície de funcionalidades hoje; navegação +
+  CRUD de ativos + formulários de checkout em andamento
+  ([#52](https://github.com/VitorMRodovalho/panorama/issues/52)).
+- **Preview hospedado:** abre quando a [Wave 0 readiness](./docs/audits/HANDOFF-2026-05-09-session-end.md)
+  fechar (Privacy + ToS + status page + fix da audit chain + endpoint de export de dados).
+
+Decisões de arquitetura em [`docs/adr/`](./docs/adr/); estado atual + plano de ondas em
+[`docs/audits/HANDOFF-2026-05-09-session-end.md`](./docs/audits/HANDOFF-2026-05-09-session-end.md).
 
 ## Edições
 
@@ -41,29 +52,32 @@ Veja [`docs/adr/`](./docs/adr/) para as decisões já registradas.
 |--------------|---------------|------------|----------------------------------------------------------------------|
 | **Community**| AGPL-3.0      | Este repo  | Auto-hospedagem completa para qualquer tamanho, sem feature gating no core |
 | **Enterprise**| Comercial    | Repositório privado `panorama-enterprise` (puxado no build) | Conectores SSO especializados, pacotes de auditoria SOC-2, white-label, suporte 24×7 |
-| **Cloud**    | SaaS gerenciado | Operado por nós | Onboarding mais rápido, Postgres + backups + patching por nossa conta |
+| **Preview hospedado** | Gratuito (acesso antecipado) | Operado por nós | Instância hospedada gratuita pra avaliação; abre quando a Wave 0 readiness fechar (ver handoff) |
 
 A edição **Community** é a implementação de referência — tudo nela tem que funcionar
 ponta-a-ponta sem código Enterprise. Enterprise é **aditivo**, nunca subtrativo.
 
 ## Pilares de funcionalidades
 
-| Pilar | Do Snipe-IT preservamos | Do FleetManager preservamos | Panorama adiciona |
-|-------|-------------------------|------------------------------|-------------------|
-| **Ativos** | Hardware/Licença/Acessório/Consumível/Componente/Kits, Categorias, Fabricantes, Modelos, Fornecedores, Status, Campos/Fieldsets Customizados, Eventos de ciclo de vida, Depreciação, Aceite/EULA | Modelo veículo-first, validação de VIN/placa duplicada, prefixo de tag por empresa | Abstração `assetable` unificada: qualquer tipo de ativo pode ser reservável |
-| **Reservas**| — | Reserva com antecedência + workflow de aprovação, reservas recorrentes, blackouts, exigência de treinamento, auto-aprovação VIP, cesta multi-ativos | Experiência de calendário de primeira classe, detecção de conflito com `FOR UPDATE`, matrizes de aprovação configuráveis |
-| **Inspeções**| — | Checklist configurável (Quick 4 / Full 50 itens / Off), foto, strip de EXIF, comparação antes/depois | Checklists arbitrários por tipo de ativo, captura de assinatura, offline-first no mobile |
-| **Manutenção**| Manutenções de ativo | Flag de manutenção na devolução, alertas por KM/tempo | Alertas preditivos, cronogramas por tipo, portal do fornecedor |
-| **Pessoas**| Usuários, Grupos, Departamentos, Locais, Empresas, Permissões | Validade de treinamento do motorista, sincronização OAuth por e-mail | SCIM 2.0, mapeamento de grupo via IdP, matriz RBAC por empresa |
-| **Multi-tenancy**| Empresas (row-level), flag de permissão por empresa | Filtragem por empresa nos veículos/reservas | Tenancy estrito no nível da query + chaves de cache tenant-aware |
-| **Autenticação**| LDAP, SAML, OAuth Google/Microsoft, tokens de API Passport, 2FA | OAuth para web, token para CLI | OIDC, SAML, provisionamento SCIM, mapeamento de grupo por IdP, WebAuthn, API keys de curta duração |
-| **Notificações**| E-mail, Slack, Teams, Google Chat | SMTP + Teams por evento, lembretes de atraso, expiração de treinamento | Webhooks, PagerDuty, event bus configurável (`panorama.asset.checked_out`), entrega via fila |
-| **Relatórios**| 20+ relatórios nativos, export CSV | Utilização, compliance, analytics de motorista | ReportTemplate 2.0: salvar-como-view, agendar, enviar por e-mail; export CSV/XLSX/PDF |
-| **Labels/Códigos**| PDFs QR + 1D via TCPDF | — | Renderização SVG no servidor, templates por tenant |
-| **Importadores**| CSV para toda entidade principal | — | CSV idempotente com preview dry-run, CLI `panorama migrate-from-snipeit` |
-| **API**| REST v1 (1.379 rotas), tokens OAuth 2 Passport | — | REST + OpenAPI 3.1 tipado, GraphQL opcional, webhooks com assinatura HMAC |
-| **Observabilidade**| Log de atividade, backups Spatie | Log de atividade, monitor de saúde do CRON | Tracing OpenTelemetry, métricas Prometheus, logs JSON estruturados |
-| **i18n**| 50+ traduções da comunidade | Só inglês | EN / PT-BR / ES de primeira classe, framework para contribuir com mais idiomas |
+> Pronto = funciona ponta-a-ponta hoje. Em construção = desenvolvimento ativo pra 0.3.
+> Planejado = no roadmap (0.4+).
+
+| Pilar | Estado |
+|-------|--------|
+| **Ativos** | **Pronto:** schema core, Categorias, Fabricantes, Modelos, prefixo de tag, campos veiculares. **Planejado (0.4+):** Custom Fields & Fieldsets, Fornecedores, Depreciação, Status Labels, Aceite/EULA. |
+| **Reservas** | **Pronto:** reserva com antecedência + workflow de aprovação, cesta (multi-ativos), blackouts, detecção de conflito sob `FOR UPDATE` SERIALIZABLE. **Em construção:** UI de gestão de blackouts, sweep de detecção de atraso + sinal na UI. **Planejado (0.4+):** reservas recorrentes, gating de compliance de treinamento, matrizes de aprovação configuráveis. |
+| **Inspeções** | **Pronto:** templates configuráveis (por tenant), evidência fotográfica com strip de EXIF, versionamento de itens via snapshot, workflow FAIL-review, sweep de retenção de fotos. **Planejado (0.4+):** captura de assinatura, offline-first no mobile, comparação antes/depois. |
+| **Manutenção** | **Em construção:** abertura/listagem/fechamento manual de ticket + flip de status do ativo. **Planejado (0.4+):** auto-sugestão a partir de inspeção FAIL ou flag de damage, alertas preditivos por KM/tempo, portal do fornecedor. |
+| **Pessoas** | **Pronto:** Usuários, TenantMembership com role + status, OIDC + auth e-mail/senha, fluxo de convite. **Planejado (0.4+):** SCIM 2.0, mapeamento de grupo via IdP. SAML/LDAP fora do roadmap pré-1.0. |
+| **Multi-tenancy** | **Pronto:** Postgres RLS na camada de query, GUC `panorama.current_tenant` enforced via `runInTenant`, FORCE RLS em cada tabela escopada por tenant, trigger de FK cross-tenant. |
+| **Autenticação** | **Pronto:** OIDC (Google + Microsoft Entra) com gate `email_verified` + override Workspace `hd`, e-mail/senha com argon2id, Personal Access Tokens. **Planejado (0.4+):** SAML, WebAuthn. |
+| **Notificações** | **Pronto:** event bus interno (`panorama.*.*`), registry de canal por evento, audit hash-chained de adulteração, canal de e-mail de convite. **Planejado (0.4+):** conectores Slack/Teams/PagerDuty, entrega via webhook com HMAC, e-mails de ciclo de vida de reserva. |
+| **Relatórios** | **Planejado (0.4+):** salvar-como-view, agendar, enviar por e-mail; export CSV/XLSX/PDF. Nada pronto hoje. |
+| **Labels/Códigos** | **Planejado (0.4+):** renderização SVG no servidor, templates por tenant. Nada pronto hoje. |
+| **Importadores** | **Pronto:** CSV importer + CLI `panorama-migrator` com adapters pra sistemas upstream de TI/frota. |
+| **API** | **Pronto:** REST sob NestJS, OpenAPI tipado auto-gerado, shim de compatibilidade autenticado por PAT pra clientes legados de TI. **Planejado (0.4+):** webhooks com HMAC. GraphQL **não** está no roadmap. |
+| **Observabilidade** | **Pronto:** logs JSON estruturados via Pino, audit hash chain, threshold de coverage do vitest. **Planejado (0.4+):** tracing OpenTelemetry, métricas Prometheus. |
+| **i18n** | **Pronto:** framework EN/PT-BR/ES + gate de CI (cada chave precisa existir nos três locais). **Em construção:** ~80% das strings web ainda hardcoded em inglês; migração pra UI totalmente traduzida acontece durante a prep do pilot. |
 
 ## Arquitetura em uma tela
 
@@ -108,5 +122,5 @@ Veja [LICENSE](./LICENSE) e [docs/pt-br/licenciamento.md](./docs/pt-br/licenciam
 
 ## Créditos
 
-- Derivado de trabalho no [SnipeScheduler-FleetManager](https://github.com/VitorMRodovalho/SnipeScheduler-FleetManager) por Vitor Rodovalho, por sua vez um fork do [SnipeScheduler](https://github.com/JSY-Ben/SnipeScheduler) do Ben Pirozzolo.
-- Cobertura de funcionalidades mapeada contra o [Snipe-IT](https://github.com/grokability/snipe-it) (AGPL-3.0, © Grokability Inc.).
+- Atribuição da cadeia de fork por obrigação AGPL — ver [README.md](./README.md) seção Credits.
+- Agradecimentos aos projetos OSS que usamos — ver `THIRD_PARTY_NOTICES.md` no momento do release.

--- a/docs/audits/HANDOFF-2026-05-09-session-end.md
+++ b/docs/audits/HANDOFF-2026-05-09-session-end.md
@@ -355,6 +355,32 @@ Persists for canary onboarding reuse:
 4. **Connection_limit math** — explicit per-Fly-instance value pinned in deploy config; data-architect's caveat about pgBouncer client-connection ceilings.
 5. **Bus factor of 1 (#50)** — at 10 paying tenants, 3am pages are real. Mitigation = "document everything to the level a stranger can run it." That's literally what this handoff is for.
 
+### vitormr.dev personal-page Panorama copy (recommendation, owner action)
+
+The Panorama mention on the maintainer's personal site
+(https://vitormr.dev) currently reads:
+
+> Open-source IT asset + fleet management
+> Successor to Snipe-IT plus a custom scheduling overlay. Multi-tenant
+> Postgres RLS, OIDC, trilingual EN/PT-BR/ES. Born from a real need at
+> AECOM B&P Tunnel program. AGPL-3.0 + Enterprise.
+
+Recommended rewrite (committee delta — Option B, chosen by maintainer
+because Snipe-IT/SnipeScheduler aren't framing the project anymore):
+
+> One open-source platform for IT assets AND operational fleet —
+> laptops, vehicles, licenses, equipment, in one pane.
+> Multi-tenant Postgres RLS, OIDC, hash-chained audit, trilingual
+> EN/PT-BR/ES.
+> AGPL-3.0 (fork-friendly). Free hosted preview coming.
+
+Rationale: drops the "successor to" framing (Panorama stands on its
+own), drops the "AGPL + Enterprise" tag (commercial-leaning;
+inconsistent with free-hosted-preview pivot), keeps technical
+credibility signals (RLS/OIDC/trilingual), keeps licensing
+transparency. Personal-page edit is owner action, not a Panorama-repo
+change.
+
 ---
 
 ## Numbers


### PR DESCRIPTION
## Summary

Removes "successor to Snipe-IT + SnipeScheduler-FleetManager" framing across all three READMEs (EN + PT-BR + ES). Per maintainer direction: Panorama stands on its own; not positioned as a replacement for legacy systems.

## What changed

| change | scope |
|---|---|
| **Tagline** | drops "successor to ..."; leads with what Panorama IS |
| **Why Panorama** | generic stitching pain instead of naming Snipe-IT vs FleetManager |
| **Status** | refreshed: backend prod-ready, web in build, hosted preview gated on Wave 0 |
| **Editions table** | "Cloud — Managed SaaS" → "Hosted preview — Free (early access)" |
| **PT-BR + ES "Pilares" tables** | collapsed the explicit "Snipe-IT mantém / FleetManager mantém / Panorama adiciona" three-column shape into single status column (mirrors EN) |
| **Importer + API rows** | softened from named-system mentions to factual capability descriptions |
| **"Migrating from..." (EN)** | renamed to "Importing data from another system"; neutral tone |
| **Audit trail pointer** | now points to 2026-05-09-v2 handoff as primary |

## What did NOT change

- **EN Credits section** — unchanged. Fork-chain attribution to SnipeScheduler-FleetManager and Snipe-IT is an AGPL legal obligation; positional removal would violate the licence.
- PT-BR + ES Credits now point at EN's Credits section to consolidate the legal attribution in one place.
- Importer + API capabilities still exist as features; just framed without positioning weight.

## Trilingual parity

EN is the canonical structure; PT-BR + ES align on hero + Why + Status + Editions + Pilares table shape. Earlier drift between the three has been reduced but not perfectly closed — follow-up sweep welcome.

## Bonus

Handoff doc gains the vitormr.dev personal-page rewrite recommendation (Option B, maintainer-selected) for execution by the owner outside this repo.

## Test plan

- [ ] CI green (markdown-only)