### PR TITLE
docs+a11y: Round 1 — Wave 0 quick wins (homepage + runbook + ROLLBACK + a11y)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ coverage/
 .env.local
 .env.*.local
 !.env.example
-apps/*/.env
+apps/*/.env*
 !apps/*/.env.example
 
 # Prisma local bits

--- a/apps/core-api/prisma/migrations/20260419130000_0014_asset_maintenance_flow/ROLLBACK.md
+++ b/apps/core-api/prisma/migrations/20260419130000_0014_asset_maintenance_flow/ROLLBACK.md
@@ -1,10 +1,38 @@
 # Rollback — migration 0014 (asset maintenance flow, ADR-0016)
 
-Destructive — drops two tables, one enum, one trigger function +
-trigger, four+ added columns. Photos in S3 are NOT deleted by this
+**Destructive** — drops two tables, one enum, one trigger function +
+trigger, seven added columns. Photos in S3 are NOT deleted by this
 rollback (audit-safe; manual `mc rm --recursive` if needed).
 
-Run in this order; each block is idempotent.
+## Pre-flight (operator MUST verify BEFORE running SQL)
+
+The running app will throw on missing tables if the rollback SQL
+runs while `FEATURE_MAINTENANCE=true`. Execute pre-flight in this
+order:
+
+1. **Flip the feature flag** — set `FEATURE_MAINTENANCE=false`:
+   ```
+   fly secrets set --app panorama-staging FEATURE_MAINTENANCE=false
+   ```
+   (Or set in `.env` for self-host.)
+
+2. **Restart core-api** — `fly deploy --strategy rolling` for the
+   hosted instance, or `pm2 restart core-api` for self-host. Verify
+   `/health` returns OK after all instances cycle.
+
+3. **Confirm no in-flight maintenance writes** — the SQL block
+   below acquires brief ACCESS EXCLUSIVE locks; check
+   `pg_stat_activity` for any pending `INSERT INTO asset_maintenances`
+   queries and let them complete first.
+
+4. **Communicate the rollback window** to any operators who care
+   about active maintenance tickets — they survive the rollback as
+   audit-event history but the UI/admin surface disappears.
+
+## SQL revert (privileged role)
+
+Run from a psql session against `$DATABASE_PRIVILEGED_URL`. Each
+block is idempotent (uses `IF EXISTS`).
 
 ```sql
 BEGIN;
@@ -58,7 +86,7 @@ DELETE FROM "_prisma_migrations"
 COMMIT;
 ```
 
-## Notes
+## Data-loss warnings
 
 - **Photos in S3** are not removed by the rollback. After confirming
   no business need, run:
@@ -95,10 +123,21 @@ COMMIT;
   only the discriminator is gone. Manual ops process can re-handle
   via reservation cancel / mileage-in.
 
-- **FEATURE_MAINTENANCE** flag should be set to `false` BEFORE running
-  the rollback (otherwise the running app will throw on missing
-  tables until restart). Rollback ordering:
-  1. Set `FEATURE_MAINTENANCE=false` in env.
-  2. Restart core-api.
-  3. Run the rollback SQL.
-  4. Verify `\d asset_maintenances` returns "does not exist".
+## When you would actually revert
+
+Three scenarios that justify rolling back 0014:
+
+1. Maintenance feature causing a critical bug in a tenant that needs
+   immediate isolation (and `FEATURE_MAINTENANCE=false` per-tenant
+   is not enough)
+2. Schema-level data corruption that requires re-applying with a
+   patched migration
+3. ADR-0016 superseded by a follow-up ADR that requires schema reset
+
+## Re-apply pattern
+
+After rollback, re-apply via standard `prisma migrate deploy`. The
+migration is idempotent; no special handling required. The system-
+user demotion step (§5 above) means a re-apply re-promotes the
+demoted users — they retain their `userId` so audit-event references
+stay intact.

--- a/apps/core-api/prisma/migrations/20260428080000_0020_audit_trigger_digest_ms_truncate/ROLLBACK.md
+++ b/apps/core-api/prisma/migrations/20260428080000_0020_audit_trigger_digest_ms_truncate/ROLLBACK.md
@@ -1,19 +1,75 @@
 # Rollback — migration 0020 (audit trigger digest ms-truncate)
 
-```sql
--- Restore the pre-#96 functions (microsecond `now()` directly,
--- exposing the rounding/truncation mismatch documented in
--- migration.sql).
-\\i ../20260426094000_0015_audit_wave1_data_layer_corrections/migration.sql
+## Pre-flight (operator MUST verify BEFORE running)
+
+This is a forward-only fix; rollback resurrects the divergent-digest
+behaviour documented in `migration.sql`. Only roll back if verifier
+tooling regresses against the post-0020 digest format — the pre-#96
+behaviour was provably unreproducible (per the 2026-05-16 data-
+architect scan).
+
+Confirm the regression is real (not transient) before running.
+
+## SQL revert (privileged role)
+
+Run from a psql session against `$DATABASE_PRIVILEGED_URL`. Two
+options depending on your working directory:
+
+**Option 1 — from the repo root:**
+
+```bash
+psql "$DATABASE_PRIVILEGED_URL" \
+  -f apps/core-api/prisma/migrations/20260426094000_0015_audit_wave1_data_layer_corrections/migration.sql
 ```
 
-Rollback restores the divergent-digest behaviour. Don't roll back
-unless verifier tooling regresses — the fix is forward-compatible
-with all prior fires (verifiers that handle the rounding ambiguity
-keep working) and uniquely deterministic from this point on.
+**Option 2 — inside psql (from any CWD):**
 
-The cutover marker emitted at apply time (`panorama.audit.chain_repair`
-with `metadata.migration = '0020'`) is left in place on rollback
-— it's an audit event documenting that the fix WAS applied and
-later reverted. Verifier tooling should treat the marker as a
-historical waypoint regardless of whether it's still in force.
+```sql
+\i apps/core-api/prisma/migrations/20260426094000_0015_audit_wave1_data_layer_corrections/migration.sql
+```
+
+(The `\i` directive resolves paths relative to the CWD `psql` was
+launched from; if you `cd` into the migration directory first, use
+`\i ../20260426094000_0015_audit_wave1_data_layer_corrections/migration.sql`
+instead.)
+
+This re-applies the pre-#96 trigger functions (microsecond `now()`
+directly, exposing the rounding / truncation mismatch documented in
+migration 0020's commentary).
+
+## Data-loss warnings
+
+- The cutover marker emitted at apply time (`panorama.audit.chain_repair`
+  with `metadata.migration = '0020'`) is **left in place** on
+  rollback — it's an audit event documenting that the fix WAS
+  applied and later reverted. Verifier tooling should treat the
+  marker as a historical waypoint regardless of whether the fix is
+  still in force.
+- Audit-event rows written DURING the period 0020 was applied
+  retain their ms-truncated `occurredAt` digest. These rows are
+  correct as written; the rollback does NOT recompute them.
+
+## When you would actually revert
+
+Only if verifier tooling regresses against the post-0020 digest
+format AND the regression cannot be fixed in the verifier itself.
+The pre-#96 behaviour re-introduces the original bug — prefer to
+patch the verifier first.
+
+## Re-apply pattern
+
+Forward-only by design. If 0020 is rolled back and then re-applied
+after new audit-event rows have been written:
+
+1. Rows written DURING the rollback window use the pre-0020 (raw
+   microsecond `now()`) digest format
+2. Re-applying 0020 emits a NEW `panorama.audit.chain_repair`
+   marker AND starts ms-truncating again from that marker forward
+3. The verifier MUST understand BOTH chain-repair markers as
+   "format change points" and apply the correct rounding rule to
+   events on each side of each marker
+
+If the verifier doesn't support multi-marker traversal, expect
+digest mismatches on rows from the rollback window. There's no
+automated remediation — the rows are correct as written; the
+verifier needs the multi-marker handling.

--- a/apps/web/src/app/(authenticated)/reservations/calendar/page.tsx
+++ b/apps/web/src/app/(authenticated)/reservations/calendar/page.tsx
@@ -252,19 +252,24 @@ export default async function ReservationCalendarPage({
 function CalendarLegend({ t }: { t: (k: string) => string }): ReactNode {
   return (
     <div className="panorama-calendar-legend">
-      <Swatch kind="pending" label={t('calendar.legend.pending')} />
-      <Swatch kind="approved" label={t('calendar.legend.approved')} />
-      <Swatch kind="checkedout" label={t('calendar.legend.checkedout')} />
-      <Swatch kind="returned" label={t('calendar.legend.returned')} />
+      <Swatch kind="pending" label={t('calendar.legend.pending')} prefix="P" />
+      <Swatch kind="approved" label={t('calendar.legend.approved')} prefix="A" />
+      <Swatch kind="checkedout" label={t('calendar.legend.checkedout')} prefix="O" />
+      <Swatch kind="returned" label={t('calendar.legend.returned')} prefix="R" />
       <Swatch kind="blackout" label={t('calendar.legend.blackout')} />
     </div>
   );
 }
 
-function Swatch({ kind, label }: { kind: string; label: string }): ReactNode {
+function Swatch({ kind, label, prefix }: { kind: string; label: string; prefix?: string }): ReactNode {
   return (
     <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, marginRight: 12 }}>
-      <span className={`panorama-swatch panorama-block--${kind}`} />
+      <span className={`panorama-swatch panorama-block--${kind}`} aria-hidden="true" />
+      {prefix ? (
+        <kbd style={{ fontSize: 11, fontWeight: 600, opacity: 0.8 }} aria-hidden="true">
+          {prefix}
+        </kbd>
+      ) : null}
       <span style={{ fontSize: 12 }}>{label}</span>
     </span>
   );
@@ -311,10 +316,20 @@ function reservationKind(r: ReservationView): string {
   return 'approved';
 }
 
+const STATUS_PREFIX: Record<string, string> = {
+  pending: 'P',
+  approved: 'A',
+  checkedout: 'O',
+  returned: 'R',
+  cancelled: 'X',
+  rejected: '!',
+};
+
 function labelForReservation(r: ReservationView, locale: SupportedLocale): string {
   const fmt = (d: string): string =>
     new Date(d).toLocaleString(locale, { month: 'numeric', day: 'numeric', hour: 'numeric' });
-  return `${fmt(r.startAt)}–${fmt(r.endAt)}`;
+  const prefix = STATUS_PREFIX[reservationKind(r)] ?? '';
+  return prefix ? `${prefix} · ${fmt(r.startAt)}–${fmt(r.endAt)}` : `${fmt(r.startAt)}–${fmt(r.endAt)}`;
 }
 
 function atStartOfDay(d: Date): Date {

--- a/apps/web/src/app/(authenticated)/reservations/page.tsx
+++ b/apps/web/src/app/(authenticated)/reservations/page.tsx
@@ -464,6 +464,9 @@ export default async function ReservationsPage({
                                   <input
                                     type="text"
                                     name="note"
+                                    aria-label={messages.t(
+                                      'reservation.batch.approve.note_placeholder',
+                                    )}
                                     placeholder={messages.t(
                                       'reservation.batch.approve.note_placeholder',
                                     )}
@@ -500,6 +503,9 @@ export default async function ReservationsPage({
                                     minLength={1}
                                     maxLength={500}
                                     rows={2}
+                                    aria-label={messages.t(
+                                      'reservation.action.reject.note_placeholder',
+                                    )}
                                     placeholder={messages.t(
                                       'reservation.action.reject.note_placeholder',
                                     )}
@@ -534,6 +540,9 @@ export default async function ReservationsPage({
                                 <input
                                   type="text"
                                   name="reason"
+                                  aria-label={messages.t(
+                                    'reservation.batch.cancel.note_placeholder',
+                                  )}
                                   placeholder={messages.t(
                                     'reservation.batch.cancel.note_placeholder',
                                   )}
@@ -578,6 +587,9 @@ export default async function ReservationsPage({
                                 type="text"
                                 name="note"
                                 maxLength={500}
+                                aria-label={messages.t(
+                                  'reservation.action.approve.note_placeholder',
+                                )}
                                 placeholder={messages.t(
                                   'reservation.action.approve.note_placeholder',
                                 )}
@@ -630,6 +642,9 @@ export default async function ReservationsPage({
                                 minLength={1}
                                 maxLength={500}
                                 rows={2}
+                                aria-label={messages.t(
+                                  'reservation.action.reject.note_placeholder',
+                                )}
                                 placeholder={messages.t(
                                   'reservation.action.reject.note_placeholder',
                                 )}
@@ -661,6 +676,9 @@ export default async function ReservationsPage({
                             <input
                               type="number"
                               name="mileage"
+                              aria-label={messages.t(
+                                'reservation.action.checkout.mileage_placeholder',
+                              )}
                               placeholder={messages.t(
                                 'reservation.action.checkout.mileage_placeholder',
                               )}
@@ -671,6 +689,9 @@ export default async function ReservationsPage({
                             <input
                               type="text"
                               name="condition"
+                              aria-label={messages.t(
+                                'reservation.action.checkout.condition_placeholder',
+                              )}
                               placeholder={messages.t(
                                 'reservation.action.checkout.condition_placeholder',
                               )}
@@ -692,6 +713,9 @@ export default async function ReservationsPage({
                             <input
                               type="number"
                               name="mileage"
+                              aria-label={messages.t(
+                                'reservation.action.checkin.mileage_placeholder',
+                              )}
                               placeholder={messages.t(
                                 'reservation.action.checkin.mileage_placeholder',
                               )}
@@ -702,6 +726,9 @@ export default async function ReservationsPage({
                             <input
                               type="text"
                               name="condition"
+                              aria-label={messages.t(
+                                'reservation.action.checkin.condition_placeholder',
+                              )}
                               placeholder={messages.t(
                                 'reservation.action.checkin.condition_placeholder',
                               )}
@@ -714,6 +741,9 @@ export default async function ReservationsPage({
                             <input
                               type="text"
                               name="damageNote"
+                              aria-label={messages.t(
+                                'reservation.action.checkin.damage_note_placeholder',
+                              )}
                               placeholder={messages.t(
                                 'reservation.action.checkin.damage_note_placeholder',
                               )}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -36,7 +36,7 @@ export default async function RootLayout({
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
       <body>
-        <main className="panorama-main">{children}</main>
+        <div className="panorama-main">{children}</div>
       </body>
     </html>
   );

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -51,7 +51,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps): Promi
       : messages.t('login.subtitle.default');
 
   return (
-    <div className="panorama-login">
+    <main className="panorama-login">
       <h1>{messages.t('login.title')}</h1>
       <p className="muted">{subtitle}</p>
 
@@ -115,6 +115,6 @@ export default async function LoginPage({ searchParams }: LoginPageProps): Promi
           </>
         ) : null}
       </div>
-    </div>
+    </main>
   );
 }

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -121,10 +121,10 @@ export async function AppShell({ children }: { children: ReactNode }): Promise<R
         </div>
       </header>
 
-      <section className="panorama-content">
+      <main className="panorama-content">
         <AppNav items={navItems} />
         {children}
-      </section>
+      </main>
     </>
   );
 }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -6,9 +6,6 @@ export default defineConfig({
   outDir: '../dist-docs',
   cleanUrls: true,
   lastUpdated: true,
-  // Pre-alpha docs — PT-BR/ES translation stubs intentionally link to
-  // files that will exist later. Tighten once the translations land.
-  ignoreDeadLinks: true,
 
   head: [
     ['link', { rel: 'icon', href: '/favicon.ico' }],

--- a/docs/en/early-access.md
+++ b/docs/en/early-access.md
@@ -1,0 +1,52 @@
+---
+title: Early access
+---
+
+# Early access — Panorama hosted preview
+
+The Panorama hosted preview is **not yet open**. We're working through
+the public-preview readiness checklist (Wave 0 in the
+[roadmap](/en/roadmap)) before the URL goes live.
+
+## When it opens
+
+The hosted preview will be **free, no SLA, data may be wiped with 30
+days notice** (operational commitments codified in
+[ADR-0014](/adr/0014-public-hosted-instance)). You'll be able to:
+
+- Sign up via Google or Microsoft OIDC (no password)
+- Provision your own tenant in one click
+- Bring real fleet or asset data and try the workflows
+- Export your data anytime
+- Delete your tenant anytime (7-day cool-off applies)
+- Talk to the maintainer weekly about what's broken — that's the deal
+
+## Until it opens
+
+- **Watch the repo** — [GitHub Releases](https://github.com/VitorMRodovalho/panorama/releases)
+  will publish the URL-flip release tag
+- **Public roadmap** — [`/en/roadmap`](/en/roadmap) tracks the Wave 0 path
+- **Email** —
+  [vitorodovalho@gmail.com](mailto:vitorodovalho@gmail.com?subject=Panorama%20hosted%20preview%20-%20notify%20me)
+  to follow along; we'll email you when the URL opens
+
+## Self-host alternative
+
+If you'd rather not wait, or you want your data on your own
+infrastructure: Panorama is AGPL-3.0 self-host-friendly. See the
+[self-hosting guide](/en/self-hosting). Same codebase, same features,
+your servers.
+
+## Why "preview" and not "beta"
+
+Different word, different meaning. "Beta" implies "feature-complete,
+hunting bugs." Panorama isn't there yet — the daily-driver UI surface
+is still being built, photo uploads still run synchronously, and the
+hosted instance is **the maintainer's instance** you're welcome to
+use, not a commercial offering. "Preview" describes what's true:
+you'll see something real, with rough edges, while the operator who
+ships it is genuinely available to talk about what's broken.
+
+Bring real data only if you also have a copy elsewhere. We'll be
+honest about what's stable enough to depend on as the surface
+matures.

--- a/docs/en/roadmap.md
+++ b/docs/en/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Target versions and tenant-visible milestones. Living document — last updated 2026-04-18.
+Target versions and tenant-visible milestones. Living document — last updated 2026-05-16.
 
 ## 0.1 — Scaffold (shipped 2026-04-17)
 
@@ -63,15 +63,26 @@ Target versions and tenant-visible milestones. Living document — last updated 
           0.3 (ADR-0009 §"Conflict detection" notes this).
 - [ ] **Step 5** — Snipe-IT API compatibility shim read-only
 
-## 0.3 — Inspections, maintenance, enterprise prep (target Sept 2026)
+## 0.3 — Inspections, maintenance, public-preview readiness (target Sept 2026)
 
 - [~] Configurable checklists (per asset type), photo evidence, EXIF strip
       — see [ADR-0012](../adr/0012-inspection-photo-pipeline.md). Backend
       and web UI feature-complete (steps 2–11). Canary rollout (step 13)
       remains — feature stays dark behind `FEATURE_INSPECTIONS=false`
-      until a pilot tenant validates. See
+      until the public preview opens and a design partner validates. See
       [`docs/en/inspections.md`](./inspections.md) for the operator brief.
-- [ ] Asset maintenances, Snipe-IT-compatible maintenance flow
+- [~] Asset maintenances, Snipe-IT-compatible maintenance flow
+      — see [ADR-0016](../adr/0016-asset-maintenance-flow.md).
+      Feature-complete for Community pending canary; backend + web UI
+      shipped across PRs #132 / #136 / #139 / #140. `FEATURE_MAINTENANCE`
+      ready to flip with first design partner. Enterprise email channel +
+      sister sweeps remain.
+- [~] **Wave 0 — public-preview readiness** (the gate on the hosted URL)
+      — see [`docs/audits/HANDOFF-2026-05-16-wave0-scan.md`](../audits/HANDOFF-2026-05-16-wave0-scan.md)
+      for the round-by-round plan + the 6-agent scan that produced it.
+      ADR-0014 (Public hosted instance), ADR-0018 (Observability), ADR-0019
+      (Worker boundary), ADR-0020 (Self-serve OIDC signup) all landed in
+      Round 0; backend hardening + endpoints + UX work follow.
 - [ ] Mileage + time-based alerts
 - [ ] CSV exports for every list view
 - [ ] Training-expiry gating
@@ -79,13 +90,17 @@ Target versions and tenant-visible milestones. Living document — last updated 
 - [ ] Just-in-time tenant membership based on `allowedEmailDomains` match
       at first OIDC login (gates the enterprise SCIM story)
 
-## 0.4 — Notifications + reports + webhooks (target Oct 2026)
+## 0.4 — Public preview live + notifications + reports (target Oct 2026)
 
+- [ ] Hosted preview URL opens publicly (Wave 0 acceptance closed)
+- [ ] First design partners onboarded via the seeded smoke-tenant pattern
+      — they ARE the canary (per ADR-0014 §A reasoning)
 - [ ] Event bus (NATS JetStream), outbox pattern, delivery retries
 - [ ] Email, Teams, Slack, webhook channels
 - [ ] Saved reports, schedule to email, CSV/XLSX/PDF render
-- [ ] First closed-beta customer live
-- [ ] `panorama-enterprise` private repo spun up; white-label + SOC-2 pack start
+- [ ] Day-60 metrics decision (per [ADR-0014 §3](../adr/0014-public-hosted-instance.md))
+      — go/no-go on paid SKU draft
+- [ ] `panorama-enterprise` private repo decision (gated on day-60 metrics signal)
 
 ## 1.0 GA (target: Q1 2027)
 

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -4,15 +4,20 @@ Esta carpeta contiene las versiones en español de la documentación de producto
 y arquitectura. El README del proyecto trilingüe está en
 [`../../README.es.md`](../../README.es.md).
 
-Documentos principales (las traducciones se añaden a medida que cada documento
-se estabiliza en inglés — los ADRs permanecen en inglés por regla, para evitar
-desincronización entre versiones):
+## Estado de las traducciones
 
-- [Arquitectura](./arquitectura.md) — en preparación (será traducción de `../en/architecture.md`)
-- [Matriz de funcionalidades](./matriz-de-funcionalidades.md) — en preparación
-- [Roadmap](./roadmap.md) — en preparación
-- [Licenciamiento](./licenciamiento.md) — en preparación
+La referencia canónica es la versión en inglés en [`../en/`](../en/). La
+traducción al español se añade a medida que cada documento se
+estabiliza en inglés. Los ADRs permanecen en inglés por regla, para
+evitar desincronización entre versiones.
 
-Mientras tanto, la referencia canónica es la versión en inglés en
-[`../en/`](../en/). Las contribuciones de traducción son muy bienvenidas —
-abrir un PR con `[docs][es]` en el título.
+**En preparación** (todavía no traducidos — siga la versión en inglés):
+
+- Arquitectura → [`../en/architecture.md`](../en/architecture.md)
+- Matriz de funcionalidades → [`../en/feature-matrix.md`](../en/feature-matrix.md)
+- Roadmap → [`../en/roadmap.md`](../en/roadmap.md)
+- Licenciamiento → [`../en/licensing.md`](../en/licensing.md)
+- Self-hosting → [`../en/self-hosting.md`](../en/self-hosting.md)
+
+Las contribuciones de traducción son muy bienvenidas — abrir un PR con
+`[docs][es]` en el título.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,30 +2,52 @@
 layout: home
 hero:
   name: Panorama
-  text: IT assets + operational fleet — in one pane of glass.
-  tagline: Unified open-source platform (AGPL-3.0). Trilingual (EN / PT-BR / ES). Self-hostable.
+  text: Run your IT assets and your operational fleet from one place.
+  tagline: Open source (AGPL-3.0). Trilingual EN / PT-BR / ES. Self-host it, or use the maintainer's hosted preview while we shape it with operators.
   actions:
     - theme: brand
-      text: Read the docs
-      link: /en/architecture
+      text: Get a hosted account
+      link: /en/early-access
     - theme: alt
-      text: View on GitHub
+      text: Self-host on GitHub
       link: https://github.com/VitorMRodovalho/panorama
-features:
-  - title: One system for both worlds
-    details: Absorbs Snipe-IT's IT asset management AND SnipeScheduler-FleetManager's advance booking, inspection, and fleet-partition features. No more two systems to operate.
-  - title: Trilingual from day one
-    details: EN / PT-BR / ES shipping out of the box. Every user-facing string is in the i18n bundle — CI blocks PRs that hardcode English.
-  - title: Multi-tenant by construction
-    details: Prisma middleware + Postgres Row-Level Security enforce company/tenant isolation in two independent layers. Forgetting a filter is impossible.
-  - title: Community + Enterprise
-    details: Everything needed to run is in the AGPL Community edition. Enterprise is strictly additive — no feature gating on the flows that matter.
 ---
 
-> Status — **pre-alpha**. See the [roadmap](/en/roadmap) and [architecture](/en/architecture).
+> **Early access** — real product, rough edges, weekly contact with the team. Bring real fleet data, expect rough edges, talk to us weekly.
+
+## What works today
+
+- **Multi-tenant isolation** — your data is yours, enforced at the DB layer (Postgres Row-Level Security + Prisma middleware, two independent layers)
+- **Vehicle / equipment booking** with conflict checks, approvals, blackouts, basket-style multi-asset requests
+- **Check-in / check-out flow** with mileage tracking + damage flagging
+- **Photo inspections** — configurable checklists, EXIF strip, photo evidence (gated behind a flag we'll turn on with you)
+- **OIDC login** — Google + Microsoft, end-to-end tested
+- **CSV export** from every list view; full audit trail per record
+- **Trilingual UI** — EN / PT-BR / ES, every user-facing string in i18n bundles (CI blocks PRs that hardcode English)
+
+## What's rough
+
+- No admin UI for inviting users yet — email and we'll add your team
+- Calendar UI is functional, not pretty
+- Asset add / edit screens land in the next 30 days
+- We back up nightly; no point-in-time recovery yet — don't store the only copy of irreplaceable data here
+- We may need to wipe and recreate the database during this preview — 30 days notice if so
+- Photo uploads run synchronously today; under heavy load the request thread is busy
+- Weekly contact: we want to hear what's broken; that's the deal
+
+## Two journeys, one repo
+
+**Hosted preview** — the maintainer runs a Panorama instance you can try for free. No SLA. Data may be wiped with 30 days notice (per [ADR-0014](/adr/0014-public-hosted-instance)). Great for evaluating, not for storing irreplaceable data yet.
+
+**Self-host** — AGPL-3.0 fork-friendly. See the [self-hosting guide](/en/self-hosting), the [feature matrix](/en/feature-matrix), and the [migration-from-Snipe-IT path](/en/migration-from-snipeit). The codebase deployed on the hosted preview is identical to what you'd self-host.
+
+## Trust
+
+- [Public roadmap](/en/roadmap) — what's coming, what's deferred
+- [Architecture decisions](/adr/0000-index) — every load-bearing choice with reasoning
+- [Security contact](mailto:security@vitormr.dev) — disclosure policy at [SECURITY.md](https://github.com/VitorMRodovalho/panorama/blob/main/SECURITY.md)
+- [Open issues](https://github.com/VitorMRodovalho/panorama/issues) — public bug tracker
 
 ## Language
 
-- 🇬🇧 [English](/en/)
-- 🇧🇷 [Português (Brasil)](/pt-br/)
-- 🇪🇸 [Español](/es/)
+EN · [PT-BR](/pt-br/) · [ES](/es/)

--- a/docs/pt-br/README.md
+++ b/docs/pt-br/README.md
@@ -4,15 +4,20 @@ Esta pasta guarda as versões em português-BR da documentação de produto e
 arquitetura. O README de projeto trilíngue fica em
 [`../../README.pt-br.md`](../../README.pt-br.md).
 
-Documentos principais (traduções são adicionadas conforme cada doc fica
-estável em inglês — os ADRs permanecem em inglês por regra, para evitar
-drift entre versões):
+## Status das traduções
 
-- [Arquitetura](./arquitetura.md) — em redação (será tradução de `../en/architecture.md`)
-- [Matriz de funcionalidades](./matriz-de-funcionalidades.md) — em redação
-- [Roadmap](./roadmap.md) — em redação
-- [Licenciamento](./licenciamento.md) — em redação
+A referência canônica é o equivalente em inglês em [`../en/`](../en/). A
+tradução para PT-BR está sendo adicionada conforme cada doc estabiliza
+em inglês. Os ADRs permanecem em inglês por regra, para evitar drift
+entre versões.
 
-Enquanto a tradução não chega, a referência canônica é o equivalente em
-inglês em [`../en/`](../en/). Contribuições de tradução são muito bem-vindas —
-abra PR com `[docs][pt-br]` no título.
+**Em preparação** (ainda não traduzidos — siga o equivalente em inglês):
+
+- Arquitetura → [`../en/architecture.md`](../en/architecture.md)
+- Matriz de funcionalidades → [`../en/feature-matrix.md`](../en/feature-matrix.md)
+- Roadmap → [`../en/roadmap.md`](../en/roadmap.md)
+- Licenciamento → [`../en/licensing.md`](../en/licensing.md)
+- Self-hosting → [`../en/self-hosting.md`](../en/self-hosting.md)
+
+Contribuições de tradução são muito bem-vindas — abra PR com
+`[docs][pt-br]` no título.

--- a/docs/runbooks/secrets-inventory.md
+++ b/docs/runbooks/secrets-inventory.md
@@ -1,0 +1,230 @@
+# Secrets inventory
+
+Authoritative list of every secret (credential, key, password, or
+URL containing one) Panorama depends on, grouped by rotation
+procedure. The actual rotation runbook is at
+[`./secrets-rotation.md`](./secrets-rotation.md) (TBD as part of
+Wave 0 Round 6); this file is the source-of-truth of what exists,
+where it lives, and who can rotate it.
+
+**Updated 2026-05-16** as part of Wave 0 Round 1 (per tech-lead's C1
+scan finding: 35+ `process.env.*` accesses in core-api + ~8
+duplicates in apps/web). Cross-reference to
+[`HANDOFF-2026-05-16-wave0-scan.md`](../audits/HANDOFF-2026-05-16-wave0-scan.md).
+
+## Database credentials (Supabase managed Postgres)
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `DATABASE_URL` | `apps/core-api/.env*`, Fly secrets | **Secret** — contains role + password | Pooler (port 6543); runtime app traffic |
+| `DATABASE_DIRECT_URL` | same | **Secret** | Direct (port 5432); `prisma migrate deploy` |
+| `DATABASE_PRIVILEGED_URL` | same | **Secret** | Direct (port 5432); rls.sql + bootstrap |
+| `DATABASE_APP_ROLE` | bootstrap, `apply-migrations.sh` env | Non-secret (role name) | Default `panorama_app` |
+| `DATABASE_APP_PASSWORD` | bootstrap, env | **Secret** — raw password | Set by `setup-staging-env.sh`; rotated independently of pooler password |
+
+**Rotation procedure (per ADR-0015 + 0013 architecture):**
+
+1. Rotate Supabase pooler password via Supabase dashboard → Project
+   Settings → Database
+2. Re-run `scripts/setup-staging-env.sh` locally to regenerate
+   `apps/core-api/.env.staging` with the new pooler URL
+3. `fly secrets set --app panorama-staging DATABASE_URL=...
+   DATABASE_DIRECT_URL=... DATABASE_PRIVILEGED_URL=...`
+4. Rolling deploy: `fly deploy --strategy rolling`
+5. Verify `/health` returns OK after each instance comes up
+6. The `panorama_app` role password rotates separately via
+   `ALTER ROLE panorama_app WITH PASSWORD 'new'` from a privileged
+   psql session; `DATABASE_APP_PASSWORD` env var updated to match
+7. **Rollback**: revert the `fly secrets set` to the previous values
+
+## Session crypto
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `SESSION_SECRET` | `apps/core-api/.env*`, Fly secrets | **Secret** — 32+ byte random | Iron-session encryption key |
+
+**Rotation procedure (current state, Wave 0 Round 5 will improve):**
+
+Today, rotation invalidates all sessions because `auth.config.ts:64`
+accepts a single secret. Procedure:
+
+1. Generate new value: `node -e 'console.log(require("crypto").randomBytes(32).toString("base64url"))'`
+2. `fly secrets set --app panorama-staging SESSION_SECRET="$NEW"`
+3. Rolling deploy
+4. All users logged out — communicate the window ahead of time
+
+**Wave 0 Round 5 enhancement (per maintainer decision 2026-05-16):**
+Add secondary-key support via iron-session array config. Rotation
+becomes a two-phase procedure:
+
+1. Register new secret as **secondary** (kept as fallback for
+   in-flight session cookies)
+2. Deploy → existing sessions still decrypt via secondary; new
+   sessions encrypt with primary
+3. After `SESSION_MAX_AGE_SECONDS` elapses (default ~30 days), drop
+   the old secret entirely
+4. Net result: zero-downtime rotation
+
+## OIDC client secrets
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `OIDC_GOOGLE_CLIENT_ID` | env, Fly secrets | Non-secret (public ID) | |
+| `OIDC_GOOGLE_CLIENT_SECRET` | env, Fly secrets | **Secret** | |
+| `OIDC_MICROSOFT_CLIENT_ID` | env, Fly secrets | Non-secret | |
+| `OIDC_MICROSOFT_CLIENT_SECRET` | env, Fly secrets | **Secret** | |
+
+**Rotation procedure (per provider):**
+
+Rotation is **IdP-driven** — Google or Microsoft generates a new
+secret in their respective consoles. Our procedure:
+
+1. In Google Cloud Console → OAuth 2.0 → rotate client secret (or
+   Azure → App registrations → certificates and secrets → new
+   secret)
+2. IdP provides the new secret (visible once; capture immediately)
+3. `fly secrets set --app panorama-staging OIDC_GOOGLE_CLIENT_SECRET=...`
+4. Rolling deploy
+5. In the IdP console, revoke the old secret after the rolling
+   deploy completes (both secrets may be active during the window
+   if the IdP supports it; check provider docs)
+6. **Rollback**: re-set the prior secret in fly + IdP
+
+## S3-compatible object storage (Cloudflare R2 in staging)
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `S3_ENDPOINT` | env, Fly secrets | Non-secret (URL) | |
+| `S3_REGION` | env, Fly secrets | Non-secret | |
+| `S3_BUCKET_PHOTOS` | env, Fly secrets | Non-secret | |
+| `S3_ACCESS_KEY` | env, Fly secrets | **Secret** | |
+| `S3_SECRET_KEY` | env, Fly secrets | **Secret** | |
+| `S3_FORCE_PATH_STYLE` | env, Fly secrets | Non-secret (boolean) | |
+| `S3_ALLOW_PRIVATE_ENDPOINT` | env, Fly secrets | Non-secret (boolean) | |
+
+**Rotation procedure:**
+
+1. In Cloudflare R2 dashboard → API Tokens → create new R2 token →
+   capture new access + secret pair
+2. `fly secrets set --app panorama-staging S3_ACCESS_KEY=... S3_SECRET_KEY=...`
+3. Rolling deploy
+4. Revoke the old token in the R2 dashboard after rolling deploy
+5. **Validation**: upload a test photo via the staging app; check
+   it lands in R2 + can be served back
+
+## SMTP
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `SMTP_HOST` | env, Fly secrets | Non-secret | |
+| `SMTP_PORT` | env, Fly secrets | Non-secret | |
+| `SMTP_SECURE` | env, Fly secrets | Non-secret (boolean) | |
+| `SMTP_USER` | env, Fly secrets | **Secret-ish** — may be a real email or API key on managed services | |
+| `SMTP_PASSWORD` | env, Fly secrets | **Secret** | |
+| `MAIL_FROM` | env, Fly secrets | Non-secret | |
+| `MAIL_FROM_NAME` | env, Fly secrets | Non-secret | |
+
+**Rotation procedure (depends on provider):**
+
+For SES / SendGrid / Postmark / etc.: rotate via the provider's API
+token rotation UI; capture new credentials. Then:
+
+1. `fly secrets set --app panorama-staging SMTP_USER=... SMTP_PASSWORD=...`
+2. Rolling deploy
+3. Revoke old credentials in provider console
+4. **Validation**: trigger a test invitation email; verify SPF /
+   DKIM still pass
+
+## Redis (Upstash in staging)
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `REDIS_URL` | env, Fly secrets | **Secret** — `rediss://default:password@endpoint:6379` | Token embedded in URL |
+
+**Rotation procedure:**
+
+1. In Upstash dashboard → reset token (generates new connection URL)
+2. `fly secrets set --app panorama-staging REDIS_URL=...`
+3. Rolling deploy
+4. Old token is automatically invalidated when the new one is
+   created
+
+**Note:** During the rotation window, BullMQ workers will see auth
+errors briefly. This is expected; the rolling deploy resolves it
+within the deploy window.
+
+## Sentry (future — per ADR-0018)
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `SENTRY_DSN` | env, Fly secrets | **Quasi-secret** — exposes Sentry project | Unset = Sentry no-op (per ADR-0018) |
+
+**Rotation procedure:**
+
+DSN rotation is tied to Sentry project recreation. If the DSN
+leaks, the threat is event-injection (someone sending fake errors
+to your project), not data exfiltration. Procedure:
+
+1. In Sentry → Project Settings → Client Keys → create new DSN
+2. `fly secrets set --app panorama-staging SENTRY_DSN=...`
+3. Rolling deploy
+4. Revoke old DSN in Sentry
+
+## CAPTCHA (future — per ADR-0020)
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `CAPTCHA_SITE_KEY` | env, web build | Non-secret (public) | hCaptcha or Turnstile |
+| `CAPTCHA_SECRET` | env, Fly secrets | **Secret** — server-side verification | |
+
+Rotation procedure TBD when ADR-0020's signup endpoint lands in
+Round 3.
+
+## Seed credentials (devops only)
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `SEED_OWNER_PASSWORD` | local env only | **Secret** | Used by `smoke-staging-seed.ts` for fixture provisioning; never set in production |
+| `SEED_OWNER_PASSWORD_FILE` | local env only | Path to file | Alternative to inline password |
+
+These are dev-only and never live on Fly. Rotation = "regenerate
+the smoke tenant when you need to."
+
+## Non-secret config (documented for completeness)
+
+These are environment variables that affect behavior but are not
+credentials. Listed so the inventory is complete + future ops can
+quickly identify what's safe to log.
+
+- `APP_BASE_URL`, `APP_VERSION`, `CORE_API_URL`, `WEB_ORIGIN`
+- `NODE_ENV`, `PORT`
+- `ALLOW_STAGING_SEED`, `FEATURE_INSPECTIONS`, `FEATURE_MAINTENANCE`,
+  `FEATURE_SELF_SERVE_SIGNUP` (future per ADR-0020)
+- `OIDC_GOOGLE_HOSTED_DOMAIN`, `OIDC_GOOGLE_ISSUER`,
+  `OIDC_GOOGLE_TRUSTED_HD_DOMAINS`, `OIDC_MICROSOFT_TENANT`,
+  `OIDC_ALLOW_INSECURE_ISSUER`
+- `OAUTH_STATE_COOKIE_NAME`, `SESSION_COOKIE_NAME`,
+  `SESSION_MAX_AGE_SECONDS`
+- `INVITE_RATE_ADMIN_HOUR`, `INVITE_RATE_TENANT_DAY`
+
+## Total count
+
+- **Secrets requiring rotation procedure:** 14 (Database ×5,
+  Session ×1, OIDC ×2, S3 ×2, SMTP ×2, Redis ×1, SEED ×1)
+- **Future secrets pending ADR implementation:** 2 (Sentry DSN,
+  CAPTCHA secret)
+- **Non-secret env vars:** ~18 (listed above)
+
+## Maintainer accountability
+
+Today, the maintainer is the sole rotater for all of the above
+(bus factor of 1 per [issue #50](https://github.com/VitorMRodovalho/panorama/issues/50)).
+This runbook is the foundation of "documentation for the second
+maintainer who doesn't exist yet" (per
+[HANDOFF-2026-05-16-wave0-scan.md](../audits/HANDOFF-2026-05-16-wave0-scan.md)
+§"Open risks").
+
+Update this file when:
+- New secret added (e.g., a new IdP, a new managed service)
+- Rotation procedure changes (e.g., provider UI redesign)
+- Sensitivity classification changes

--- a/docs/runbooks/setup-supabase-staging.md
+++ b/docs/runbooks/setup-supabase-staging.md
@@ -169,7 +169,14 @@ Outside Supabase, create the Fly app pointing at the URLs from step 1:
 ```bash
 flyctl apps create panorama-staging --org personal
 flyctl secrets set --app panorama-staging \
-  DATABASE_URL="postgres://postgres:...@aws-0-us-east-1.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1&sslmode=require" \
+  DATABASE_URL="postgres://postgres:...@aws-0-us-east-1.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=10&sslmode=require" \
+  # connection_limit=10 — per Prisma client × 2 clients (app + privileged
+  # per ADR-0015) × Fly instances ≤ 100 to leave headroom under Supabase
+  # Pro pooler's 200 client-conn cap. Public-preview budget assumes ≤2
+  # Fly instances + 50 active tenants × 5 concurrent users × ~0.04 active
+  # fraction = ~10 in-flight × 2 clients = 20 client conns per instance.
+  # If you ever scale beyond 4 instances, lower this or request the
+  # Supabase pooler cap bump first.
   DATABASE_PRIVILEGED_URL="postgres://postgres:...@db.<project-ref>.supabase.co:5432/postgres?sslmode=require" \
   DATABASE_DIRECT_URL="postgres://postgres:...@db.<project-ref>.supabase.co:5432/postgres?sslmode=require" \
   REDIS_URL="rediss://default:...@<upstash-endpoint>:6379" \


### PR DESCRIPTION
## Summary

Round 1 of the post-Wave-0-scan sequencing — the lowest-risk must-fix items from the 2026-05-16 6-agent scan. **Stacks on #199** (Round 0 ADRs); base branch will auto-update to main when #199 merges.

Two commits bundled here:
1. `4b2ca80` — docs/runbook/ROLLBACK content (no app code)
2. `4c1f0b6` — apps/web a11y fixes (the three non-negotiable blockers from ux-critic)

## Homepage / public site (commit 1)
- **`docs/index.md` fully rewritten** — dropped \"pre-alpha\" framing + 4 Snipe-IT-positioned feature cards; dual CTA (Get a hosted account / Self-host on GitHub); honesty band in same eyeful as hero; trust strip; clean language footer
- **`docs/en/early-access.md` new** — destination for the \"Get a hosted account\" CTA; explains \"not yet open\" + 3 follow-along channels (Releases, roadmap, email)
- **`docs/.vitepress/config.mts`** — removed `ignoreDeadLinks: true` (previously masked broken PT-BR/ES stub links)
- **`docs/pt-br/README.md` + `docs/es/README.md`** — removed 4 broken bullet links each; replaced with structured \"in preparation — see English equivalent\" section pointing to `../en/`

## Runbooks + roadmap (commit 1)
- **`docs/en/roadmap.md`** — 0.3 maintenance status updated to `[~]` feature-complete pending canary; added Wave 0 public-preview readiness line; 0.4 reframed from \"first closed-beta customer\" to \"hosted preview URL opens publicly\" with first design partners as canary
- **`docs/runbooks/setup-supabase-staging.md`** — `connection_limit=1` → `10` with inline math explaining the public-preview budget (data-architect Blocker 2)
- **`docs/runbooks/secrets-inventory.md` new** — authoritative inventory of 14 production secrets + 2 future + 18 non-secret env vars, grouped by rotation procedure (tech-lead C1)

## Migration ROLLBACK.md fixes (commit 1)
- **0014 (asset_maintenance_flow)** — pre-flight section now at the TOP (FEATURE_MAINTENANCE flip before SQL); explicit re-apply pattern + when-to-revert section (data-architect C3)
- **0020 (audit_trigger_digest_ms_truncate)** — heredoc path issue fixed (two CWD-aware options spelled out); re-apply pattern expanded to handle multi-marker traversal (data-architect C4)

## Build hygiene (commit 1)
- **`.gitignore`** — `apps/*/.env` → `apps/*/.env*` catches `.env.staging` (and future `.env.production` etc.) which currently leak past the filter

## Web a11y blockers (commit 2)

### Main landmark relocation
- `apps/web/src/app/layout.tsx` — `<main className=\"panorama-main\">` → `<div>`. Was wrapping the whole AppShell (header + content) so \"skip to main content\" landed in the header.
- `apps/web/src/components/app-shell.tsx` — `<section className=\"panorama-content\">` → `<main>`. Now the main landmark wraps ONLY the per-page content.
- `apps/web/src/app/login/page.tsx` — outermost `<div className=\"panorama-login\">` → `<main>`. Unauthenticated pages need their own main landmark now.

### Form labels (`apps/web/src/app/(authenticated)/reservations/page.tsx`)
Added `aria-label` to 10 inputs/textareas that previously had only placeholder text. Uses the same i18n key as the placeholder for semantic equivalence. Placeholders kept for sighted users; aria-label is what screen readers announce.

### Calendar status-by-colour fix (`apps/web/src/app/(authenticated)/reservations/calendar/page.tsx`)
- New `STATUS_PREFIX` map maps kinds → single-letter mnemonics (P/A/O/R/X/!)
- `labelForReservation` prefixes each reservation block's date-range label with the letter
- `Swatch` component takes an optional `prefix` prop; rendered as a `<kbd>` next to the swatch in the legend so the letter-to-status mapping is discoverable
- `panorama-swatch` span gets `aria-hidden=\"true\"` (kind+label pair is already announced)

## Test plan

- [ ] Visual: `pnpm --filter @panorama/docs dev` — homepage renders clean, dual CTA reachable, honesty band in same eyeful as hero
- [ ] Dead-link check: `pnpm --filter @panorama/docs build` passes (we removed `ignoreDeadLinks`)
- [ ] Maintainer-local `.env.staging`: re-run `scripts/setup-staging-env.sh` to regenerate with the three-URL contract (pre-#186 file is missing `DATABASE_DIRECT_URL`)
- [ ] `.gitignore` change: run `touch apps/foo/.env.staging` + `git status` — should not appear as untracked
- [ ] a11y: keyboard tab through login page; verify focus goes through `<main>` content (skip-to-main lands at page content, not header)
- [ ] a11y: screen reader reads aria-label on the 10 inline-form inputs in `/reservations`
- [ ] a11y: calendar legend shows letter prefixes; reservation blocks show the same letter at the start of their date-range label
- [ ] CI: lint + typecheck + Build VitePress + Unit tests + i18n coverage all green

**Pre-existing typecheck note**: `pnpm --filter @panorama/web typecheck` shows errors in `.next/types/validator.ts` about `Promise<ReactNode>` vs `AwaitedReactNode`. These are auto-generated Next 16 validator errors that pre-date this PR (they fire for every page/layout in the repo, including ones not touched here). The actual page files type-check fine.

Next step after merge: Round 2 (backend hardening — throttler wiring + audit-chain reproducibility).

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>