### PR TITLE
feat(auth): Round 2A.1 — wire ThrottlerGuard + trust proxy + auth-route throttle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ coverage/
 .env.local
 .env.*.local
 !.env.example
-apps/*/.env
+apps/*/.env*
 !apps/*/.env.example
 
 # Prisma local bits

--- a/apps/core-api/prisma/migrations/20260419130000_0014_asset_maintenance_flow/ROLLBACK.md
+++ b/apps/core-api/prisma/migrations/20260419130000_0014_asset_maintenance_flow/ROLLBACK.md
@@ -1,10 +1,38 @@
 # Rollback — migration 0014 (asset maintenance flow, ADR-0016)
 
-Destructive — drops two tables, one enum, one trigger function +
-trigger, four+ added columns. Photos in S3 are NOT deleted by this
+**Destructive** — drops two tables, one enum, one trigger function +
+trigger, seven added columns. Photos in S3 are NOT deleted by this
 rollback (audit-safe; manual `mc rm --recursive` if needed).
 
-Run in this order; each block is idempotent.
+## Pre-flight (operator MUST verify BEFORE running SQL)
+
+The running app will throw on missing tables if the rollback SQL
+runs while `FEATURE_MAINTENANCE=true`. Execute pre-flight in this
+order:
+
+1. **Flip the feature flag** — set `FEATURE_MAINTENANCE=false`:
+   ```
+   fly secrets set --app panorama-staging FEATURE_MAINTENANCE=false
+   ```
+   (Or set in `.env` for self-host.)
+
+2. **Restart core-api** — `fly deploy --strategy rolling` for the
+   hosted instance, or `pm2 restart core-api` for self-host. Verify
+   `/health` returns OK after all instances cycle.
+
+3. **Confirm no in-flight maintenance writes** — the SQL block
+   below acquires brief ACCESS EXCLUSIVE locks; check
+   `pg_stat_activity` for any pending `INSERT INTO asset_maintenances`
+   queries and let them complete first.
+
+4. **Communicate the rollback window** to any operators who care
+   about active maintenance tickets — they survive the rollback as
+   audit-event history but the UI/admin surface disappears.
+
+## SQL revert (privileged role)
+
+Run from a psql session against `$DATABASE_PRIVILEGED_URL`. Each
+block is idempotent (uses `IF EXISTS`).
 
 ```sql
 BEGIN;
@@ -58,7 +86,7 @@ DELETE FROM "_prisma_migrations"
 COMMIT;
 ```
 
-## Notes
+## Data-loss warnings
 
 - **Photos in S3** are not removed by the rollback. After confirming
   no business need, run:
@@ -95,10 +123,21 @@ COMMIT;
   only the discriminator is gone. Manual ops process can re-handle
   via reservation cancel / mileage-in.
 
-- **FEATURE_MAINTENANCE** flag should be set to `false` BEFORE running
-  the rollback (otherwise the running app will throw on missing
-  tables until restart). Rollback ordering:
-  1. Set `FEATURE_MAINTENANCE=false` in env.
-  2. Restart core-api.
-  3. Run the rollback SQL.
-  4. Verify `\d asset_maintenances` returns "does not exist".
+## When you would actually revert
+
+Three scenarios that justify rolling back 0014:
+
+1. Maintenance feature causing a critical bug in a tenant that needs
+   immediate isolation (and `FEATURE_MAINTENANCE=false` per-tenant
+   is not enough)
+2. Schema-level data corruption that requires re-applying with a
+   patched migration
+3. ADR-0016 superseded by a follow-up ADR that requires schema reset
+
+## Re-apply pattern
+
+After rollback, re-apply via standard `prisma migrate deploy`. The
+migration is idempotent; no special handling required. The system-
+user demotion step (§5 above) means a re-apply re-promotes the
+demoted users — they retain their `userId` so audit-event references
+stay intact.

--- a/apps/core-api/prisma/migrations/20260428080000_0020_audit_trigger_digest_ms_truncate/ROLLBACK.md
+++ b/apps/core-api/prisma/migrations/20260428080000_0020_audit_trigger_digest_ms_truncate/ROLLBACK.md
@@ -1,19 +1,75 @@
 # Rollback — migration 0020 (audit trigger digest ms-truncate)
 
-```sql
--- Restore the pre-#96 functions (microsecond `now()` directly,
--- exposing the rounding/truncation mismatch documented in
--- migration.sql).
-\\i ../20260426094000_0015_audit_wave1_data_layer_corrections/migration.sql
+## Pre-flight (operator MUST verify BEFORE running)
+
+This is a forward-only fix; rollback resurrects the divergent-digest
+behaviour documented in `migration.sql`. Only roll back if verifier
+tooling regresses against the post-0020 digest format — the pre-#96
+behaviour was provably unreproducible (per the 2026-05-16 data-
+architect scan).
+
+Confirm the regression is real (not transient) before running.
+
+## SQL revert (privileged role)
+
+Run from a psql session against `$DATABASE_PRIVILEGED_URL`. Two
+options depending on your working directory:
+
+**Option 1 — from the repo root:**
+
+```bash
+psql "$DATABASE_PRIVILEGED_URL" \
+  -f apps/core-api/prisma/migrations/20260426094000_0015_audit_wave1_data_layer_corrections/migration.sql
 ```
 
-Rollback restores the divergent-digest behaviour. Don't roll back
-unless verifier tooling regresses — the fix is forward-compatible
-with all prior fires (verifiers that handle the rounding ambiguity
-keep working) and uniquely deterministic from this point on.
+**Option 2 — inside psql (from any CWD):**
 
-The cutover marker emitted at apply time (`panorama.audit.chain_repair`
-with `metadata.migration = '0020'`) is left in place on rollback
-— it's an audit event documenting that the fix WAS applied and
-later reverted. Verifier tooling should treat the marker as a
-historical waypoint regardless of whether it's still in force.
+```sql
+\i apps/core-api/prisma/migrations/20260426094000_0015_audit_wave1_data_layer_corrections/migration.sql
+```
+
+(The `\i` directive resolves paths relative to the CWD `psql` was
+launched from; if you `cd` into the migration directory first, use
+`\i ../20260426094000_0015_audit_wave1_data_layer_corrections/migration.sql`
+instead.)
+
+This re-applies the pre-#96 trigger functions (microsecond `now()`
+directly, exposing the rounding / truncation mismatch documented in
+migration 0020's commentary).
+
+## Data-loss warnings
+
+- The cutover marker emitted at apply time (`panorama.audit.chain_repair`
+  with `metadata.migration = '0020'`) is **left in place** on
+  rollback — it's an audit event documenting that the fix WAS
+  applied and later reverted. Verifier tooling should treat the
+  marker as a historical waypoint regardless of whether the fix is
+  still in force.
+- Audit-event rows written DURING the period 0020 was applied
+  retain their ms-truncated `occurredAt` digest. These rows are
+  correct as written; the rollback does NOT recompute them.
+
+## When you would actually revert
+
+Only if verifier tooling regresses against the post-0020 digest
+format AND the regression cannot be fixed in the verifier itself.
+The pre-#96 behaviour re-introduces the original bug — prefer to
+patch the verifier first.
+
+## Re-apply pattern
+
+Forward-only by design. If 0020 is rolled back and then re-applied
+after new audit-event rows have been written:
+
+1. Rows written DURING the rollback window use the pre-0020 (raw
+   microsecond `now()`) digest format
+2. Re-applying 0020 emits a NEW `panorama.audit.chain_repair`
+   marker AND starts ms-truncating again from that marker forward
+3. The verifier MUST understand BOTH chain-repair markers as
+   "format change points" and apply the correct rounding rule to
+   events on each side of each marker
+
+If the verifier doesn't support multi-marker traversal, expect
+digest mismatches on rows from the rollback window. There's no
+automated remediation — the rows are correct as written; the
+verifier needs the multi-marker handling.

--- a/apps/core-api/src/app.module.ts
+++ b/apps/core-api/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module, type DynamicModule } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
-import { ThrottlerModule } from '@nestjs/throttler';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { PrismaModule } from './modules/prisma/prisma.module.js';
 import { TenantModule } from './modules/tenant/tenant.module.js';
 import { AssetModule } from './modules/asset/asset.module.js';
@@ -82,6 +83,7 @@ const conditionalMaintenance: DynamicModule[] = maintenanceEnabled()
     ThrottlerModule.forRoot([
       { name: 'global', ttl: 60_000, limit: 120 },
       { name: 'auth', ttl: 60_000, limit: 10 },
+      { name: 'upload', ttl: 60_000, limit: 5 },
     ]),
     PrismaModule,
     TenantModule,
@@ -103,6 +105,13 @@ const conditionalMaintenance: DynamicModule[] = maintenanceEnabled()
     // Audit + Redis are wired so the boot audits commit cleanly.
     BootAuditModule,
     // 0.2: PluginHostModule, I18nModule.forRootAsync.
+  ],
+  providers: [
+    // ThrottlerGuard wired as a global APP_GUARD — without this, the
+    // ThrottlerModule.forRoot config is dead metadata. Wave 0 Round 2
+    // (ADR-0014 prerequisite): the synthetic-flood test in
+    // test/login-flood.e2e.test.ts exercises the auth bucket.
+    { provide: APP_GUARD, useClass: ThrottlerGuard },
   ],
 })
 export class AppModule {}

--- a/apps/core-api/src/main.ts
+++ b/apps/core-api/src/main.ts
@@ -1,13 +1,21 @@
 import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe, Logger } from '@nestjs/common';
+import type { NestExpressApplication } from '@nestjs/platform-express';
 import helmet from 'helmet';
 import { AppModule } from './app.module.js';
 
 async function bootstrap(): Promise<void> {
-  const app = await NestFactory.create(AppModule, {
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     bufferLogs: true,
   });
+
+  // Trust the first proxy hop (Fly edge → app, or LB → app on self-host).
+  // Without this, req.ip resolves to the proxy IP and the ThrottlerGuard
+  // sees every request as coming from one IP — fail-united, not
+  // fail-closed. Single hop is the conservative choice; bump if you
+  // run multiple LBs in front.
+  app.set('trust proxy', 1);
 
   app.use(
     helmet({

--- a/apps/core-api/src/modules/auth/auth.controller.ts
+++ b/apps/core-api/src/modules/auth/auth.controller.ts
@@ -13,6 +13,7 @@ import {
   Res,
   UnauthorizedException,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import type { Request, Response } from 'express';
 import { z } from 'zod';
 import { AuthService } from './auth.service.js';
@@ -76,6 +77,7 @@ export class AuthController {
 
   @Post('login')
   @HttpCode(200)
+  @Throttle({ auth: { ttl: 60_000, limit: 10 } })
   async login(
     @Body() body: unknown,
     @Req() req: Request,
@@ -238,6 +240,7 @@ export class AuthController {
   }
 
   @Get('oidc/:provider/callback')
+  @Throttle({ auth: { ttl: 60_000, limit: 10 } })
   async oidcCallback(
     @Query('code') code: string | undefined,
     @Query('state') state: string | undefined,

--- a/apps/core-api/src/modules/invitation/invitation.controller.ts
+++ b/apps/core-api/src/modules/invitation/invitation.controller.ts
@@ -11,6 +11,7 @@ import {
   Res,
   UnauthorizedException,
 } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
 import type { Request, Response } from 'express';
 import {
   CreateInvitationSchema,
@@ -140,6 +141,7 @@ export class InvitationController {
 
   @Post('accept')
   @HttpCode(200)
+  @Throttle({ auth: { ttl: 60_000, limit: 10 } })
   async finalizeAccept(
     @Query('t') token: string | undefined,
     @Req() req: Request,

--- a/apps/core-api/test/login-flood.e2e.test.ts
+++ b/apps/core-api/test/login-flood.e2e.test.ts
@@ -1,0 +1,87 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Test } from '@nestjs/testing';
+import { ValidationPipe } from '@nestjs/common';
+import type { INestApplication } from '@nestjs/common';
+import type { NestExpressApplication } from '@nestjs/platform-express';
+import { PrismaClient } from '@prisma/client';
+import { AppModule } from '../src/app.module.js';
+import { resetTestDb } from './_reset-db.js';
+
+/**
+ * Synthetic-flood test (Wave 0 Round 2, ADR-0014 prerequisite per the
+ * security-reviewer B1 finding in HANDOFF-2026-05-16-wave0-scan.md).
+ *
+ * Proves the auth-bucket ThrottlerGuard is actually wired — pre-Round 2
+ * the ThrottlerModule was registered but no APP_GUARD provider existed,
+ * so the documented `auth: 10/min` cap was fictional.
+ *
+ * Asserts: after 15 rapid POSTs to /auth/login with invalid credentials,
+ * at least 3 return 429 (the throttler should fire on attempts 11+).
+ * The exact count varies slightly with test timing; the floor of 3
+ * proves wiring without making the test brittle on environment speed.
+ */
+
+const HOST = process.env.PG_HOST ?? 'localhost';
+const PORT = process.env.PG_PORT ?? '5432';
+const DB = process.env.PG_DB ?? 'panorama';
+const ADMIN_URL = `postgres://panorama_super_admin:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+const APP_URL = `postgres://panorama_app:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+
+describe('abuse: login flood (Wave 0 Round 2)', () => {
+  let app: INestApplication;
+  let url: string;
+
+  beforeAll(async () => {
+    process.env.SESSION_SECRET = process.env.SESSION_SECRET ?? 'a'.repeat(32);
+    process.env.DATABASE_URL = APP_URL;
+
+    // Reset is needed because the throttler bucket persists across
+    // tests within a process; an empty DB ensures the login lookups
+    // return 401 quickly without depending on seeded state.
+    const admin = new PrismaClient({ datasources: { db: { url: ADMIN_URL } } });
+    await resetTestDb(admin);
+    await admin.$disconnect();
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = moduleRef.createNestApplication<NestExpressApplication>({
+      logger: ['error', 'warn'],
+    });
+    (app as NestExpressApplication).set('trust proxy', 1);
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+    await app.listen(0);
+    url = await app.getUrl();
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  it('returns 429 once the auth bucket is exhausted', async () => {
+    const statuses: number[] = [];
+    for (let i = 0; i < 15; i++) {
+      const res = await fetch(`${url}/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: `flood-${i}@invalid.example`,
+          password: 'wrong',
+        }),
+      });
+      statuses.push(res.status);
+    }
+    // First ~10 attempts: 401 (no such user) — auth-controller path.
+    // Attempts 11+ from the same IP: 429 — ThrottlerGuard kicks in.
+    const tooMany = statuses.filter((s) => s === 429).length;
+    expect(tooMany).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/apps/web/src/app/(authenticated)/reservations/calendar/page.tsx
+++ b/apps/web/src/app/(authenticated)/reservations/calendar/page.tsx
@@ -252,19 +252,24 @@ export default async function ReservationCalendarPage({
 function CalendarLegend({ t }: { t: (k: string) => string }): ReactNode {
   return (
     <div className="panorama-calendar-legend">
-      <Swatch kind="pending" label={t('calendar.legend.pending')} />
-      <Swatch kind="approved" label={t('calendar.legend.approved')} />
-      <Swatch kind="checkedout" label={t('calendar.legend.checkedout')} />
-      <Swatch kind="returned" label={t('calendar.legend.returned')} />
+      <Swatch kind="pending" label={t('calendar.legend.pending')} prefix="P" />
+      <Swatch kind="approved" label={t('calendar.legend.approved')} prefix="A" />
+      <Swatch kind="checkedout" label={t('calendar.legend.checkedout')} prefix="O" />
+      <Swatch kind="returned" label={t('calendar.legend.returned')} prefix="R" />
       <Swatch kind="blackout" label={t('calendar.legend.blackout')} />
     </div>
   );
 }
 
-function Swatch({ kind, label }: { kind: string; label: string }): ReactNode {
+function Swatch({ kind, label, prefix }: { kind: string; label: string; prefix?: string }): ReactNode {
   return (
     <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, marginRight: 12 }}>
-      <span className={`panorama-swatch panorama-block--${kind}`} />
+      <span className={`panorama-swatch panorama-block--${kind}`} aria-hidden="true" />
+      {prefix ? (
+        <kbd style={{ fontSize: 11, fontWeight: 600, opacity: 0.8 }} aria-hidden="true">
+          {prefix}
+        </kbd>
+      ) : null}
       <span style={{ fontSize: 12 }}>{label}</span>
     </span>
   );
@@ -311,10 +316,20 @@ function reservationKind(r: ReservationView): string {
   return 'approved';
 }
 
+const STATUS_PREFIX: Record<string, string> = {
+  pending: 'P',
+  approved: 'A',
+  checkedout: 'O',
+  returned: 'R',
+  cancelled: 'X',
+  rejected: '!',
+};
+
 function labelForReservation(r: ReservationView, locale: SupportedLocale): string {
   const fmt = (d: string): string =>
     new Date(d).toLocaleString(locale, { month: 'numeric', day: 'numeric', hour: 'numeric' });
-  return `${fmt(r.startAt)}–${fmt(r.endAt)}`;
+  const prefix = STATUS_PREFIX[reservationKind(r)] ?? '';
+  return prefix ? `${prefix} · ${fmt(r.startAt)}–${fmt(r.endAt)}` : `${fmt(r.startAt)}–${fmt(r.endAt)}`;
 }
 
 function atStartOfDay(d: Date): Date {

--- a/apps/web/src/app/(authenticated)/reservations/page.tsx
+++ b/apps/web/src/app/(authenticated)/reservations/page.tsx
@@ -464,6 +464,9 @@ export default async function ReservationsPage({
                                   <input
                                     type="text"
                                     name="note"
+                                    aria-label={messages.t(
+                                      'reservation.batch.approve.note_placeholder',
+                                    )}
                                     placeholder={messages.t(
                                       'reservation.batch.approve.note_placeholder',
                                     )}
@@ -500,6 +503,9 @@ export default async function ReservationsPage({
                                     minLength={1}
                                     maxLength={500}
                                     rows={2}
+                                    aria-label={messages.t(
+                                      'reservation.action.reject.note_placeholder',
+                                    )}
                                     placeholder={messages.t(
                                       'reservation.action.reject.note_placeholder',
                                     )}
@@ -534,6 +540,9 @@ export default async function ReservationsPage({
                                 <input
                                   type="text"
                                   name="reason"
+                                  aria-label={messages.t(
+                                    'reservation.batch.cancel.note_placeholder',
+                                  )}
                                   placeholder={messages.t(
                                     'reservation.batch.cancel.note_placeholder',
                                   )}
@@ -578,6 +587,9 @@ export default async function ReservationsPage({
                                 type="text"
                                 name="note"
                                 maxLength={500}
+                                aria-label={messages.t(
+                                  'reservation.action.approve.note_placeholder',
+                                )}
                                 placeholder={messages.t(
                                   'reservation.action.approve.note_placeholder',
                                 )}
@@ -630,6 +642,9 @@ export default async function ReservationsPage({
                                 minLength={1}
                                 maxLength={500}
                                 rows={2}
+                                aria-label={messages.t(
+                                  'reservation.action.reject.note_placeholder',
+                                )}
                                 placeholder={messages.t(
                                   'reservation.action.reject.note_placeholder',
                                 )}
@@ -661,6 +676,9 @@ export default async function ReservationsPage({
                             <input
                               type="number"
                               name="mileage"
+                              aria-label={messages.t(
+                                'reservation.action.checkout.mileage_placeholder',
+                              )}
                               placeholder={messages.t(
                                 'reservation.action.checkout.mileage_placeholder',
                               )}
@@ -671,6 +689,9 @@ export default async function ReservationsPage({
                             <input
                               type="text"
                               name="condition"
+                              aria-label={messages.t(
+                                'reservation.action.checkout.condition_placeholder',
+                              )}
                               placeholder={messages.t(
                                 'reservation.action.checkout.condition_placeholder',
                               )}
@@ -692,6 +713,9 @@ export default async function ReservationsPage({
                             <input
                               type="number"
                               name="mileage"
+                              aria-label={messages.t(
+                                'reservation.action.checkin.mileage_placeholder',
+                              )}
                               placeholder={messages.t(
                                 'reservation.action.checkin.mileage_placeholder',
                               )}
@@ -702,6 +726,9 @@ export default async function ReservationsPage({
                             <input
                               type="text"
                               name="condition"
+                              aria-label={messages.t(
+                                'reservation.action.checkin.condition_placeholder',
+                              )}
                               placeholder={messages.t(
                                 'reservation.action.checkin.condition_placeholder',
                               )}
@@ -714,6 +741,9 @@ export default async function ReservationsPage({
                             <input
                               type="text"
                               name="damageNote"
+                              aria-label={messages.t(
+                                'reservation.action.checkin.damage_note_placeholder',
+                              )}
                               placeholder={messages.t(
                                 'reservation.action.checkin.damage_note_placeholder',
                               )}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -36,7 +36,7 @@ export default async function RootLayout({
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
       <body>
-        <main className="panorama-main">{children}</main>
+        <div className="panorama-main">{children}</div>
       </body>
     </html>
   );

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -51,7 +51,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps): Promi
       : messages.t('login.subtitle.default');
 
   return (
-    <div className="panorama-login">
+    <main className="panorama-login">
       <h1>{messages.t('login.title')}</h1>
       <p className="muted">{subtitle}</p>
 
@@ -115,6 +115,6 @@ export default async function LoginPage({ searchParams }: LoginPageProps): Promi
           </>
         ) : null}
       </div>
-    </div>
+    </main>
   );
 }

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -121,10 +121,10 @@ export async function AppShell({ children }: { children: ReactNode }): Promise<R
         </div>
       </header>
 
-      <section className="panorama-content">
+      <main className="panorama-content">
         <AppNav items={navItems} />
         {children}
-      </section>
+      </main>
     </>
   );
 }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -6,9 +6,6 @@ export default defineConfig({
   outDir: '../dist-docs',
   cleanUrls: true,
   lastUpdated: true,
-  // Pre-alpha docs — PT-BR/ES translation stubs intentionally link to
-  // files that will exist later. Tighten once the translations land.
-  ignoreDeadLinks: true,
 
   head: [
     ['link', { rel: 'icon', href: '/favicon.ico' }],

--- a/docs/adr/0000-index.md
+++ b/docs/adr/0000-index.md
@@ -18,9 +18,13 @@ Keep them short. Date them. When superseding, link back and mark the old one dep
 | 0011 | [Notification event bus — architecture](./0011-notification-event-bus.md) | Accepted | 2026-04-18 |
 | 0012 | [Inspection checklists + photo evidence pipeline](./0012-inspection-photo-pipeline.md) | Accepted | 2026-04-18 |
 | 0013 | [Staging deploy architecture (internal only)](./0013-staging-deploy-architecture.md) | Accepted | 2026-04-19 |
-| 0014 | _(reserved — Cloud SKU + edition placement; unwritten by intent until customer signal)_ | — | — |
+| 0014 | [Public hosted instance (Community deployed, free preview)](./0014-public-hosted-instance.md) | Accepted | 2026-05-16 |
 | 0015 | [BYPASSRLS removal refactor (SECURITY DEFINER bypass function)](./0015-bypassrls-removal-refactor.md) | Accepted | 2026-04-19 |
 | 0016 | [Asset maintenance flow (Snipe-IT-compatible)](./0016-asset-maintenance-flow.md) | Accepted (v3 2026-04-26) | 2026-04-19 |
+| 0017 | [AI/LLM integration principles](./0017-ai-llm-integration-principles.md) | Accepted | 2026-04-23 |
+| 0018 | [Observability stack (pino + Sentry + request-id ALS)](./0018-observability-stack.md) | Accepted | 2026-05-16 |
+| 0019 | [Worker process boundary (photo pipeline defer-with-trigger)](./0019-worker-process-boundary.md) | Accepted | 2026-05-16 |
+| 0020 | [Self-serve OIDC signup (Wave 0.5)](./0020-self-serve-oidc-signup.md) | Proposed | 2026-05-16 |
 
 ## Template
 

--- a/docs/adr/0014-public-hosted-instance.md
+++ b/docs/adr/0014-public-hosted-instance.md
@@ -1,0 +1,227 @@
+# ADR-0014: Public hosted instance (Community deployed, free preview)
+
+- Status: Accepted (2026-05-16). Drafted from the Wave 0 6-agent scan
+  on the same date; accepted by maintainer in the same session.
+  Supersedes the prior "Cloud SKU" reservation in `docs/adr/0000-index.md`,
+  which was held open since 2026-04-19 awaiting customer signal.
+- Date: 2026-05-16
+- Deciders: Vitor Rodovalho (maintainer)
+- Reviewers (Wave 0 scan, 2026-05-16):
+  - product-lead → SUPPORT with named amendments (items 1–5 below
+    are the verbatim guard rails that defuse the "third edition by
+    accident" concern this slot has carried since 2026-04-19)
+  - tech-lead → no objection on framing; observability + per-tenant
+    throttler + worker boundary captured in ADR-0018 / ADR-0019
+  - data-architect → no objection on data surface; rollback + restore
+    drill remain Wave 0 deliverables
+  - security-reviewer → no objection on framing; signup model + threat
+    model split into ADR-0020
+  - ux-critic → no objection on positioning; homepage rewrite is a
+    Wave 0 deliverable that follows this ADR's framing
+  - persona-fleet-ops → SUPPORT; "free hosted = real ops feedback at
+    zero customer-acquisition cost" is the loop that was missing
+- Related: [ADR-0002 OSS/Enterprise edition split](./0002-oss-commercial-split.md),
+  [ADR-0013 Staging deploy architecture](./0013-staging-deploy-architecture.md),
+  [ADR-0020 Self-serve OIDC signup](./0020-self-serve-oidc-signup.md)
+
+## Context
+
+Panorama needs to open a public URL where ops teams can evaluate the
+product against real fleet/asset workflows. Until 2026-05-09 this slot
+was reserved as "Cloud SKU + edition placement; unwritten by intent
+until customer signal" — gated on a paying-customer hypothesis that
+never had its anchor (the 2026-04-19 product-lead BLOCK was framed
+against an Amtrak/FDT pilot that the maintainer is no longer
+employed at).
+
+The 2026-05-09 strategic re-anchor (see
+`docs/audits/HANDOFF-2026-05-09-session-end.md`) replaced the paid-SKU
+hypothesis with a **free hosted public preview alongside the AGPL
+self-host option** — two journeys, one homepage. The Wave 0 6-agent
+scan on 2026-05-16 converged on this framing and produced the five
+guard rails captured below.
+
+This ADR exists to **lock the operational scope of that hosted
+instance** so that subsequent Wave 0 work (legal docs, observability,
+audit-chain reproducibility, signup endpoint, homepage rewrite) can
+cite a single source of truth, and so that the "third edition by
+accident" risk that has gated this slot since 2026-04-19 is defused
+in writing rather than rhetorically.
+
+## Decision
+
+Panorama operates a **maintainer-run hosted instance of the Community
+edition under AGPL §13**. The instance is free, has no SLA, and is
+explicitly framed as a public preview — not a product.
+
+### 1. Operational scope statement
+
+This ADR scopes a maintainer-operated hosted instance of the Community
+edition under AGPL §13. **It does NOT introduce a third edition.** The
+code surface running on the hosted instance is identical to a vanilla
+self-host of the same Git SHA: zero Enterprise modules, zero
+hosted-only endpoints, zero hosted-only feature flags.
+
+### 2. Edition-boundary lock
+
+If this instance ever ships any code, feature, endpoint, schema
+change, or configuration that does not exist on a vanilla self-host of
+the same Git SHA, **that is a violation of this ADR and triggers an
+immediate amendment** — not a "we'll productise later." The CI gate
+established in #49 (Wave A, replacing the current grep with a
+functional bootstrap-without-Enterprise-flags assertion) is the
+mechanical enforcement of this clause and is a hard prerequisite for
+opening the public URL.
+
+### 3. Pricing non-decision
+
+Pricing is explicitly out of scope of this ADR. The decision to charge
+for any version of this hosted instance, and the resulting SKU shape,
+is a **separate future amendment** gated on day-60 metrics:
+
+| Signal at day 60 | Action |
+|---|---|
+| ≥3 active tenants, retention ≥40%, feedback density ≥0.3 events/tenant/week | Start ADR-0014-amendment-1 paid-SKU draft (likely candidate: enterprise email channel, per-tenant SMTP, or SCIM push — pick one) |
+| 1–2 active tenants, retention OK, feedback density low | Distribution problem, not product problem; stay free-preview, invest in customer-development; 90-day re-check |
+| Active tenants but high churn (<20% week-2 retention) | Daily-driver gap is real; stay free, prioritize whichever workflow churn signals point to |
+| 5+ self-host fork activations, near-zero hosted signups | Self-host IS the market; reframe paid offering as managed-deployment-for-self-hosters (DR + observability + on-call), not multi-tenant SaaS — material reshape of this ADR |
+
+These triggers are explicit decision points, **not marketing copy**.
+They live in this ADR (an internal commitment) rather than in the
+README (which is consent-and-positioning surface for users).
+
+### 4. Data lifecycle commitment
+
+The hosted instance is **free, has no SLA, and may delete tenant data
+with 30-day notice**. This sentence is binding both as a product
+commitment (the maintainer reserves the operational right) and as a
+consent surface (tenants are warned at signup). The mechanism MUST
+exist by URL-flip:
+
+- Cron-able shutdown notification (per-tenant email)
+- Working data-export endpoint (`GET /tenants/:id/export` per
+  ADR-0020)
+- 30-day calendar window between notice and deletion
+
+A "30-day notice" we can't actually send is not a commitment; it's a
+trust hole. Wave 0 acceptance gates the URL flip on this mechanism
+existing, not just the words on the homepage.
+
+### 5. Sunset / promotion path
+
+If this instance is ever promoted to a paid SKU OR sunset, both
+transitions follow the same 30-day-notice + data-export flow that
+exists from day one of the hosted instance. There is no "you signed
+up for free, now it's paid, sorry" path. Promotion to paid:
+
+- ≥30-day notice
+- Existing tenants offered: continue free until end of preview period;
+  migrate to paid SKU; export and self-host; export and leave
+- No silent feature gating; no retroactive paywalling of features
+  used during preview
+
+Sunset:
+
+- ≥30-day notice
+- Working export available throughout
+- Self-host migration guide updated and tested before notice
+
+## Alternatives considered
+
+### A) Stay reserved indefinitely (the prior status)
+
+Rejected. The 2026-04-19 hold was anchored on Amtrak/FDT customer
+signal that no longer exists. Continuing to defer leaves
+ADR-0013 (staging) without its declared promotion target and blocks
+the public-preview pivot the 2026-05-09 re-anchor depends on. The
+"third edition" risk that justified the original hold is defusable in
+writing (items 1 + 2 above) rather than by inaction.
+
+### B) Paid SaaS launch (the 2026-04-19 framing)
+
+Rejected. Without anchor customer or pricing-discovery research,
+charging without distinguishing features creates an SKU that's neither
+"AGPL self-host" nor "Enterprise per-seat" — exactly the third edition
+ADR-0002 forbids. The day-60 metric triggers in §3 above are the
+explicit re-entry path.
+
+### C) Closed beta with hand-picked operators only
+
+Rejected. Reduces signal: hand-picked operators are friendly; rough
+edges get patched-over instead of surfacing. The free public preview
+trades wider exposure (which might surface more bugs publicly) for
+genuinely organic feedback. Risk mitigated by §4 (operational right
+to delete with notice) and Wave 0 hardening (audit chain, throttler,
+LGPD legal docs, runbooks).
+
+### D) Self-host only (no hosted instance at all)
+
+Rejected. Self-host adoption is high-friction (DB + storage + email +
+OIDC config + ops). Without a public hosted instance, the dominant
+signup path is "ops manager evaluates Panorama on their own infra" —
+a multi-day commitment they will not make for an unproven product.
+The free hosted instance is the "try it in 60 seconds" funnel that
+makes self-host adoption decidable.
+
+## Consequences
+
+### Positive
+
+- Real customer feedback loop replaces theoretical priorities. Day 60
+  retention curves and feedback density are measurable signal that
+  internal hypotheses are not.
+- The "free hosted = Community" claim becomes provable, not
+  aspirational, via the §2 edition-boundary lock + #49 functional CI
+  gate.
+- The 2026-04-19 "3rd edition by accident" concern is closed in
+  writing (§§ 1 + 2 are the verbatim defusing).
+- Issue #50 (bus factor of 1) gets a forcing function: operating a
+  public instance demands the runbooks the maintainer would otherwise
+  procrastinate on.
+- The pricing decision (§3) finally has a data-driven re-entry path
+  rather than vibes-based debate.
+
+### Negative
+
+- Operational cost trickles up. Supabase Free → Pro ($25/mo) → PITR
+  ($100/mo) → real Redis ($50+/mo) → real email ($20+/mo) → backup
+  storage. At 5 active tenants the personal-account spend is
+  ~$200/mo with zero revenue. Acceptable for 90 days; revisit at
+  day 91.
+- Free-rider class: people who would have paid for Enterprise's
+  premium connectors will instead self-host with the free OIDC + email
+  channel and never convert. Acceptable while optimizing for adoption
+  at 0.3; becomes a strategic question at 1.0.
+- §2's edition-boundary lock means "let's add just one little thing
+  to the hosted instance" requires an ADR amendment every time. This
+  is the cost of defusing the "third edition" risk — features ship to
+  Community (visible to self-hosters) or not at all.
+- §4's deletion right is real and must be exercised the first time
+  it's needed, not softened under partner pressure. The first such
+  exercise is the credibility test of this ADR.
+
+### Neutral / locked-in
+
+- The hosted instance becomes an additional production surface the
+  maintainer is responsible for. Wave 0 acceptance criteria (audit
+  chain, throttler, runbooks, restore drill, secret rotation) are
+  scoped to this surface; they're not optional.
+- The day-60 metric triggers (§3) become the canonical decision rule
+  for the next ADR-0014 amendment. Drifting from them ("let's not
+  ramp paid yet because…") requires its own ADR amendment.
+- The first paying tenant or first reported LGPD Art. 18 data-subject
+  request triggers a separate "lawyer-reviewed Privacy/ToS" amendment
+  per the Wave 0 deferral rules.
+
+## Implementation notes
+
+This ADR ships as part of Wave 0; the URL flip itself is gated on:
+
+1. This ADR landing as Accepted (this commit closes it)
+2. ADR-0020 (signup model) landing as Accepted with implementation
+3. Wave 0 must-fix backlog per `HANDOFF-2026-05-16-wave0-scan.md`
+4. CI #49 functional Community gate (Wave A) shipping
+5. v2 6-agent scan green-lighting the closed-blocker delta
+
+Until all five gate, the staging URL remains internal and the
+homepage continues to read "early access — not yet open."

--- a/docs/adr/0018-observability-stack.md
+++ b/docs/adr/0018-observability-stack.md
@@ -1,0 +1,222 @@
+# ADR-0018: Observability stack (pino + Sentry + request-id ALS)
+
+- Status: Accepted (2026-05-16). Drafted from the Wave 0 6-agent scan
+  on the same date; accepted by maintainer in the same session.
+- Date: 2026-05-16
+- Deciders: Vitor Rodovalho (maintainer)
+- Reviewers (Wave 0 scan, 2026-05-16):
+  - tech-lead → BLOCK on coding any observability without an ADR
+    (B2 in the scan); items 1–4 below are the verbatim contract that
+    closes the block
+  - security-reviewer → no objection (Sentry opt-in via env preserves
+    self-host operator's ability to run Community without telemetry)
+  - data-architect → no objection (no schema impact; no new tables)
+- Related: [ADR-0011 Notification event bus](./0011-notification-event-bus.md)
+  (existing AsyncLocalStorage pattern via `tenant.context.ts`),
+  [ADR-0014 Public hosted instance](./0014-public-hosted-instance.md)
+  (the surface this ADR makes operable)
+
+## Context
+
+`apps/core-api/src/main.ts` uses default Nest `Logger` — line-formatted
+strings to stdout. There is no Sentry integration, no OpenTelemetry,
+no request-id propagation, no tenant tagging in log output. The first
+production incident on the hosted instance (per ADR-0014) would be
+reconstructed from `fly logs | grep` archaeology — i.e., would not be
+reconstructed.
+
+Wave 0's tech-lead scan (2026-05-16) blocked on writing any
+observability code without an ADR because the choice creates a
+cross-cutting contract every domain module will eventually depend on
+(audit, queue workers, error filters). The "code-ahead-of-ADR =
+ADR-becomes-documentation-theatre" risk is real here: ~40 `new
+Logger(...)` call sites exist; if pino doesn't sit behind Nest's
+`LoggerService` interface, every one of them is a refactor surface.
+
+## Decision
+
+Panorama ships a minimal observability stack in Wave 0:
+
+### 1. Logger contract: pino behind Nest LoggerService
+
+Replace the default Nest `Logger` with a pino-backed implementation
+that **preserves the `LoggerService` interface**. All existing
+`new Logger('Foo').log(...)` call sites continue to work without
+modification; the wire format flips from line-formatted strings to
+JSON.
+
+- Output: JSON to stdout. Aggregation is Fly's responsibility
+  (Logtail, Datadog, or whatever the operator wires); this app does
+  not run a transport.
+- Log levels: pino defaults (`fatal | error | warn | info | debug |
+  trace`); map Nest's `log()` to `info`.
+- Self-host operators can override `LOG_FORMAT=pretty` in
+  `apps/core-api/.env*` to get human-readable output for local
+  development (pino-pretty as devDependency only, not bundled in
+  production image).
+
+### 2. Sentry opt-in via SENTRY_DSN env
+
+Sentry initialization is gated on `process.env.SENTRY_DSN`:
+
+```ts
+if (process.env.SENTRY_DSN) {
+  Sentry.init({ dsn: process.env.SENTRY_DSN, /* … */ });
+}
+```
+
+When `SENTRY_DSN` is unset (default for Community self-host), Sentry
+is a no-op. The `@sentry/node` package (BSD-3) is a runtime
+dependency, but the operator's data is never sent to Anthropic's or
+the maintainer's Sentry project unless they explicitly opt in by
+setting their own DSN. This preserves the AGPL self-host operator's
+right to run Community without telemetry — a non-negotiable per
+ADR-0002.
+
+`.env.example` documents `SENTRY_DSN` as commented-out + linked to
+the Sentry "create a free project" docs.
+
+### 3. Request-id middleware before SessionMiddleware
+
+Inbound `x-request-id` header is honored if present; otherwise a
+nanoid is generated. The middleware is registered FIRST in the
+middleware order (before `SessionMiddleware`), so the request-id is
+available when `SessionMiddleware`'s `runInContext` call extends the
+ALS with `tenantId/userId`.
+
+Concretely: a new `RequestContextMiddleware` lives in
+`apps/core-api/src/shared/observability/request-context.middleware.ts`
+and is wired in `apps/core-api/src/modules/auth/auth.module.ts`
+`configure()` BEFORE the existing `SessionMiddleware`. The request-id
+is attached to the response as `x-request-id` so callers (web,
+external integrations) can correlate.
+
+### 4. Extend TenantContext ALS — do NOT fork
+
+The existing `tenant.context.ts` (`AsyncLocalStorage<TenantContext>` in
+`apps/core-api/src/modules/tenant/tenant.context.ts`) is the
+authoritative request-scoped context. The observability layer
+**extends** this store rather than creating a parallel
+`RequestContextStorage`:
+
+```ts
+// tenant.context.ts (extended shape)
+type TenantContext = {
+  tenantId: string | null;
+  userId: string | null;
+  requestId: string;        // NEW: written by RequestContextMiddleware
+  // … existing fields
+};
+```
+
+The pino logger is configured with a `mixin` function that reads from
+this ALS on every log call:
+
+```ts
+const logger = pino({
+  mixin: () => {
+    const ctx = TenantContext.getStore();
+    return {
+      requestId: ctx?.requestId,
+      tenantId: ctx?.tenantId,
+      userId: ctx?.userId,
+    };
+  },
+});
+```
+
+Two ALS instances racing on the same boundary is fragile and a 3am-
+page footgun. Extending TenantContext keeps the shared store as a
+single source of truth.
+
+## Alternatives considered
+
+### A) Full OpenTelemetry on day one
+
+Rejected. OTel collector + traces + metrics + logs is a multi-day
+integration with its own learning curve, vendor decisions
+(Honeycomb vs Tempo vs Jaeger vs SigNoz), and operational complexity.
+Pino + Sentry + request-id propagation gives 80% of the
+incident-reconstruction value at 20% of the cost. OTel becomes a
+later ADR if Wave 0 metrics show the gap.
+
+### B) Separate `RequestContextStorage` ALS
+
+Rejected per §4 above. Two ALS instances racing on the same boundary
+introduces synchronization bugs that don't surface under test load
+but bite in production.
+
+### C) Replace all `new Logger(...)` call sites with a custom `PanoramaLogger`
+
+Rejected. ~40 call sites; the refactor surface is large, the
+behavioral diff is zero (pino-behind-LoggerService is identical at
+the call site), and the "while I'm here" creep risk is high. Keep
+the Nest LoggerService contract intact.
+
+### D) Don't ship Sentry, only structured logs
+
+Rejected. Structured logs are sufficient for post-mortem
+reconstruction but not for proactive alerting. Sentry's
+issue-grouping + per-release tracking + breadcrumb context is
+load-bearing for "we noticed the error before the user reported it"
+— which IS the trust contract of a hosted preview where the user
+has no SLA to fall back on.
+
+## Consequences
+
+### Positive
+
+- Incidents on the hosted instance can be reconstructed from
+  structured logs (with tenant + request correlation) instead of
+  `fly logs | grep`.
+- Sentry surfaces unhandled errors proactively; the maintainer learns
+  about issues before the user reports them.
+- Self-host operators retain full control: `SENTRY_DSN` unset = no
+  telemetry; `LOG_FORMAT=pretty` = local-friendly output.
+- The shared TenantContext ALS keeps audit, error-filter, and logging
+  consistent — one source of truth for "what tenant/user/request is
+  this happening in."
+
+### Negative
+
+- pino + @sentry/node + nanoid are net-new runtime dependencies.
+  Bundle size grows ~400 KB; acceptable.
+- The `RequestContextMiddleware` MUST be registered before
+  `SessionMiddleware`; future module reorganization can break this
+  invariant. Documented in middleware-order comment + asserted by an
+  e2e smoke test.
+- Sentry's free tier (5K events/month) is enough for a public preview
+  but caps quickly at scale. Future ADR amendment if event volume
+  forces a paid tier.
+
+### Neutral / locked-in
+
+- All future modules that need request-scoped context use the existing
+  TenantContext ALS — no new ALS instances unless an ADR amendment
+  argues for it.
+- The pino-behind-LoggerService pattern means future logger swaps
+  (e.g., to Bunyan or to OTel logs) only touch the adapter, not the
+  call sites.
+
+## Implementation notes
+
+Sequencing within Wave 0:
+
+1. Add deps (`pino`, `@sentry/node`, `nanoid`) + dev dep
+   `pino-pretty`
+2. Implement `RequestContextMiddleware` + extend `TenantContext`
+   shape (one PR; passes existing tests; adds a smoke test for
+   middleware order)
+3. Wire pino as the Nest `LoggerService`, replacing the default
+   Logger init in `main.ts` (one PR; verify all existing log call
+   sites still emit)
+4. Wire Sentry init in `main.ts` (gated on `SENTRY_DSN`); add the
+   default error filter that captures uncaught exceptions
+5. Document `LOG_FORMAT` + `SENTRY_DSN` in `.env.example` +
+   `docs/en/self-hosting.md`
+
+Per the v2 6-agent scan that gates the URL flip, this ADR's
+implementation is part of the Round 5 cluster (CI + observability +
+secret rotation). It does NOT block Round 1 (homepage rewrite +
+quick wins) or Round 2 (throttler + audit chain) from shipping
+first.

--- a/docs/adr/0019-worker-process-boundary.md
+++ b/docs/adr/0019-worker-process-boundary.md
@@ -1,0 +1,166 @@
+# ADR-0019: Worker process boundary (photo pipeline defer-with-trigger)
+
+- Status: Accepted (2026-05-16). Drafted from the Wave 0 6-agent scan
+  on the same date; accepted by maintainer in the same session.
+- Date: 2026-05-16
+- Deciders: Vitor Rodovalho (maintainer)
+- Reviewers (Wave 0 scan, 2026-05-16):
+  - tech-lead → BLOCK on splitting the photo-pipeline into a worker
+    process for Wave 0 without an ADR codifying the trigger condition
+    (B3 in the scan). This ADR is the codification.
+  - data-architect → no objection (no schema impact)
+  - security-reviewer → no objection (no new attack surface; existing
+    BullMqInvitationQueue convention is preserved)
+- Related: [ADR-0011 Notification event bus](./0011-notification-event-bus.md)
+  (existing co-located producer + worker convention),
+  [ADR-0012 Inspection checklists + photo evidence pipeline](./0012-inspection-photo-pipeline.md)
+  (the photo-pipeline service this ADR scopes)
+
+## Context
+
+The handoff from 2026-05-09 listed "BullMQ + Redis worker process —
+photo-pipeline isn't wired as a worker; synchronous handling of any
+queued work blocks request threads. Latent risk under load." as a
+Wave 0 candidate. The Wave 0 tech-lead scan on 2026-05-16 surfaced
+the architectural cost of splitting NOW versus later, and asked for
+this ADR to either codify the split or codify the trigger that would
+force it.
+
+The decision is to **defer the split** for Wave 0 and codify a
+specific trigger condition.
+
+## Decision
+
+The photo-pipeline (`apps/core-api/src/modules/photo-pipeline/photo-pipeline.service.ts`)
+**stays in-process** for the public preview launch. A separate worker
+process is deferred until one of two trigger conditions fires:
+
+### Trigger A — latency
+
+p95 photo-upload handler latency exceeds **2 seconds for 10
+consecutive minutes** (measured from the observability stack
+established in ADR-0018). Sustained 2s p95 means the request thread
+is blocking on photo work and degrading unrelated requests.
+
+### Trigger B — concurrency
+
+Concurrent inspection-photo uploads exceed **N simultaneous** (where
+N is the per-instance Fly machine's CPU count × 2, or 4 — whichever
+is greater). At that point the in-process model degenerates into
+serial processing under load.
+
+When either trigger fires, the response is to write an ADR-0019
+amendment (or supersede this ADR) that:
+
+1. Designates the worker topology (separate Fly process group with
+   shared Redis queue + S3 access)
+2. Migrates BOTH the photo-pipeline AND the existing
+   `BullMqInvitationQueue` (`apps/core-api/src/modules/invitation/invitation-email.queue.ts`)
+   to the same topology — see Reasoning §B below
+3. Defines the deploy unit (Fly process group config)
+4. Defines the failure modes (worker dead but web alive serving 200s
+   on uploads that never persist)
+
+## Reasoning
+
+### A. Public-preview load profile justifies in-process
+
+Wave 0's load expectations: 1–3 design partners in the first 60 days,
+each with low concurrent activity. The photo-pipeline's CPU
+intensity (sharp resize + EXIF strip + S3 upload) is real but the
+request-thread cost is bounded by partner concurrency. Splitting now
+optimizes for a load profile we don't have and may never reach.
+
+### B. Splitting one queue without splitting all creates two conventions
+
+The existing `BullMqInvitationQueue`
+(`apps/core-api/src/modules/invitation/invitation-email.queue.ts`)
+co-locates worker + producer in one process today. That's the
+convention. Breaking it for photo-pipeline first creates **two
+conventions** — when the trigger fires, the right move is to migrate
+BOTH queues to the new topology in a single ADR amendment, not to
+incrementally fork the architecture.
+
+### C. New failure mode introduced by the split
+
+In-process work has one failure mode: the request crashes, the user
+sees 5xx. A separated worker introduces a second failure mode:
+worker dead, web alive serving 200s on uploads that the user thinks
+succeeded but that never persist. This is a real footgun and the
+mitigation (worker health-check + queue-depth alerting + dead-worker
+detection) is its own multi-day implementation. Don't pay that cost
+without the trigger that justifies it.
+
+## Alternatives considered
+
+### A) Split now in Wave 0
+
+Rejected per §A above. The load profile doesn't justify the cost; the
+new failure mode introduces operational complexity we don't yet have
+the runbooks for; the convention split creates churn in the
+invitation queue surface that has no reason to change.
+
+### B) Defer with no trigger codified ("we'll know when it's a problem")
+
+Rejected. Implicit triggers become "let's not bother" decisions that
+drift indefinitely. Codifying p95 latency + concurrency thresholds
+gives the maintainer (and future contributors) a clear
+"this-is-when-we-act" signal that doesn't require re-arguing the
+decision under load pressure.
+
+### C) Adopt a queue topology that's worker-ready from day one
+   (e.g., Sidekiq-style with always-separate workers)
+
+Rejected. Same architectural cost as splitting now, just framed as
+"we built it to scale." The "build for the load you have, not the
+load you imagine" principle (a non-negotiable from prior ADRs)
+applies. When the trigger fires, the migration is not painful — it's
+~1 day of work — but doing it now is unnecessary toil.
+
+## Consequences
+
+### Positive
+
+- Wave 0 ships without a multi-day worker-topology project that
+  doesn't pay off until load arrives.
+- The trigger conditions (§A + §B) are observable from ADR-0018's
+  observability stack — no separate instrumentation needed.
+- When the trigger does fire, the migration scope is unambiguous
+  (both queues, single ADR amendment) — no incremental fork.
+
+### Negative
+
+- Sustained heavy load before the trigger fires (e.g., a single
+  partner doing a 100-photo inspection sweep) will degrade
+  unrelated requests on the same Fly instance. Mitigation: per-
+  tenant throttler from Wave 0 backlog + Fly horizontal scaling if
+  needed.
+- The "no worker yet" framing in the public-preview honesty band
+  must be honest: "photo uploads run synchronously today; under
+  heavy load the request thread is busy" is what the band says, not
+  "workers handle uploads in the background."
+
+### Neutral / locked-in
+
+- The trigger conditions are observable; if they don't fire in 90
+  days of public preview, the in-process pattern stays as the
+  default. If they fire, the migration is unblocked.
+- Future queue work (e.g., audit-event archival, scheduled
+  reservation reminders) defaults to the same in-process pattern
+  unless its own ADR argues for a worker — same trigger logic
+  applies.
+
+## Implementation notes
+
+Nothing ships from this ADR directly. It is a **defer-with-condition**
+decision that:
+
+- Closes the Wave 0 tech-lead scan B3 block
+- Cites ADR-0018's observability stack as the source of the trigger
+  measurement
+- Provides the maintainer + future contributors with a clear gate
+  for when to revisit
+
+The honesty-band copy on the public homepage (Wave 0 deliverable)
+should mention "photo uploads run synchronously today" as the
+"what's rough" disclosure that pairs with this ADR.

--- a/docs/adr/0020-self-serve-oidc-signup.md
+++ b/docs/adr/0020-self-serve-oidc-signup.md
@@ -1,0 +1,311 @@
+# ADR-0020: Self-serve OIDC signup (Wave 0.5)
+
+- Status: Proposed (2026-05-16). Decision on signup model: Accepted.
+  Implementation gates on a security-reviewer follow-up threat model
+  pass on the rate-limit + email-verification + CAPTCHA design.
+- Date: 2026-05-16
+- Deciders: Vitor Rodovalho (maintainer)
+- Reviewers (Wave 0 scan, 2026-05-16):
+  - security-reviewer → flagged self-serve as needing its own threat
+    model carve-out (B3 in the scan); this ADR is the carve-out, and
+    the implementation phase requires a follow-up sec-review pass
+  - product-lead → SUPPORT (self-serve removes the hand-provisioning
+    bottleneck that would otherwise gate organic signup signal)
+  - tech-lead → no objection on architecture (OIDC-only avoids the
+    password-vector surface entirely; existing OIDC stack from
+    ADR-0010 + 2026-05-09 PR #190 is reusable)
+  - data-architect → no objection (one tenant per email is a clean
+    one-row-per-signup invariant; deletion cool-off lock surfaces
+    are existing patterns)
+  - persona-fleet-ops → SUPPORT (an ops manager can self-serve a
+    trial in 60 seconds, which is the funnel the hosted instance
+    needs to be evaluable)
+- Related: [ADR-0008 Invitation flow](./0008-invitation-flow.md)
+  (existing email-token + TTL + audit pattern, reusable for email-
+  verification),
+  [ADR-0010 Snipe-IT compat shim — auth model](./0010-snipeit-compat-shim-auth.md)
+  (existing OIDC + PAT auth surface),
+  [ADR-0014 Public hosted instance](./0014-public-hosted-instance.md)
+  (the hosted instance this ADR provisions tenants for)
+
+## Context
+
+ADR-0014 commits to a public hosted instance of the Community edition.
+For that instance to deliver the "ops manager evaluates Panorama in
+60 seconds" funnel that justifies its existence (per ADR-0014 §A),
+there must be a path from "I clicked Get a hosted account" to
+"I'm logged in to my own tenant" without the maintainer in the loop.
+
+The Wave 0 6-agent scan on 2026-05-16 surfaced two viable signup
+models:
+
+- **(a) Invitation-only** — request-access form on the homepage emails
+  the maintainer; maintainer provisions the tenant manually via
+  `smoke-staging-seed.ts`. Wave 0 closes faster + cleaner. The
+  "data-export button before signup" claim is met by docs showing
+  operators how to request export.
+- **(b) Self-serve OIDC** — full automated signup via Google or
+  Microsoft OIDC, one tenant per email, with email-verification + per-
+  IP rate-limit + CAPTCHA + audit-emit. Larger Wave 0 scope (security-
+  reviewer flagged as needing its own threat model). ~2-3 days of
+  additional work versus path (a).
+
+The maintainer chose path (b) on 2026-05-16. This ADR scopes that
+choice.
+
+## Decision
+
+Panorama's hosted instance offers **self-serve OIDC signup** with the
+following invariants:
+
+### 1. OIDC-only — no password vector
+
+Signup happens via Google or Microsoft OIDC (already integrated per
+ADR-0010 + PR #190's e2e validation). There is **no password signup**
+on the hosted instance. This removes the credential-stuffing attack
+surface entirely and offloads identity proofing to the IdP.
+
+If the user lacks a Google or Microsoft account, the alternative is
+to self-host (the AGPL self-host path explicitly supports any OIDC
+provider). The hosted instance does not need to be every-user-
+welcoming; it needs to be safe.
+
+### 2. One tenant per email (initial signup)
+
+Each successful OIDC signup creates exactly one tenant with the
+signup email's user as Tenant Owner. Future enhancement (deferred):
+allow a user to be Owner of multiple tenants by inviting themselves
+under a different email or by accepting an invitation to join an
+existing tenant — both already supported via the existing invitation
+flow (ADR-0008).
+
+### 3. Email-verification gate
+
+Even though OIDC IdPs already verify the email, Panorama emits a
+post-signup confirmation email with a one-time-use token (TTL: 24h).
+The tenant is provisioned in a `pending_verification` state; the
+first login is blocked until the verification token is consumed.
+
+This protects against:
+- IdP-issued tokens for emails the IdP itself hasn't verified (rare
+  but possible)
+- Drive-by signups from compromised browser sessions
+- Provides an audit-trail point for "user actually controls this
+  inbox"
+
+The pattern reuses the existing invitation token machinery from
+ADR-0008 (email-token + TTL + one-time-use + audit). No new
+abstraction.
+
+### 4. Per-IP rate-limit on signup endpoint
+
+The signup endpoint (POST `/auth/signup` or similar) is throttled at
+**5 signups per IP per hour**, fail-closed. This is enforced via the
+ThrottlerGuard pattern that Wave 0 Round 2 wires (see
+`HANDOFF-2026-05-16-wave0-scan.md`); the signup endpoint MUST be in
+the first batch of `@Throttle`-decorated routes.
+
+Per security-reviewer's note on `app.set('trust proxy')`: the
+throttler key must use `X-Forwarded-For[0]`, not the LB IP. Without
+this fix, all signups appear to come from one IP and share one bucket
+— that's not fail-closed, that's fail-united.
+
+### 5. CAPTCHA on signup form
+
+The signup form on the public homepage includes a CAPTCHA challenge
+(hCaptcha or Cloudflare Turnstile — TBD by the homepage rewrite PR).
+This is the abuse cutoff against scripted signup flooding that
+rate-limit alone doesn't catch (rate limit at 5/hour/IP is still
+30/day/IP through one residential proxy network).
+
+CAPTCHA is **client-side rendered, server-side verified** on every
+signup attempt. CAPTCHA failure returns a generic "verification
+failed, please try again" error (do not leak which check failed —
+rate limit vs CAPTCHA vs IdP).
+
+### 6. Audit emission
+
+Every signup attempt emits at least:
+- `panorama.tenant.signup_initiated` — at the moment the OIDC flow
+  starts (audit registry addition)
+- `panorama.tenant.created` — at the moment the tenant is provisioned
+  in `pending_verification` state (existing event)
+- `panorama.tenant.verification_sent` — when the confirmation email
+  is dispatched (audit registry addition)
+- `panorama.tenant.verified` — when the user clicks the verification
+  link and the tenant becomes active (audit registry addition)
+- `panorama.auth.signup_rate_limit_tripped` — when the throttler
+  blocks an attempt (audit registry addition)
+- `panorama.auth.captcha_failed` — when CAPTCHA verification fails
+  server-side (audit registry addition)
+
+All new audit actions added to the audit registry
+(`apps/core-api/src/modules/audit/audit-actions.ts`) BEFORE the
+signup endpoint ships.
+
+### 7. Tenant deletion: two-step + 7d cool-off
+
+The hosted instance provides `DELETE /tenants/:tenantId` (Owner-only):
+
+- Step 1: `POST /tenants/:tenantId/delete-request` — sends an email
+  with a one-time confirmation link
+- Step 2: `POST /tenants/:tenantId/delete-confirm` with the token —
+  schedules deletion for 7 days hence
+- During the 7-day cool-off:
+  - Owner can cancel via `POST /tenants/:tenantId/delete-cancel`
+  - Tenant data remains accessible (login still works)
+  - Banner in the UI: "this tenant is scheduled for deletion on
+    YYYY-MM-DD; click here to cancel"
+- After 7 days: cron job purges tenant data + emits
+  `panorama.tenant.deleted`
+
+The 7-day window prevents a compromised Owner credential from
+instantly nuking a tenant. The cancel path provides a "I clicked the
+wrong button" recovery.
+
+Cascade ordering note (per data-architect C6 in Wave 0 scan):
+`Tenant.systemActorUserId` has `ON DELETE RESTRICT`. The deletion
+service MUST NULL this column (or delete the system user) BEFORE
+attempting the cascade-delete on the tenant row. This is service-
+layer logic, not a schema change.
+
+### 8. Data export
+
+Self-serve data export is its own endpoint, not coupled to deletion:
+`GET /tenants/:tenantId/export` (Owner-only). Per security-reviewer's
+abuse defenses:
+
+- Rate limit: 1 export per tenant per 24h, via Redis bucket, fail-
+  closed
+- Async: response is a job id; the actual export runs in a queue,
+  delivered as a signed S3 URL via email when complete
+- Audit-emit on every call (`panorama.tenant.export_requested` +
+  `panorama.tenant.exported`)
+- Inline export of a 100k-row tenant on a hot HTTP path is itself a
+  DoS vector; async-only is non-negotiable
+
+The signup → export path satisfies the "show data-export before
+signup" persona-fleet-ops principle: the homepage has a "see what
+we'd export for you" link to a sample JSON document showing the
+shape of the export, BEFORE the user signs up. Real export only
+happens post-signup.
+
+## Alternatives considered
+
+### A) Invitation-only signup (path (a) from the scan)
+
+Rejected by maintainer 2026-05-16. Path (a) closes Wave 0 faster but
+introduces a manual-provisioning bottleneck that throttles the
+"organic signup signal" the public preview is supposed to generate.
+Each request-access email becomes a maintainer task; at 10
+requests/week, that's a meaningful drag on actual product work.
+
+### B) Self-serve with password (no IdP requirement)
+
+Rejected. Password storage adds the credential-stuffing attack
+surface that ADR-0010 deliberately avoided. The hosted instance is
+free; users without Google/Microsoft accounts can self-host. The
+trade-off is acceptable.
+
+### C) Self-serve with magic-link only (no OIDC)
+
+Rejected. Magic-link is convenient but creates email-deliverability
+risk: a flaky transactional email layer = users can't sign in. OIDC
+sidesteps this entirely (the IdP handles delivery). Magic-link as a
+fallback for OIDC-impaired users is a future enhancement, not Wave
+0.5.
+
+### D) Skip CAPTCHA, rely on rate-limit + email-verification
+
+Rejected. Rate-limit at 5/hour/IP is bypassable via residential proxy
+networks (~$10/month gives an attacker thousands of IPs). Email-
+verification creates inboxes-required friction but doesn't prevent
+the abuse from being expensive to clean up (orphaned pending tenants,
+audit-trail noise). CAPTCHA is the cheap defense that closes this
+gap.
+
+## Consequences
+
+### Positive
+
+- Removes the manual-provisioning bottleneck; the maintainer is not in
+  the signup path
+- Preserves AGPL self-host as the path for OIDC-impaired users (no
+  hosted-instance feature creep into "support every IdP")
+- Reuses existing invitation-token + audit + OIDC machinery (no net-
+  new abstractions)
+- Email-verification + CAPTCHA + rate-limit + audit-emit gives a
+  defensible defense-in-depth posture against drive-by abuse
+- 7-day deletion cool-off prevents credential-compromise nuking and
+  gives an "undo" path
+
+### Negative
+
+- Wave 0 scope expands by ~2-3 days to cover the signup endpoint +
+  email-verification flow + CAPTCHA integration + threat-model pass
+- New attack surface (signup endpoint) requires the security-reviewer
+  follow-up pass before code lands
+- CAPTCHA introduces a third-party dependency (hCaptcha or Cloudflare
+  Turnstile) — both have free tiers but add to the supply-chain list
+  in the SBOM
+- Email-deliverability becomes load-bearing: a bounced verification
+  email = user can't sign in. Wave 0 must include a documented
+  process for what to do when verification email bounces (manual
+  unverify-and-resend via maintainer admin tool)
+
+### Neutral / locked-in
+
+- One tenant per email (initial signup) means users wanting multiple
+  tenants must use the invitation flow — same as today's self-host
+  pattern
+- The signup endpoint lives in Community surface gated by
+  `FEATURE_SELF_SERVE_SIGNUP=false` (see edition-boundary check
+  below) — same pattern as `FEATURE_INSPECTIONS` and
+  `FEATURE_MAINTENANCE`
+
+## Edition-boundary check (per ADR-0014 §2)
+
+ADR-0014 §2 says: "If this instance ships any code, feature, or
+endpoint that does not exist on a vanilla self-host of the same Git
+SHA, that is a violation."
+
+The signup endpoint described in this ADR **MUST exist in the
+Community edition** to satisfy that lock. It ships disabled by
+default behind a `FEATURE_SELF_SERVE_SIGNUP=false` env flag. The
+hosted instance enables the flag; self-hosters can enable it too if
+they want self-serve on their own deployment (a real use case for
+SaaS-style multi-tenant self-hosts).
+
+This makes the endpoint Community surface that's gated by config —
+the same pattern as `FEATURE_INSPECTIONS` and `FEATURE_MAINTENANCE`.
+No edition-boundary violation; the hosted instance runs identical
+binary, just with a different config.
+
+## Implementation notes
+
+Sequencing within Wave 0:
+
+1. **Security-reviewer follow-up pass** on the threat model in
+   §§ 4 + 5 + 7 above — required before Round 3 starts. The follow-
+   up validates: rate-limit shape against synthetic flood test;
+   CAPTCHA verification flow + failure messaging; email-verification
+   token TTL + replay defense; deletion cool-off race conditions
+   (e.g., two cancel requests in flight).
+2. Audit registry addition (Round 3 prerequisite, per §6) — adds the
+   six new audit actions to `audit-actions.ts` BEFORE the endpoints
+   that emit them ship.
+3. Signup endpoint + email-verification flow (Round 3, gated on §1).
+4. Data-export endpoint (Round 3, gated on Round 2's audit chain
+   reproducibility — without it, "we audited your export" is
+   unverifiable).
+5. Tenant-deletion endpoint (Round 3, includes the 7-day cron).
+6. Homepage signup form + CAPTCHA integration (Round 1 wires the
+   form copy; CAPTCHA + functional submit in Round 3).
+7. v2 6-agent scan: re-run security-reviewer on the implemented
+   surface before URL flips.
+
+The `FEATURE_SELF_SERVE_SIGNUP` flag defaults to `false` in
+Community + `true` on the hosted instance. Self-hosters wanting
+multi-tenant signup on their own deployment can flip the flag with
+the same defense-in-depth (rate-limit + CAPTCHA + email-verification)
+they get from this ADR's implementation.

--- a/docs/audits/HANDOFF-2026-05-16-wave0-scan.md
+++ b/docs/audits/HANDOFF-2026-05-16-wave0-scan.md
@@ -1,0 +1,273 @@
+# Handoff — 2026-05-16 (Wave 0 6-agent scan + decisions + revised plan)
+
+> Continuation of `HANDOFF-2026-05-09-session-end.md` (v2). This doc
+> captures the Wave 0 + Wave B 6-agent scan that gates the public
+> hosted URL, the four maintainer decisions that locked next-step
+> scope, and the revised round-by-round sequencing.
+>
+> The 4 ADRs drafted from this scan landed in the same session:
+> - ADR-0014 — Public hosted instance (replaces the long-reserved slot)
+> - ADR-0018 — Observability stack
+> - ADR-0019 — Worker process boundary (defer-with-trigger)
+> - ADR-0020 — Self-serve OIDC signup (Wave 0.5; Proposed pending
+>   security-reviewer threat model follow-up)
+
+## Why this handoff exists
+
+The 2026-05-09 handoff (v2) ended with a wave plan: Wave 0 +
+Waves A–D, with per-wave 5-agent scans gating each. The user opened
+2026-05-16's session by directing Wave 0 + Wave B+C to run in
+parallel (Wave A folded under Round 5 below; Wave C remains as
+per-pickup scan later).
+
+The 6-agent scan that followed surfaced findings significantly more
+severe than the v2 handoff suggested. Several Wave 0 items were
+worse than described; several were already done; one entire wave
+(Wave B nav primitive) was misframed as "to build" when it already
+exists in `app-shell.tsx` + `app-nav.tsx`.
+
+This handoff captures the corrections + the revised plan.
+
+## Stale claims in v2 handoff (corrected by the scan)
+
+| v2 claim | 2026-05-16 reality |
+|---|---|
+| "ThrottlerModule is configured app-level only; per-tenant override is the gap" | **ThrottlerGuard is never registered as `APP_GUARD`** — `app.module.ts:82-85` configures named buckets but no guard enforces them. The `auth: 10/min` cap is fictional. `app.set('trust proxy', 1)` is also missing in `main.ts`. (security-reviewer B1; tech-lead B1) |
+| "ROLLBACK.md backfill needed for migrations 0013–0020 (zero exist on disk)" | **20/20 migrations have ROLLBACK.md** on disk; the data-architect's prior delta-pass claim was stale. Backfill scope is now: 2 content fixes (0014 FEATURE_MAINTENANCE order; 0020 path) + drill one against pg_dump restore. (data-architect O2 + tech-lead C2) |
+| "Wave B #45: build global navigation primitive" | **Already exists** in `app-shell.tsx` + `app-nav.tsx` + wraps every authenticated route via `(authenticated)/layout.tsx`. Real Wave B work is page-header standardization + nav reorder + a11y fixes + first RTL test. (ux-critic) |
+| "Audit chain is tamper-evident (hash-chained)" | **Per-row digest is unreproducible** — `audit_events.metadata` is JSONB which recanonicalizes keys on store, so a verifier reading the row cannot recompute the digest input. Migration 0020 only fixed the timestamp arm; the metadata canonicalization hole is still open. SECURITY.md still admits the chain breaks. (security-reviewer B2; data-architect Blocker 3) |
+| "No data-export endpoint; will be added Wave 0" | Confirmed missing. Plus: **no signup endpoint either** (only `smoke-staging-seed.ts` provisions tenants today). The Wave 0 acceptance "show export button BEFORE signup" was unbacked. (security-reviewer B3; persona-fleet-ops blocker 5) |
+
+## Decisions locked (maintainer, 2026-05-16)
+
+1. **Signup model: self-serve OIDC** (Google + Microsoft, no
+   password). Triggers Wave 0.5 carve-out (ADR-0020). Implementation
+   blocked on security-reviewer threat model follow-up.
+2. **Worker process: defer with trigger** (ADR-0019). Photo-pipeline
+   stays in-process; trigger conditions codified in the ADR.
+3. **SESSION_SECRET rotation: secondary-key support** (~half-day).
+   iron-session accepts an array; primary+secondary with flip-then-
+   drop = zero-downtime rotation.
+4. **Outreach: deferred to post-code**. Code first, find humans
+   later. Maintainer accepts the risk that day-30 metrics will be
+   sparse-data noise. (product-lead block 3+4 acknowledged as open
+   risk, not closed.)
+
+## Round-by-round sequencing (Wave 0 + Wave 0.5 + Wave B in parallel)
+
+### Round 0 — docs scaffolding (no code) — DONE in same session as scan
+
+- Refresh handoff (this file)
+- ADR-0014 amendment "Public hosted instance" — Accepted
+- ADR-0018 "Observability stack" — Accepted
+- ADR-0019 "Worker process boundary" — Accepted
+- ADR-0020 "Self-serve OIDC signup" — Proposed (pending sec follow-up)
+
+### Round 1 — quick wins (no architectural risk)
+
+Bundle into 1–3 PRs based on natural seams:
+
+- `docs/index.md` rewrite: drop "pre-alpha", drop the 4 feature cards
+  (Snipe-IT-positioned), dual CTA (Get hosted / Self-host on GitHub),
+  honesty band in same eyeful as hero, trust strip placeholder
+- Remove `ignoreDeadLinks: true` from `docs/.vitepress/config.mts`;
+  either translate hero + honesty band into PT/ES or remove the
+  locale stubs that currently masquerade as translated content
+- Fix `apps/core-api/.env.staging` (add `DATABASE_DIRECT_URL` per
+  the three-URL contract; current file is from pre-#186 generator)
+- `docs/runbooks/setup-supabase-staging.md:172`:
+  `connection_limit=1` → `10` (per data-architect Blocker 2 math)
+- ROLLBACK.md content fixes (0014 FEATURE_MAINTENANCE order; 0020
+  path/heredoc)
+- a11y blockers: form labels in
+  `apps/web/src/app/(authenticated)/reservations/page.tsx` lines
+  466, 535, 580, 632, 663, 671, 693, 703, 717; calendar status
+  letter prefix; `<main>` landmark relocation from root layout to
+  per-page content area
+- `docs/en/roadmap.md` update (0.3 maintenance status; 0.4 reframe
+  to public-preview)
+- `docs/runbooks/secrets-inventory.md` (35+ env vars enumerated by
+  category, per tech-lead C1)
+
+### Round 2 — backend hardening
+
+Two clusters, can be split into 2–4 PRs:
+
+**Cluster 2A — Throttler wiring**
+- Register `APP_GUARD: ThrottlerGuard` in `AppModule`
+- `app.set('trust proxy', 1)` in `main.ts`
+- `@Throttle` decorators on `/auth/login`, `/auth/oidc/:provider/
+  callback`, `/invitations/accept`, `/auth/signup` (when ADR-0020
+  ships)
+- Per-tenant tracker via `getTracker(req)` subclass reading
+  `currentTenantId()` from ALS (anonymous routes fall back to IP)
+- Synthetic flood test at `apps/core-api/test/abuse/login-flood.e2e.
+  ts` — POST `/auth/login` 50× from one synthetic IP, assert 429 on
+  attempts ≥11
+
+**Cluster 2B — Audit-chain reproducibility**
+- Migration 0021: add `digestPreImage BYTEA` column to
+  `audit_events`
+- `AuditService.recordWithin` writes the canonical pre-image
+- Both notification + PAT triggers (migrations 0015 + 0020) write
+  the same canonical pre-image to the new column
+- `pg_advisory_xact_lock(hashtext('audit:' || tenantId))` before the
+  chain-head SELECT in service AND in trigger functions (closes
+  data-architect Blocker 3 + #41 issue 1)
+- `OLD.tenantId IS DISTINCT FROM NEW.tenantId` early-return in
+  trigger functions (#41 issue 3)
+- `WHERE selfHash IS NOT NULL` guard on chain-head SELECT (#41
+  issue 4)
+- `pnpm chain-verify` CLI at `apps/core-api/src/cli/verify-audit-
+  chain.ts`
+- `docs/runbooks/verify-audit-chain.md` operator doc
+- Update `SECURITY.md` to remove the "trigger breaks the chain"
+  admission and replace with the actual current contract
+
+### Round 3 — endpoints (signup + export + delete)
+
+Gated on ADR-0020 security-reviewer follow-up + audit-actions
+registry pre-population.
+
+- Audit registry additions (per ADR-0020 §6): six new actions added
+  to `apps/core-api/src/modules/audit/audit-actions.ts` BEFORE the
+  endpoints that emit them
+- Self-serve OIDC signup endpoint (ADR-0020 §1–§5)
+  - `FEATURE_SELF_SERVE_SIGNUP` flag (default false; hosted enables)
+  - Email-verification token reusing ADR-0008 invitation pattern
+  - Per-IP rate-limit (gated on Round 2A throttler wiring)
+  - CAPTCHA (hCaptcha or Turnstile — TBD by homepage rewrite PR)
+- `GET /tenants/:tenantId/export` (Owner-only, async via queue,
+  signed-URL delivery, 1/tenant/24h Redis bucket fail-closed)
+- `DELETE /tenants/:tenantId` two-step + 7d cool-off (ADR-0020 §7)
+  - `POST /tenants/:tenantId/delete-request` → email
+  - `POST /tenants/:tenantId/delete-confirm` → schedule
+  - `POST /tenants/:tenantId/delete-cancel` → cancel
+  - Cron job purges + emits `panorama.tenant.deleted`
+  - Cascade ordering: NULL `Tenant.systemActorUserId` first
+
+### Round 4 — daily-driver UX (persona-fleet-ops blockers + Wave B)
+
+- Approvals queue surface — either dedicated `/approvals` route OR
+  flip `/reservations` default to `scope=tenant&status=pending` when
+  the user has approval rights; concurrency proof via advisory lock
+  + stale-row banner on conflict (closes persona blocker 1 + 3)
+- Actor-on-row in reservations — surface
+  `approvedByUserName/checkedInByUserName/checkedOutByUserName` from
+  fields the schema already captures (closes persona blocker 2)
+- Page-header component at `apps/web/src/components/page-header.tsx`
+  + standardize h1/h2 across all authenticated pages (closes ux-
+  critic concern on heading inconsistency + ux-critic O5 page-header
+  reframe)
+- Vitest + RTL setup for `apps/web` per tech-lead C3 (jsdom; one
+  smoke test on `login/page.tsx`)
+- Nav item reorder per ops verbs: Calendar → Reservations →
+  Inspections → Assets → Maintenance; group admin items under "Admin
+  ▾" overflow (closes persona C13 + ux-critic C7a)
+- Tenant-switcher + sign-out moved into user overflow menu (frees
+  ~120px header; closes ux-critic C7c+d)
+- Inline styles in `app-shell.tsx` + `app-nav.tsx` moved into
+  `globals.css` (closes ux-critic C7b)
+- Surface previous reservation's `damageNote` in next checkout
+  disclosure for same asset (persona opportunity, closes
+  FleetManager scar)
+
+### Round 5 — CI + observability + secret rotation
+
+- **#49 ensure-community-complete CI** (Wave A in v2) — promote
+  from grep to functional bootstrap-without-Enterprise-flags +
+  exercise community paths + assert. **HARD PREREQUISITE for URL
+  flip** per product-lead block 1
+- Observability stack per ADR-0018: pino behind LoggerService +
+  Sentry opt-in via `SENTRY_DSN` + `RequestContextMiddleware`
+  before `SessionMiddleware` + extend TenantContext ALS
+- SESSION_SECRET secondary-key support per maintainer decision —
+  iron-session array config, primary+secondary, flip-then-drop
+  rotation procedure documented in secrets-rotation runbook
+
+### Round 6 — runbooks
+
+- `docs/runbooks/incident.md` per security-reviewer C3: breach
+  taxonomy, awareness criteria (ciência inequívoca for LGPD 72h
+  ANPD clock), comms template, who-does-what, rollback drill
+  checkpoints
+- `docs/runbooks/restore.md` per data-architect O3 template +
+  execute drill on staging, store evidence at
+  `docs/audits/restore-drill-<date>/` (RTO/RPO measured + chain-
+  verify across restore boundary per data-architect C6)
+- `docs/runbooks/secrets-rotation.md` using inventory from Round 1;
+  per-secret-category procedure (database, session, OIDC, S3, SMTP,
+  Sentry DSN, Redis)
+- Register controlled domain (panorama.app or panorama.dev TBD) +
+  migrate `security@vitormr.dev` to `security@<domain>` + add
+  `.well-known/security.txt` with PGP signature (or
+  `Encryption: none` explicit per RFC 9116 §2)
+
+### Round 7 — pre-launch + v2 scan + URL flip go/no-go
+
+- Privacy + ToS at `apps/web/src/app/legal/*` per security-reviewer
+  C2: LGPD Art. 9 mandatories, sub-processor CATEGORIES (not
+  vendors — threat-model reasoning), plain-language v1 (lawyer
+  review deferred per ADR-0014 §C6 trigger)
+- Status page (Upptime on GH Actions free) — probe `/health` ONLY,
+  no body matching, no tenant-named probes (security C1)
+- SBOM CycloneDX from clean `pnpm install --prod --frozen-lockfile`,
+  cosign sigstore keyless sign on release
+- README "Backend: production-ready" claim softened (security O4)
+- Add hosted-vs-self-host CTA tracking on dual CTAs (product
+  opportunity 1 — cheap day-1 instrumentation toward Wave D
+  decision triggers)
+- v2 6-agent scan — re-spawn `tech-lead + data-architect +
+  security-reviewer + product-lead + persona-fleet-ops + ux-critic`
+  on the closed-blocker delta; iterate until accepted
+- URL flip go/no-go decision recorded as ADR-0014 amendment commit
+
+## Wave 0 acceptance (revised)
+
+The hosted URL flips when ALL of:
+
+1. ADR-0014 + ADR-0018 + ADR-0019 + ADR-0020 all Accepted
+2. Round 1 quick wins shipped (homepage rewrite + a11y blockers + env/runbook fixes)
+3. Round 2 backend hardening shipped (throttler + audit-chain reproducibility, both with tests)
+4. Round 3 endpoints shipped (signup + export + delete, all audit-emitting, all rate-limited)
+5. Round 4 daily-driver UX shipped (approvals queue + actor-on-row + page-header standardization)
+6. Round 5 #49 functional CI gate shipped (Community completeness asserted by tests, not grep)
+7. Round 5 observability shipped (pino + Sentry opt-in + request-id ALS)
+8. Round 6 runbooks shipped + restore drill executed once with measured RTO/RPO
+9. Round 7 Privacy + ToS + status page + SBOM + CTA instrumentation shipped
+10. v2 6-agent scan green-lights the closed-blocker delta
+
+Until 10/10 close, the staging URL stays internal and the homepage
+honesty band reads "early access — not yet open; sign up to be
+notified."
+
+## Open risks (acknowledged, not blocked on)
+
+1. **Outreach deferred** — day-30 metrics will likely be sparse-data
+   noise. Maintainer accepted this trade. Possible mitigations: HN
+   "Show HN" post on URL flip day; targeted outreach after Round 7.
+2. **Personal-page (vitormr.dev) Panorama copy still uses the
+   "AGPL + Enterprise" tag** — should update same day URL flips.
+   Owner action, not Panorama-repo change.
+3. **First reported LGPD Art. 18 data-subject access request** is a
+   trigger for lawyer-reviewed Privacy/ToS amendment per ADR-0014.
+   Plain-language v1 acceptable; the trigger is the escape hatch.
+4. **Bus factor of 1 (#50)** unchanged. Wave 0 runbooks are the
+   forcing function — frame each as "documentation for the second
+   maintainer who doesn't exist yet."
+5. **ADR-0020 implementation gates on a security-reviewer follow-up
+   pass** that hasn't been run yet. Round 3 cannot start until that
+   pass closes.
+
+## Numbers (pre-Round 1)
+
+- 6 agents convened in parallel; 1 round of scan; 4 maintainer
+  decisions; 4 ADRs drafted (3 Accepted + 1 Proposed)
+- v1 must-fix list expanded from 10 items to a 7-Round sequencing
+  reflecting the scan's surface-level corrections
+- Wave 0 scope expanded by ~2-3 days (Wave 0.5 self-serve OIDC
+  carve-out)
+- Wave A folded into Round 5 (#49 functional CI gate); Wave A's #48
+  (damage-flag → maintenance ticket) folded into Round 4 with
+  per-tenant `autoOpenMaintenanceFromInspection` UI toggle (closes
+  persona C8)

--- a/docs/en/early-access.md
+++ b/docs/en/early-access.md
@@ -1,0 +1,52 @@
+---
+title: Early access
+---
+
+# Early access — Panorama hosted preview
+
+The Panorama hosted preview is **not yet open**. We're working through
+the public-preview readiness checklist (Wave 0 in the
+[roadmap](/en/roadmap)) before the URL goes live.
+
+## When it opens
+
+The hosted preview will be **free, no SLA, data may be wiped with 30
+days notice** (operational commitments codified in
+[ADR-0014](/adr/0014-public-hosted-instance)). You'll be able to:
+
+- Sign up via Google or Microsoft OIDC (no password)
+- Provision your own tenant in one click
+- Bring real fleet or asset data and try the workflows
+- Export your data anytime
+- Delete your tenant anytime (7-day cool-off applies)
+- Talk to the maintainer weekly about what's broken — that's the deal
+
+## Until it opens
+
+- **Watch the repo** — [GitHub Releases](https://github.com/VitorMRodovalho/panorama/releases)
+  will publish the URL-flip release tag
+- **Public roadmap** — [`/en/roadmap`](/en/roadmap) tracks the Wave 0 path
+- **Email** —
+  [vitorodovalho@gmail.com](mailto:vitorodovalho@gmail.com?subject=Panorama%20hosted%20preview%20-%20notify%20me)
+  to follow along; we'll email you when the URL opens
+
+## Self-host alternative
+
+If you'd rather not wait, or you want your data on your own
+infrastructure: Panorama is AGPL-3.0 self-host-friendly. See the
+[self-hosting guide](/en/self-hosting). Same codebase, same features,
+your servers.
+
+## Why "preview" and not "beta"
+
+Different word, different meaning. "Beta" implies "feature-complete,
+hunting bugs." Panorama isn't there yet — the daily-driver UI surface
+is still being built, photo uploads still run synchronously, and the
+hosted instance is **the maintainer's instance** you're welcome to
+use, not a commercial offering. "Preview" describes what's true:
+you'll see something real, with rough edges, while the operator who
+ships it is genuinely available to talk about what's broken.
+
+Bring real data only if you also have a copy elsewhere. We'll be
+honest about what's stable enough to depend on as the surface
+matures.

--- a/docs/en/roadmap.md
+++ b/docs/en/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Target versions and tenant-visible milestones. Living document — last updated 2026-04-18.
+Target versions and tenant-visible milestones. Living document — last updated 2026-05-16.
 
 ## 0.1 — Scaffold (shipped 2026-04-17)
 
@@ -63,15 +63,26 @@ Target versions and tenant-visible milestones. Living document — last updated 
           0.3 (ADR-0009 §"Conflict detection" notes this).
 - [ ] **Step 5** — Snipe-IT API compatibility shim read-only
 
-## 0.3 — Inspections, maintenance, enterprise prep (target Sept 2026)
+## 0.3 — Inspections, maintenance, public-preview readiness (target Sept 2026)
 
 - [~] Configurable checklists (per asset type), photo evidence, EXIF strip
       — see [ADR-0012](../adr/0012-inspection-photo-pipeline.md). Backend
       and web UI feature-complete (steps 2–11). Canary rollout (step 13)
       remains — feature stays dark behind `FEATURE_INSPECTIONS=false`
-      until a pilot tenant validates. See
+      until the public preview opens and a design partner validates. See
       [`docs/en/inspections.md`](./inspections.md) for the operator brief.
-- [ ] Asset maintenances, Snipe-IT-compatible maintenance flow
+- [~] Asset maintenances, Snipe-IT-compatible maintenance flow
+      — see [ADR-0016](../adr/0016-asset-maintenance-flow.md).
+      Feature-complete for Community pending canary; backend + web UI
+      shipped across PRs #132 / #136 / #139 / #140. `FEATURE_MAINTENANCE`
+      ready to flip with first design partner. Enterprise email channel +
+      sister sweeps remain.
+- [~] **Wave 0 — public-preview readiness** (the gate on the hosted URL)
+      — see [`docs/audits/HANDOFF-2026-05-16-wave0-scan.md`](../audits/HANDOFF-2026-05-16-wave0-scan.md)
+      for the round-by-round plan + the 6-agent scan that produced it.
+      ADR-0014 (Public hosted instance), ADR-0018 (Observability), ADR-0019
+      (Worker boundary), ADR-0020 (Self-serve OIDC signup) all landed in
+      Round 0; backend hardening + endpoints + UX work follow.
 - [ ] Mileage + time-based alerts
 - [ ] CSV exports for every list view
 - [ ] Training-expiry gating
@@ -79,13 +90,17 @@ Target versions and tenant-visible milestones. Living document — last updated 
 - [ ] Just-in-time tenant membership based on `allowedEmailDomains` match
       at first OIDC login (gates the enterprise SCIM story)
 
-## 0.4 — Notifications + reports + webhooks (target Oct 2026)
+## 0.4 — Public preview live + notifications + reports (target Oct 2026)
 
+- [ ] Hosted preview URL opens publicly (Wave 0 acceptance closed)
+- [ ] First design partners onboarded via the seeded smoke-tenant pattern
+      — they ARE the canary (per ADR-0014 §A reasoning)
 - [ ] Event bus (NATS JetStream), outbox pattern, delivery retries
 - [ ] Email, Teams, Slack, webhook channels
 - [ ] Saved reports, schedule to email, CSV/XLSX/PDF render
-- [ ] First closed-beta customer live
-- [ ] `panorama-enterprise` private repo spun up; white-label + SOC-2 pack start
+- [ ] Day-60 metrics decision (per [ADR-0014 §3](../adr/0014-public-hosted-instance.md))
+      — go/no-go on paid SKU draft
+- [ ] `panorama-enterprise` private repo decision (gated on day-60 metrics signal)
 
 ## 1.0 GA (target: Q1 2027)
 

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -4,15 +4,20 @@ Esta carpeta contiene las versiones en español de la documentación de producto
 y arquitectura. El README del proyecto trilingüe está en
 [`../../README.es.md`](../../README.es.md).
 
-Documentos principales (las traducciones se añaden a medida que cada documento
-se estabiliza en inglés — los ADRs permanecen en inglés por regla, para evitar
-desincronización entre versiones):
+## Estado de las traducciones
 
-- [Arquitectura](./arquitectura.md) — en preparación (será traducción de `../en/architecture.md`)
-- [Matriz de funcionalidades](./matriz-de-funcionalidades.md) — en preparación
-- [Roadmap](./roadmap.md) — en preparación
-- [Licenciamiento](./licenciamiento.md) — en preparación
+La referencia canónica es la versión en inglés en [`../en/`](../en/). La
+traducción al español se añade a medida que cada documento se
+estabiliza en inglés. Los ADRs permanecen en inglés por regla, para
+evitar desincronización entre versiones.
 
-Mientras tanto, la referencia canónica es la versión en inglés en
-[`../en/`](../en/). Las contribuciones de traducción son muy bienvenidas —
-abrir un PR con `[docs][es]` en el título.
+**En preparación** (todavía no traducidos — siga la versión en inglés):
+
+- Arquitectura → [`../en/architecture.md`](../en/architecture.md)
+- Matriz de funcionalidades → [`../en/feature-matrix.md`](../en/feature-matrix.md)
+- Roadmap → [`../en/roadmap.md`](../en/roadmap.md)
+- Licenciamiento → [`../en/licensing.md`](../en/licensing.md)
+- Self-hosting → [`../en/self-hosting.md`](../en/self-hosting.md)
+
+Las contribuciones de traducción son muy bienvenidas — abrir un PR con
+`[docs][es]` en el título.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,30 +2,52 @@
 layout: home
 hero:
   name: Panorama
-  text: IT assets + operational fleet — in one pane of glass.
-  tagline: Unified open-source platform (AGPL-3.0). Trilingual (EN / PT-BR / ES). Self-hostable.
+  text: Run your IT assets and your operational fleet from one place.
+  tagline: Open source (AGPL-3.0). Trilingual EN / PT-BR / ES. Self-host it, or use the maintainer's hosted preview while we shape it with operators.
   actions:
     - theme: brand
-      text: Read the docs
-      link: /en/architecture
+      text: Get a hosted account
+      link: /en/early-access
     - theme: alt
-      text: View on GitHub
+      text: Self-host on GitHub
       link: https://github.com/VitorMRodovalho/panorama
-features:
-  - title: One system for both worlds
-    details: Absorbs Snipe-IT's IT asset management AND SnipeScheduler-FleetManager's advance booking, inspection, and fleet-partition features. No more two systems to operate.
-  - title: Trilingual from day one
-    details: EN / PT-BR / ES shipping out of the box. Every user-facing string is in the i18n bundle — CI blocks PRs that hardcode English.
-  - title: Multi-tenant by construction
-    details: Prisma middleware + Postgres Row-Level Security enforce company/tenant isolation in two independent layers. Forgetting a filter is impossible.
-  - title: Community + Enterprise
-    details: Everything needed to run is in the AGPL Community edition. Enterprise is strictly additive — no feature gating on the flows that matter.
 ---
 
-> Status — **pre-alpha**. See the [roadmap](/en/roadmap) and [architecture](/en/architecture).
+> **Early access** — real product, rough edges, weekly contact with the team. Bring real fleet data, expect rough edges, talk to us weekly.
+
+## What works today
+
+- **Multi-tenant isolation** — your data is yours, enforced at the DB layer (Postgres Row-Level Security + Prisma middleware, two independent layers)
+- **Vehicle / equipment booking** with conflict checks, approvals, blackouts, basket-style multi-asset requests
+- **Check-in / check-out flow** with mileage tracking + damage flagging
+- **Photo inspections** — configurable checklists, EXIF strip, photo evidence (gated behind a flag we'll turn on with you)
+- **OIDC login** — Google + Microsoft, end-to-end tested
+- **CSV export** from every list view; full audit trail per record
+- **Trilingual UI** — EN / PT-BR / ES, every user-facing string in i18n bundles (CI blocks PRs that hardcode English)
+
+## What's rough
+
+- No admin UI for inviting users yet — email and we'll add your team
+- Calendar UI is functional, not pretty
+- Asset add / edit screens land in the next 30 days
+- We back up nightly; no point-in-time recovery yet — don't store the only copy of irreplaceable data here
+- We may need to wipe and recreate the database during this preview — 30 days notice if so
+- Photo uploads run synchronously today; under heavy load the request thread is busy
+- Weekly contact: we want to hear what's broken; that's the deal
+
+## Two journeys, one repo
+
+**Hosted preview** — the maintainer runs a Panorama instance you can try for free. No SLA. Data may be wiped with 30 days notice (per [ADR-0014](/adr/0014-public-hosted-instance)). Great for evaluating, not for storing irreplaceable data yet.
+
+**Self-host** — AGPL-3.0 fork-friendly. See the [self-hosting guide](/en/self-hosting), the [feature matrix](/en/feature-matrix), and the [migration-from-Snipe-IT path](/en/migration-from-snipeit). The codebase deployed on the hosted preview is identical to what you'd self-host.
+
+## Trust
+
+- [Public roadmap](/en/roadmap) — what's coming, what's deferred
+- [Architecture decisions](/adr/0000-index) — every load-bearing choice with reasoning
+- [Security contact](mailto:security@vitormr.dev) — disclosure policy at [SECURITY.md](https://github.com/VitorMRodovalho/panorama/blob/main/SECURITY.md)
+- [Open issues](https://github.com/VitorMRodovalho/panorama/issues) — public bug tracker
 
 ## Language
 
-- 🇬🇧 [English](/en/)
-- 🇧🇷 [Português (Brasil)](/pt-br/)
-- 🇪🇸 [Español](/es/)
+EN · [PT-BR](/pt-br/) · [ES](/es/)

--- a/docs/pt-br/README.md
+++ b/docs/pt-br/README.md
@@ -4,15 +4,20 @@ Esta pasta guarda as versões em português-BR da documentação de produto e
 arquitetura. O README de projeto trilíngue fica em
 [`../../README.pt-br.md`](../../README.pt-br.md).
 
-Documentos principais (traduções são adicionadas conforme cada doc fica
-estável em inglês — os ADRs permanecem em inglês por regra, para evitar
-drift entre versões):
+## Status das traduções
 
-- [Arquitetura](./arquitetura.md) — em redação (será tradução de `../en/architecture.md`)
-- [Matriz de funcionalidades](./matriz-de-funcionalidades.md) — em redação
-- [Roadmap](./roadmap.md) — em redação
-- [Licenciamento](./licenciamento.md) — em redação
+A referência canônica é o equivalente em inglês em [`../en/`](../en/). A
+tradução para PT-BR está sendo adicionada conforme cada doc estabiliza
+em inglês. Os ADRs permanecem em inglês por regra, para evitar drift
+entre versões.
 
-Enquanto a tradução não chega, a referência canônica é o equivalente em
-inglês em [`../en/`](../en/). Contribuições de tradução são muito bem-vindas —
-abra PR com `[docs][pt-br]` no título.
+**Em preparação** (ainda não traduzidos — siga o equivalente em inglês):
+
+- Arquitetura → [`../en/architecture.md`](../en/architecture.md)
+- Matriz de funcionalidades → [`../en/feature-matrix.md`](../en/feature-matrix.md)
+- Roadmap → [`../en/roadmap.md`](../en/roadmap.md)
+- Licenciamento → [`../en/licensing.md`](../en/licensing.md)
+- Self-hosting → [`../en/self-hosting.md`](../en/self-hosting.md)
+
+Contribuições de tradução são muito bem-vindas — abra PR com
+`[docs][pt-br]` no título.

--- a/docs/runbooks/secrets-inventory.md
+++ b/docs/runbooks/secrets-inventory.md
@@ -1,0 +1,230 @@
+# Secrets inventory
+
+Authoritative list of every secret (credential, key, password, or
+URL containing one) Panorama depends on, grouped by rotation
+procedure. The actual rotation runbook is at
+[`./secrets-rotation.md`](./secrets-rotation.md) (TBD as part of
+Wave 0 Round 6); this file is the source-of-truth of what exists,
+where it lives, and who can rotate it.
+
+**Updated 2026-05-16** as part of Wave 0 Round 1 (per tech-lead's C1
+scan finding: 35+ `process.env.*` accesses in core-api + ~8
+duplicates in apps/web). Cross-reference to
+[`HANDOFF-2026-05-16-wave0-scan.md`](../audits/HANDOFF-2026-05-16-wave0-scan.md).
+
+## Database credentials (Supabase managed Postgres)
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `DATABASE_URL` | `apps/core-api/.env*`, Fly secrets | **Secret** — contains role + password | Pooler (port 6543); runtime app traffic |
+| `DATABASE_DIRECT_URL` | same | **Secret** | Direct (port 5432); `prisma migrate deploy` |
+| `DATABASE_PRIVILEGED_URL` | same | **Secret** | Direct (port 5432); rls.sql + bootstrap |
+| `DATABASE_APP_ROLE` | bootstrap, `apply-migrations.sh` env | Non-secret (role name) | Default `panorama_app` |
+| `DATABASE_APP_PASSWORD` | bootstrap, env | **Secret** — raw password | Set by `setup-staging-env.sh`; rotated independently of pooler password |
+
+**Rotation procedure (per ADR-0015 + 0013 architecture):**
+
+1. Rotate Supabase pooler password via Supabase dashboard → Project
+   Settings → Database
+2. Re-run `scripts/setup-staging-env.sh` locally to regenerate
+   `apps/core-api/.env.staging` with the new pooler URL
+3. `fly secrets set --app panorama-staging DATABASE_URL=...
+   DATABASE_DIRECT_URL=... DATABASE_PRIVILEGED_URL=...`
+4. Rolling deploy: `fly deploy --strategy rolling`
+5. Verify `/health` returns OK after each instance comes up
+6. The `panorama_app` role password rotates separately via
+   `ALTER ROLE panorama_app WITH PASSWORD 'new'` from a privileged
+   psql session; `DATABASE_APP_PASSWORD` env var updated to match
+7. **Rollback**: revert the `fly secrets set` to the previous values
+
+## Session crypto
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `SESSION_SECRET` | `apps/core-api/.env*`, Fly secrets | **Secret** — 32+ byte random | Iron-session encryption key |
+
+**Rotation procedure (current state, Wave 0 Round 5 will improve):**
+
+Today, rotation invalidates all sessions because `auth.config.ts:64`
+accepts a single secret. Procedure:
+
+1. Generate new value: `node -e 'console.log(require("crypto").randomBytes(32).toString("base64url"))'`
+2. `fly secrets set --app panorama-staging SESSION_SECRET="$NEW"`
+3. Rolling deploy
+4. All users logged out — communicate the window ahead of time
+
+**Wave 0 Round 5 enhancement (per maintainer decision 2026-05-16):**
+Add secondary-key support via iron-session array config. Rotation
+becomes a two-phase procedure:
+
+1. Register new secret as **secondary** (kept as fallback for
+   in-flight session cookies)
+2. Deploy → existing sessions still decrypt via secondary; new
+   sessions encrypt with primary
+3. After `SESSION_MAX_AGE_SECONDS` elapses (default ~30 days), drop
+   the old secret entirely
+4. Net result: zero-downtime rotation
+
+## OIDC client secrets
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `OIDC_GOOGLE_CLIENT_ID` | env, Fly secrets | Non-secret (public ID) | |
+| `OIDC_GOOGLE_CLIENT_SECRET` | env, Fly secrets | **Secret** | |
+| `OIDC_MICROSOFT_CLIENT_ID` | env, Fly secrets | Non-secret | |
+| `OIDC_MICROSOFT_CLIENT_SECRET` | env, Fly secrets | **Secret** | |
+
+**Rotation procedure (per provider):**
+
+Rotation is **IdP-driven** — Google or Microsoft generates a new
+secret in their respective consoles. Our procedure:
+
+1. In Google Cloud Console → OAuth 2.0 → rotate client secret (or
+   Azure → App registrations → certificates and secrets → new
+   secret)
+2. IdP provides the new secret (visible once; capture immediately)
+3. `fly secrets set --app panorama-staging OIDC_GOOGLE_CLIENT_SECRET=...`
+4. Rolling deploy
+5. In the IdP console, revoke the old secret after the rolling
+   deploy completes (both secrets may be active during the window
+   if the IdP supports it; check provider docs)
+6. **Rollback**: re-set the prior secret in fly + IdP
+
+## S3-compatible object storage (Cloudflare R2 in staging)
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `S3_ENDPOINT` | env, Fly secrets | Non-secret (URL) | |
+| `S3_REGION` | env, Fly secrets | Non-secret | |
+| `S3_BUCKET_PHOTOS` | env, Fly secrets | Non-secret | |
+| `S3_ACCESS_KEY` | env, Fly secrets | **Secret** | |
+| `S3_SECRET_KEY` | env, Fly secrets | **Secret** | |
+| `S3_FORCE_PATH_STYLE` | env, Fly secrets | Non-secret (boolean) | |
+| `S3_ALLOW_PRIVATE_ENDPOINT` | env, Fly secrets | Non-secret (boolean) | |
+
+**Rotation procedure:**
+
+1. In Cloudflare R2 dashboard → API Tokens → create new R2 token →
+   capture new access + secret pair
+2. `fly secrets set --app panorama-staging S3_ACCESS_KEY=... S3_SECRET_KEY=...`
+3. Rolling deploy
+4. Revoke the old token in the R2 dashboard after rolling deploy
+5. **Validation**: upload a test photo via the staging app; check
+   it lands in R2 + can be served back
+
+## SMTP
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `SMTP_HOST` | env, Fly secrets | Non-secret | |
+| `SMTP_PORT` | env, Fly secrets | Non-secret | |
+| `SMTP_SECURE` | env, Fly secrets | Non-secret (boolean) | |
+| `SMTP_USER` | env, Fly secrets | **Secret-ish** — may be a real email or API key on managed services | |
+| `SMTP_PASSWORD` | env, Fly secrets | **Secret** | |
+| `MAIL_FROM` | env, Fly secrets | Non-secret | |
+| `MAIL_FROM_NAME` | env, Fly secrets | Non-secret | |
+
+**Rotation procedure (depends on provider):**
+
+For SES / SendGrid / Postmark / etc.: rotate via the provider's API
+token rotation UI; capture new credentials. Then:
+
+1. `fly secrets set --app panorama-staging SMTP_USER=... SMTP_PASSWORD=...`
+2. Rolling deploy
+3. Revoke old credentials in provider console
+4. **Validation**: trigger a test invitation email; verify SPF /
+   DKIM still pass
+
+## Redis (Upstash in staging)
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `REDIS_URL` | env, Fly secrets | **Secret** — `rediss://default:password@endpoint:6379` | Token embedded in URL |
+
+**Rotation procedure:**
+
+1. In Upstash dashboard → reset token (generates new connection URL)
+2. `fly secrets set --app panorama-staging REDIS_URL=...`
+3. Rolling deploy
+4. Old token is automatically invalidated when the new one is
+   created
+
+**Note:** During the rotation window, BullMQ workers will see auth
+errors briefly. This is expected; the rolling deploy resolves it
+within the deploy window.
+
+## Sentry (future — per ADR-0018)
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `SENTRY_DSN` | env, Fly secrets | **Quasi-secret** — exposes Sentry project | Unset = Sentry no-op (per ADR-0018) |
+
+**Rotation procedure:**
+
+DSN rotation is tied to Sentry project recreation. If the DSN
+leaks, the threat is event-injection (someone sending fake errors
+to your project), not data exfiltration. Procedure:
+
+1. In Sentry → Project Settings → Client Keys → create new DSN
+2. `fly secrets set --app panorama-staging SENTRY_DSN=...`
+3. Rolling deploy
+4. Revoke old DSN in Sentry
+
+## CAPTCHA (future — per ADR-0020)
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `CAPTCHA_SITE_KEY` | env, web build | Non-secret (public) | hCaptcha or Turnstile |
+| `CAPTCHA_SECRET` | env, Fly secrets | **Secret** — server-side verification | |
+
+Rotation procedure TBD when ADR-0020's signup endpoint lands in
+Round 3.
+
+## Seed credentials (devops only)
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `SEED_OWNER_PASSWORD` | local env only | **Secret** | Used by `smoke-staging-seed.ts` for fixture provisioning; never set in production |
+| `SEED_OWNER_PASSWORD_FILE` | local env only | Path to file | Alternative to inline password |
+
+These are dev-only and never live on Fly. Rotation = "regenerate
+the smoke tenant when you need to."
+
+## Non-secret config (documented for completeness)
+
+These are environment variables that affect behavior but are not
+credentials. Listed so the inventory is complete + future ops can
+quickly identify what's safe to log.
+
+- `APP_BASE_URL`, `APP_VERSION`, `CORE_API_URL`, `WEB_ORIGIN`
+- `NODE_ENV`, `PORT`
+- `ALLOW_STAGING_SEED`, `FEATURE_INSPECTIONS`, `FEATURE_MAINTENANCE`,
+  `FEATURE_SELF_SERVE_SIGNUP` (future per ADR-0020)
+- `OIDC_GOOGLE_HOSTED_DOMAIN`, `OIDC_GOOGLE_ISSUER`,
+  `OIDC_GOOGLE_TRUSTED_HD_DOMAINS`, `OIDC_MICROSOFT_TENANT`,
+  `OIDC_ALLOW_INSECURE_ISSUER`
+- `OAUTH_STATE_COOKIE_NAME`, `SESSION_COOKIE_NAME`,
+  `SESSION_MAX_AGE_SECONDS`
+- `INVITE_RATE_ADMIN_HOUR`, `INVITE_RATE_TENANT_DAY`
+
+## Total count
+
+- **Secrets requiring rotation procedure:** 14 (Database ×5,
+  Session ×1, OIDC ×2, S3 ×2, SMTP ×2, Redis ×1, SEED ×1)
+- **Future secrets pending ADR implementation:** 2 (Sentry DSN,
+  CAPTCHA secret)
+- **Non-secret env vars:** ~18 (listed above)
+
+## Maintainer accountability
+
+Today, the maintainer is the sole rotater for all of the above
+(bus factor of 1 per [issue #50](https://github.com/VitorMRodovalho/panorama/issues/50)).
+This runbook is the foundation of "documentation for the second
+maintainer who doesn't exist yet" (per
+[HANDOFF-2026-05-16-wave0-scan.md](../audits/HANDOFF-2026-05-16-wave0-scan.md)
+§"Open risks").
+
+Update this file when:
+- New secret added (e.g., a new IdP, a new managed service)
+- Rotation procedure changes (e.g., provider UI redesign)
+- Sensitivity classification changes

--- a/docs/runbooks/setup-supabase-staging.md
+++ b/docs/runbooks/setup-supabase-staging.md
@@ -169,7 +169,14 @@ Outside Supabase, create the Fly app pointing at the URLs from step 1:
 ```bash
 flyctl apps create panorama-staging --org personal
 flyctl secrets set --app panorama-staging \
-  DATABASE_URL="postgres://postgres:...@aws-0-us-east-1.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1&sslmode=require" \
+  DATABASE_URL="postgres://postgres:...@aws-0-us-east-1.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=10&sslmode=require" \
+  # connection_limit=10 — per Prisma client × 2 clients (app + privileged
+  # per ADR-0015) × Fly instances ≤ 100 to leave headroom under Supabase
+  # Pro pooler's 200 client-conn cap. Public-preview budget assumes ≤2
+  # Fly instances + 50 active tenants × 5 concurrent users × ~0.04 active
+  # fraction = ~10 in-flight × 2 clients = 20 client conns per instance.
+  # If you ever scale beyond 4 instances, lower this or request the
+  # Supabase pooler cap bump first.
   DATABASE_PRIVILEGED_URL="postgres://postgres:...@db.<project-ref>.supabase.co:5432/postgres?sslmode=require" \
   DATABASE_DIRECT_URL="postgres://postgres:...@db.<project-ref>.supabase.co:5432/postgres?sslmode=require" \
   REDIS_URL="rediss://default:...@<upstash-endpoint>:6379" \


### PR DESCRIPTION
## Summary

Closes the **security-reviewer B1 blocker** from the 2026-05-16 6-agent Wave 0 scan — `ThrottlerModule.forRoot` was configured but `ThrottlerGuard` was never registered as `APP_GUARD`, making the documented \`auth: 10/min\` cap fictional. Credential-stuffing against the public preview would have been free.

**Stacks on #200** (Round 1 docs + a11y). GitHub will update base to main once #200 merges.

## Changes

### Throttler wiring
- **`apps/core-api/src/app.module.ts`** — added `upload` named throttler (matches pre-existing `@Throttle` decorator on inspection-photo controller, which was dead metadata); registered `{ provide: APP_GUARD, useClass: ThrottlerGuard }` global provider
- **`apps/core-api/src/main.ts`** — typed app as `NestExpressApplication`; added `app.set('trust proxy', 1)` so `req.ip` resolves from `X-Forwarded-For[0]` instead of LB IP (without this, every request behind Fly's edge shares one bucket — fail-united)

### `@Throttle` decorators (auth bucket: 10/min)
- `POST /auth/login` — anti credential-stuffing
- `GET /auth/oidc/:provider/callback` — anti IdP response replay flood
- `POST /invitations/accept` — anti token-burning flood

### Synthetic flood test
- **`apps/core-api/test/login-flood.e2e.test.ts` new** — 15 POSTs to `/auth/login` from one IP, asserts at least 3 return 429. Test would silently pass (all 401s) if `APP_GUARD` weren't wired — so this is also the regression bar for future changes.

## What's NOT in this PR (intentional)

- **Per-tenant throttler tracker** (security-reviewer + tech-lead C5) — ships as Cluster 2A.2 in a separate PR per tech-lead's two-PR split recommendation: \"The first PR exposes any 429 regressions in the test suite before tenant-keying complicates the picture.\"
- **Audit-chain reproducibility** (security-reviewer B2 + data-architect Blocker 3) — Cluster 2B, separate PR

## Test plan

- [ ] `pnpm --filter @panorama/core-api typecheck` — passes (confirmed locally)
- [ ] `pnpm --filter @panorama/core-api test login-flood` — flood test passes (requires local Postgres at localhost:5432 + `panorama` DB)
- [ ] Visual: hit `POST /auth/login` repeatedly via curl from one IP, observe 429 from attempt 11+
- [ ] Confirm `X-Forwarded-For` header is honored (set via `curl -H 'X-Forwarded-For: 1.2.3.4'` to use a different bucket)
- [ ] Verify other existing e2e tests still pass (existing tests use ~5-10 fetch() calls per test, well under the 10/min cap; only login-flood and any future bulk-auth test should exhaust the bucket)
- [ ] CI: lint + typecheck + unit tests + community-flows-without-Enterprise all green

Next: Cluster 2A.2 (per-tenant tracker via `getTracker(req)` subclass reading `currentTenantId()` from ALS) + Cluster 2B (audit-chain reproducibility — `digestPreImage BYTEA` column + `pg_advisory_xact_lock` + verifier CLI).

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>