### PR TITLE
feat(auth): Round 2A.2 — per-tenant throttler tracker

### DIFF
--- a/apps/core-api/src/app.module.ts
+++ b/apps/core-api/src/app.module.ts
@@ -1,7 +1,8 @@
 import { Module, type DynamicModule } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
-import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
+import { ThrottlerModule } from '@nestjs/throttler';
+import { PerTenantThrottlerGuard } from './shared/throttler/per-tenant-throttler.guard.js';
 import { PrismaModule } from './modules/prisma/prisma.module.js';
 import { TenantModule } from './modules/tenant/tenant.module.js';
 import { AssetModule } from './modules/asset/asset.module.js';
@@ -117,13 +118,14 @@ const conditionalMaintenance: DynamicModule[] = maintenanceEnabled()
     // 0.2: PluginHostModule, I18nModule.forRootAsync.
   ],
   providers: [
-    // ThrottlerGuard wired as a global APP_GUARD — without this, the
-    // ThrottlerModule.forRoot config is dead metadata. Wave 0 Round 2
-    // (ADR-0014 prerequisite): the synthetic-flood test in
-    // test/login-flood.e2e.test.ts exercises the auth bucket. The
+    // PerTenantThrottlerGuard wired as a global APP_GUARD — without
+    // this, the ThrottlerModule.forRoot config is dead metadata. The
+    // subclass overrides getTracker(req) to key by `${tenantId}:${ip}`
+    // (authenticated routes) or just `${ip}` (anonymous routes). The
     // bypass for non-flood tests is handled by skipIf in the module
-    // config above, not at provider registration.
-    { provide: APP_GUARD, useClass: ThrottlerGuard },
+    // config above, not at provider registration. Wave 0 Round 2: see
+    // test/login-flood.e2e.test.ts.
+    { provide: APP_GUARD, useClass: PerTenantThrottlerGuard },
   ],
 })
 export class AppModule {}

--- a/apps/core-api/src/shared/throttler/per-tenant-throttler.guard.ts
+++ b/apps/core-api/src/shared/throttler/per-tenant-throttler.guard.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+import type { Request } from 'express';
+import { currentTenantId } from '../../modules/tenant/tenant.context.js';
+
+/**
+ * Per-tenant rate-limiting guard (Wave 0 Round 2A.2 per
+ * HANDOFF-2026-05-16-wave0-scan.md — tech-lead C5 + security-reviewer
+ * B1 follow-up).
+ *
+ * Overrides the default IP-only key with `${tenantId}:${ip}`. Reasoning:
+ *
+ * - Authenticated routes get bucketed PER TENANT + PER IP. One tenant
+ *   under load doesn't starve other tenants behind the same egress IP
+ *   (e.g., shared corporate NAT).
+ * - Anonymous routes (login, OIDC callback, invitation accept) have no
+ *   tenant in the ALS context, so they fall back to IP-only — same as
+ *   the default ThrottlerGuard. That's the correct shape: pre-auth
+ *   abuse can only be tracked by IP.
+ * - The ALS context is populated by SessionMiddleware before guards
+ *   run, so `currentTenantId()` is the authoritative tenant on every
+ *   authenticated request.
+ *
+ * The fall-back to `'unknown'` for missing IP is defensive — Fly's
+ * edge always populates X-Forwarded-For, but a misconfigured proxy
+ * could theoretically strip it. `'unknown'` is the shared bucket for
+ * all such mis-shaped requests, which is the conservative choice.
+ */
+@Injectable()
+export class PerTenantThrottlerGuard extends ThrottlerGuard {
+  protected override async getTracker(req: Request): Promise<string> {
+    const tenantId = currentTenantId();
+    const ip = req.ip ?? 'unknown';
+    return tenantId ? `${tenantId}:${ip}` : ip;
+  }
+}


### PR DESCRIPTION
**Reopened from closed #202** (auto-closed when its base branch merged). Rebased onto current main; merge conflict in `app.module.ts` resolved by keeping the per-tenant guard registration with an updated comment that mentions both the per-tenant tracking and the skipIf-based test bypass.

## Summary

Closes the **security-reviewer B1 follow-up + tech-lead C5** from the 2026-05-16 Wave 0 scan. Per-tenant rate-limit isolation: one noisy tenant behind shared corporate NAT no longer starves other tenants on the same egress IP.

## Changes
- `apps/core-api/src/shared/throttler/per-tenant-throttler.guard.ts` new — subclasses `ThrottlerGuard`; overrides `getTracker(req)` to key by `\${tenantId}:\${ip}` (auth) or `\${ip}` (anon). Reads tenant from existing `TenantContext` ALS via `currentTenantId()`.
- `apps/core-api/src/app.module.ts` — replaced default `ThrottlerGuard` with `PerTenantThrottlerGuard` as `APP_GUARD`. The `skipIf` bypass from #204 stays intact (handles test bypass at request time, not at provider registration).

## Abstraction shape (per tech-lead C5)
- ✅ Guard subclass with `getTracker` override — ~20 LoC in `shared/`
- ❌ `@PerTenant()` decorator — \"knob for one caller\"
- ❌ Decorator-driven config

## Test plan
- [ ] `pnpm --filter @panorama/core-api typecheck` — passes (confirmed locally)
- [ ] login-flood.e2e from #204 still passes (anonymous fallback to IP-only)
- [ ] CI: all green

Next: Cluster 2B (audit-chain reproducibility) — separate PR with migration + verifier CLI.

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>