### PR TITLE
feat(audit): Round 2B — chain reproducibility + global lock + tenant-immutable

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,9 +63,25 @@ Panorama ships with sane defaults (see `apps/core-api/src/config/security.ts`):
   knob to disable the gate entirely — that is intentional.
 - All outbound fetches disable follow-redirects unless the caller opts in
 - Rate limiting on auth endpoints (configurable per-tenant)
-- Audit log appended to every write operation (tamper-evident hash chain)
-  _(NOTE: audit-flagged that the notification tamper trigger breaks the chain —
-  see issue [#41](https://github.com/VitorMRodovalho/panorama/issues/41))_
+- Audit log appended to every write operation, with per-row reproducible
+  digests. Migration 0021 persists the canonical pre-image alongside each
+  row's `selfHash`, so an operator-run verifier can recompute
+  `sha256(prevHash || digestPreImage)` byte-for-byte from the stored columns
+  and assert it equals `selfHash` — tamper of any logical column (action,
+  resourceType, resourceId, tenantId, actorUserId, metadata, occurredAt)
+  after write is caught. The SECURITY DEFINER triggers (notification
+  status-tamper, PAT resurrection) and the TypeScript writer all take a
+  global advisory lock (`pg_advisory_xact_lock(hashtext('audit:global'))`)
+  before reading the chain head, eliminating the chain-fork race surfaced in
+  issue [#41](https://github.com/VitorMRodovalho/panorama/issues/41). The
+  notification trigger also fires on `tenantId` column changes (not just
+  status) and raises `tenantId_immutable_post_create` to block cross-tenant
+  retargeting. Verifier: `pnpm --filter @panorama/core-api chain-verify`
+  (runbook:
+  [`docs/runbooks/verify-audit-chain.md`](./docs/runbooks/verify-audit-chain.md)).
+  Out of scope for the per-row check: `ipAddress` / `userAgent` are stored
+  but not hashed (observational metadata); multi-strand prev-link verification
+  is documented in the runbook as a separate future workstream.
 
 ## Audit trail
 

--- a/apps/core-api/package.json
+++ b/apps/core-api/package.json
@@ -17,7 +17,8 @@
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:deploy": "prisma migrate deploy",
-    "prisma:seed": "tsx prisma/seed.ts"
+    "prisma:seed": "tsx prisma/seed.ts",
+    "chain-verify": "tsx src/scripts/verify-audit-chain.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1045.0",

--- a/apps/core-api/prisma/migrations/20260516180117_0021_audit_digest_preimage_chain_lock/ROLLBACK.md
+++ b/apps/core-api/prisma/migrations/20260516180117_0021_audit_digest_preimage_chain_lock/ROLLBACK.md
@@ -1,0 +1,269 @@
+# Rollback — 0021 audit digest pre-image + chain lock + tenant-immutable
+
+## Pre-flight (operator MUST verify BEFORE running)
+
+This migration closes three intertwined defects (see `migration.sql`
+header). Rollback re-opens all three at once:
+
+- D1: per-row digest becomes unreproducible from columns (JSONB
+  recanonicalisation race)
+- D2: chain-head SELECT can fork under concurrent same-strand writers
+- D3: tenant-immutable invariant on `notification_events` and
+  `personal_access_tokens` UPDATEs is gone
+
+Only roll back if the chain-verify CLI regresses against the
+post-0021 digest format AND the regression cannot be patched in the
+verifier itself.
+
+## SQL revert (privileged role)
+
+Run from a psql session against `$DATABASE_PRIVILEGED_URL`.
+
+```sql
+-- 5. Cutover marker — leave in place. The marker is an audit row
+--    documenting that the fix WAS applied. Deleting it would break
+--    the chain (rows written after the marker have prevHash
+--    pointing to it).
+--
+--    The chain-verify CLI treats the marker as a historical
+--    waypoint regardless of whether the fix is still in force.
+
+-- 4. Restore the 0011 notification trigger DDL (column fire-list).
+--    Migration 0021 extended the trigger to
+--      AFTER UPDATE OF "status", "tenantId" ON "notification_events"
+--    so the tenant-immutable RAISE could intercept tenantId-only
+--    UPDATEs. Reverting restores the 0011 status-only fire-list:
+DROP TRIGGER IF EXISTS emit_notification_tamper_audit_trigger
+    ON "notification_events";
+CREATE TRIGGER emit_notification_tamper_audit_trigger
+    AFTER UPDATE OF "status" ON "notification_events"
+    FOR EACH ROW EXECUTE FUNCTION emit_notification_tamper_audit();
+
+-- 3 + 2. Restore the pre-0021 trigger function bodies (from
+--    migration 0020). Don't `\i` the whole 0020 file — that would
+--    re-fire 0020's DO $$ block and emit a spurious second
+--    `panorama.audit.chain_repair` marker, polluting the audit
+--    provenance trail with a second "0020 was applied" claim.
+--    Inline the two CREATE OR REPLACE FUNCTION blocks instead.
+--    The function bodies below are byte-identical to the post-0020
+--    versions; see migration 0020's `migration.sql` for the source
+--    of truth.
+
+CREATE OR REPLACE FUNCTION emit_notification_tamper_audit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $rollback$
+DECLARE
+    occurred      timestamptz := date_trunc('milliseconds', now());
+    payload_text  text;
+    payload_bytes bytea;
+    prev_hash     bytea;
+    self_hash     bytea;
+BEGIN
+    IF NOT (
+        (OLD."status" = 'PENDING'     AND NEW."status" = 'DISPATCHED') OR
+        (OLD."status" = 'DEAD')                                        OR
+        (OLD."status" = 'DISPATCHED'  AND NEW."status" <> 'DISPATCHED')
+    ) THEN
+        RETURN NEW;
+    END IF;
+    SELECT "selfHash" INTO prev_hash FROM audit_events
+        ORDER BY id DESC LIMIT 1;
+    payload_text := json_build_object(
+        'action',       'panorama.notification.status_tampered',
+        'resourceType', 'notification_event',
+        'resourceId',   NEW.id::text,
+        'tenantId',     NEW."tenantId"::text,
+        'actorUserId',  NULL,
+        'metadata',     json_build_object(
+                            'fromStatus', OLD."status"::text,
+                            'toStatus',   NEW."status"::text,
+                            'eventType',  NEW."eventType"
+                        ),
+        'occurredAt',   to_char(occurred AT TIME ZONE 'UTC',
+                                'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    )::text;
+    payload_bytes := convert_to(payload_text, 'UTF8');
+    IF prev_hash IS NOT NULL THEN
+        self_hash := digest(prev_hash || payload_bytes, 'sha256');
+    ELSE
+        self_hash := digest(payload_bytes, 'sha256');
+    END IF;
+    INSERT INTO audit_events (
+        "tenantId", "actorUserId", action, "resourceType", "resourceId",
+        metadata, "occurredAt", "prevHash", "selfHash"
+    ) VALUES (
+        NEW."tenantId", NULL,
+        'panorama.notification.status_tampered', 'notification_event',
+        NEW.id::text,
+        json_build_object(
+            'fromStatus', OLD."status"::text,
+            'toStatus',   NEW."status"::text,
+            'eventType',  NEW."eventType"
+        ),
+        occurred, prev_hash, self_hash
+    );
+    RETURN NEW;
+END;
+$rollback$;
+
+CREATE OR REPLACE FUNCTION emit_pat_resurrected_audit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $rollback$
+DECLARE
+    prev_hash     bytea;
+    occurred      timestamptz := date_trunc('milliseconds', now());
+    payload_text  text;
+    payload_bytes bytea;
+    self_hash     bytea;
+BEGIN
+    IF TG_OP <> 'UPDATE' THEN
+        RETURN NEW;
+    END IF;
+    IF OLD."revokedAt" IS NULL OR NEW."revokedAt" IS NOT NULL THEN
+        RETURN NEW;
+    END IF;
+    SELECT "selfHash" INTO prev_hash FROM audit_events
+        ORDER BY id DESC LIMIT 1;
+    payload_text := json_build_object(
+        'action',       'panorama.pat.resurrected',
+        'resourceType', 'personal_access_token',
+        'resourceId',   NEW.id::text,
+        'tenantId',     NEW."tenantId"::text,
+        'actorUserId',  NULL,
+        'metadata',     json_build_object(
+                            'tokenId',     NEW.id::text,
+                            'tokenPrefix', NEW."tokenPrefix",
+                            'userId',      NEW."userId"::text,
+                            'previousRevokedAt', to_char(OLD."revokedAt" AT TIME ZONE 'UTC',
+                                                         'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+                        ),
+        'occurredAt',   to_char(occurred AT TIME ZONE 'UTC',
+                                'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    )::text;
+    payload_bytes := convert_to(payload_text, 'UTF8');
+    IF prev_hash IS NOT NULL THEN
+        self_hash := digest(prev_hash || payload_bytes, 'sha256');
+    ELSE
+        self_hash := digest(payload_bytes, 'sha256');
+    END IF;
+    INSERT INTO audit_events (
+        "tenantId", "actorUserId", action, "resourceType", "resourceId",
+        metadata, "occurredAt", "prevHash", "selfHash"
+    ) VALUES (
+        NEW."tenantId", NULL,
+        'panorama.pat.resurrected', 'personal_access_token',
+        NEW.id::text,
+        json_build_object(
+            'tokenId',     NEW.id::text,
+            'tokenPrefix', NEW."tokenPrefix",
+            'userId',      NEW."userId"::text,
+            'previousRevokedAt', to_char(OLD."revokedAt" AT TIME ZONE 'UTC',
+                                         'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+        ),
+        occurred, prev_hash, self_hash
+    );
+    RETURN NEW;
+END;
+$rollback$;
+
+-- 1. Drop the canonical pre-image column.
+--    Pre-0021 rows have digestPreImage IS NULL already; only the
+--    rows written between 0021 apply and rollback carry data.
+--    Those bytes are recoverable by re-deriving the JSON pre-image
+--    from columns (only possible IF the metadata canonicalisation
+--    arm D1 happens to not have triggered for the row). Don't
+--    rely on this — assume the column data is gone.
+ALTER TABLE "audit_events"
+    DROP COLUMN "digestPreImage";
+```
+
+## Data-loss warnings
+
+- **Cutover marker is preserved.** The `panorama.audit.chain_repair`
+  row with `metadata->>'migration' = '0021'` stays. Rows written
+  after the marker continue to chain through it. The verifier sees
+  the marker on each side of a rollback as a "format change point"
+  with two adjacent cutover markers (0020 → 0021 → 0020-replayed).
+- **digestPreImage bytes are dropped.** Rows written DURING the
+  window 0021 was applied lose their pre-image. They remain
+  internally consistent (the trigger and the verifier-of-the-time
+  saw the same canonical text), but verifier tooling without the
+  pre-image must fall back to "trust selfHash, cannot recompute."
+- **Tenant-immutable RAISE goes away.** A pre-existing in-flight
+  UPDATE that would have errored under 0021 will succeed under the
+  rolled-back trigger.
+- **Global advisory lock goes away.** Concurrent writers can again
+  fork the chain via the priorTail race documented in
+  migration.sql header §D2.
+
+## When you would actually revert
+
+- chain-verify CLI cannot understand the post-0021 digest format
+  even after a verifier patch. The pre-image format is intentionally
+  the minimal viable surface (canonical UTF-8 JSON of the same shape
+  the service hashes) — if the verifier struggles, patch the
+  verifier first; rollback is the last resort.
+- The global advisory lock causes a deadlock with another
+  long-held audit-table lock. Diagnosis: `SELECT * FROM pg_locks
+  WHERE locktype = 'advisory' AND classid = 0`. Mitigation: drop
+  the `PERFORM pg_advisory_xact_lock(hashtext('audit:global'))`
+  lines from the trigger functions and the service (re-opens D2's
+  fork race). Investigate the contending caller first — the audit
+  writes themselves are tiny.
+- The tenant-immutable RAISE blocks a legitimate cross-tenant
+  re-targeting operation (extremely unlikely — by design, the only
+  cross-tenant write paths are seeded data + `runAsSuperAdmin`
+  explicit escape hatches, neither of which fire these triggers).
+
+## Re-apply pattern
+
+Forward-only by design. If 0021 is rolled back and then re-applied
+after new audit-event rows have been written:
+
+1. Rows written DURING the rollback window have
+   `digestPreImage = NULL` (the pre-0021 trigger functions don't
+   populate the column).
+2. Re-applying 0021 emits a NEW `panorama.audit.chain_repair`
+   marker and restarts digestPreImage persistence from that point
+   forward.
+3. The chain-verify CLI categorises any NULL-pre-image row as
+   "legacy (unverifiable)" — counted but neither pass nor fail.
+   The per-row verifier walks linearly and does not need to know
+   where the markers are; rows are classified on their own
+   `digestPreImage` presence, not on which marker they sit between.
+
+## Schema implications
+
+`schema.prisma` was updated to mirror the new column:
+
+```prisma
+model AuditEvent {
+  // ...
+  digestPreImage Bytes?
+}
+```
+
+A revert of THIS migration must also revert that line from
+`schema.prisma` — otherwise `prisma migrate status` will diff
+against the rolled-back DB. The SQL revert block above only
+handles the database side; the schema edit is a separate manual
+step that MUST land in the same commit as the SQL revert.
+
+## Production migration timing
+
+- `ALTER TABLE ADD COLUMN BYTEA` is metadata-only (no rewrite); takes
+  ACCESS EXCLUSIVE on `audit_events` for sub-millisecond. Safe under
+  load.
+- `CREATE OR REPLACE FUNCTION` does not take a heavy lock. New
+  trigger fires use the new function definition; in-flight calls
+  finish under the old definition (per Postgres planner cache rules).
+- The cutover marker INSERT does NOT take the advisory lock — a
+  DDL migration is a single-writer context by construction. Future
+  trigger + service writes take `hashtext('audit:global')`; the
+  marker doesn't contend with anything.

--- a/apps/core-api/prisma/migrations/20260516180117_0021_audit_digest_preimage_chain_lock/migration.sql
+++ b/apps/core-api/prisma/migrations/20260516180117_0021_audit_digest_preimage_chain_lock/migration.sql
@@ -1,0 +1,380 @@
+-- Migration 0021 — Audit chain reproducibility + concurrency hardening.
+--
+-- Closes the audit-chain-as-trust-anchor gap surfaced by the
+-- 2026-05-16 Wave 0 6-agent scan (security-reviewer B2 + data-
+-- architect Blocker 3) and ADR-0014's "tamper-evident audit log"
+-- claim. Three intertwined defects, fixed together so we only
+-- emit one chain-cutover marker:
+--
+--   D1. The per-row digest is **unreproducible** from the stored
+--       columns. The trigger and the TypeScript writer both hash a
+--       canonical JSON pre-image, but only the *result* (selfHash)
+--       is persisted. `audit_events.metadata` is JSONB, which
+--       Postgres recanonicalises (alphabetises keys, strips
+--       whitespace) on store, so a verifier reading the row back
+--       cannot recompute the digest input byte-for-byte.
+--
+--       Migration 0020 fixed the timestamp arm of this problem
+--       (ms-truncate so to_char and the column INSERT see the same
+--       value). The metadata-canonicalisation arm is closed HERE by
+--       persisting the exact pre-image bytes alongside the digest.
+--
+--   D2. Chain-head SELECT under concurrent writers can **fork**
+--       the chain. Two transactions reading the same `priorTail`
+--       both write rows whose `prevHash` points to the same
+--       predecessor — the chain becomes a tree with two children
+--       under one parent. data-architect Blocker 3.
+--
+--       Fixed via `pg_advisory_xact_lock(hashtext('audit:global'))`
+--       immediately before the chain-head SELECT in BOTH trigger
+--       functions (and in the TypeScript writer, in a sibling
+--       change to `audit.service.ts`). The lock scope matches the
+--       chain-head SELECT scope: the trigger functions are
+--       SECURITY DEFINER owned by `panorama` (BYPASSRLS, per
+--       migration 0015), so their SELECT sees the global head — a
+--       per-tenant lock would let two cross-tenant writers both
+--       read the same global tail and fork. A global lock kills
+--       cross-tenant audit-write parallelism; that's acceptable
+--       for an append-only log whose write rate is bounded by
+--       domain-write volume.
+--
+--   D3. The tamper-audit triggers fire on specific status
+--       transitions only — a row whose UPDATE also flips
+--       `tenantId` (cross-tenant re-targeting) slips past the
+--       predicate entirely. security-reviewer #15-B2.
+--
+--       Fixed via `IF OLD."tenantId" IS DISTINCT FROM NEW."tenantId"
+--       THEN RAISE EXCEPTION ...` at the top of each trigger
+--       (BEFORE the transition predicate, so it cannot be
+--       short-circuited).
+--
+-- Also: the trigger chain-head SELECT gains a
+-- `WHERE "selfHash" IS NOT NULL` defensive filter (data-architect).
+-- The column is NOT NULL at the schema level so the filter is
+-- currently a no-op, but in raw SQL the cost is zero and the filter
+-- makes the read self-documenting + survives any future schema
+-- relaxation. The TypeScript writer in `audit.service.ts` does NOT
+-- carry the same filter — Prisma's typed where-clause for a
+-- non-nullable Bytes column won't accept `{ selfHash: { not: null } }`
+-- in a clean way, and the column-level NOT NULL constraint enforces
+-- the same property end-to-end. The comment in the service
+-- (`audit.service.ts:160-165`) explains the asymmetry.
+--
+-- Forward-only: pre-0021 rows have `digestPreImage = NULL` and are
+-- flagged as "unverifiable (legacy)" by the chain-verify CLI. All
+-- post-0021 rows are byte-exact reproducible.
+
+-- ---------------------------------------------------------------------
+-- 1. Add the canonical pre-image column.
+-- ---------------------------------------------------------------------
+ALTER TABLE "audit_events"
+    ADD COLUMN "digestPreImage" BYTEA;
+
+COMMENT ON COLUMN "audit_events"."digestPreImage" IS
+'Canonical UTF-8 JSON pre-image hashed into selfHash. '
+'sha256(COALESCE(prevHash, '''') || digestPreImage) = selfHash for '
+'rows written from migration 0021 onward. NULL for pre-0021 rows '
+'(legacy, unverifiable).';
+
+-- ---------------------------------------------------------------------
+-- 2. Rewrite emit_notification_tamper_audit().
+--    Adds: tenant-immutable early-RAISE, per-strand advisory lock,
+--    chain-head selfHash filter, digestPreImage persistence.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION emit_notification_tamper_audit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    -- #96 (migration 0020): ms-truncate so to_char(MS) and the
+    -- column INSERT see the same value.
+    occurred      timestamptz := date_trunc('milliseconds', now());
+    payload_text  text;
+    payload_bytes bytea;
+    prev_hash     bytea;
+    self_hash     bytea;
+BEGIN
+    -- D3: reject any UPDATE that flips tenantId. The audit
+    -- predicate below only fires on specific status transitions,
+    -- so a same-status tenantId swap would otherwise sneak past
+    -- unaudited. This check runs FIRST so it cannot be
+    -- short-circuited by the early RETURN.
+    IF OLD."tenantId" IS DISTINCT FROM NEW."tenantId" THEN
+        RAISE EXCEPTION 'tenantId_immutable_post_create'
+            USING ERRCODE = 'check_violation',
+                  DETAIL  = format(
+                      'notification_events.id=%s attempted tenantId %s -> %s',
+                      NEW.id, OLD."tenantId", NEW."tenantId"
+                  );
+    END IF;
+
+    IF NOT (
+        (OLD."status" = 'PENDING'     AND NEW."status" = 'DISPATCHED') OR
+        (OLD."status" = 'DEAD')                                        OR
+        (OLD."status" = 'DISPATCHED'  AND NEW."status" <> 'DISPATCHED')
+    ) THEN
+        RETURN NEW;
+    END IF;
+
+    -- D2: serialise audit writes globally so the chain-head SELECT
+    -- + INSERT pair is atomic against concurrent writers. The
+    -- trigger SELECT is global (SECURITY DEFINER + BYPASSRLS owner
+    -- per migration 0015), so the lock must cover the SAME scope.
+    -- A per-tenant lock with a global SELECT permits two cross-
+    -- tenant writers to both read the same priorTail.selfHash and
+    -- both write rows pointing to it — forking the global chain.
+    -- Audit writes are sparse and tiny; global serialisation is
+    -- well below the contention floor.
+    PERFORM pg_advisory_xact_lock(hashtext('audit:global'));
+
+    SELECT "selfHash" INTO prev_hash
+      FROM audit_events
+     WHERE "selfHash" IS NOT NULL
+     ORDER BY id DESC
+     LIMIT 1;
+
+    payload_text := json_build_object(
+        'action',       'panorama.notification.status_tampered',
+        'resourceType', 'notification_event',
+        'resourceId',   NEW.id::text,
+        'tenantId',     NEW."tenantId"::text,
+        'actorUserId',  NULL,
+        'metadata',     json_build_object(
+                            'fromStatus', OLD."status"::text,
+                            'toStatus',   NEW."status"::text,
+                            'eventType',  NEW."eventType"
+                        ),
+        'occurredAt',   to_char(occurred AT TIME ZONE 'UTC',
+                                'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    )::text;
+    payload_bytes := convert_to(payload_text, 'UTF8');
+
+    IF prev_hash IS NOT NULL THEN
+        self_hash := digest(prev_hash || payload_bytes, 'sha256');
+    ELSE
+        self_hash := digest(payload_bytes, 'sha256');
+    END IF;
+
+    INSERT INTO audit_events (
+        "tenantId", "actorUserId", action, "resourceType", "resourceId",
+        metadata, "occurredAt", "prevHash", "selfHash", "digestPreImage"
+    ) VALUES (
+        NEW."tenantId",
+        NULL,
+        'panorama.notification.status_tampered',
+        'notification_event',
+        NEW.id::text,
+        json_build_object(
+            'fromStatus', OLD."status"::text,
+            'toStatus',   NEW."status"::text,
+            'eventType',  NEW."eventType"
+        ),
+        occurred,
+        prev_hash,
+        self_hash,
+        payload_bytes
+    );
+
+    RETURN NEW;
+END;
+$$;
+
+-- ---------------------------------------------------------------------
+-- 3. Rewrite emit_pat_resurrected_audit().
+--    Same shape as #2 — tenant-immutable + lock + selfHash filter +
+--    digestPreImage persistence.
+-- ---------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION emit_pat_resurrected_audit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    prev_hash     bytea;
+    -- See emit_notification_tamper_audit comment for rationale.
+    occurred      timestamptz := date_trunc('milliseconds', now());
+    payload_text  text;
+    payload_bytes bytea;
+    self_hash     bytea;
+BEGIN
+    IF TG_OP <> 'UPDATE' THEN
+        RETURN NEW;
+    END IF;
+
+    -- D3: same tenant-immutable invariant as the notification
+    -- trigger. A revoke that *also* swaps tenantId would otherwise
+    -- audit-mute itself.
+    IF OLD."tenantId" IS DISTINCT FROM NEW."tenantId" THEN
+        RAISE EXCEPTION 'tenantId_immutable_post_create'
+            USING ERRCODE = 'check_violation',
+                  DETAIL  = format(
+                      'personal_access_tokens.id=%s attempted tenantId %s -> %s',
+                      NEW.id, OLD."tenantId", NEW."tenantId"
+                  );
+    END IF;
+
+    IF OLD."revokedAt" IS NULL OR NEW."revokedAt" IS NOT NULL THEN
+        RETURN NEW;
+    END IF;
+
+    -- D2: see emit_notification_tamper_audit comment for the
+    -- single-global-lock rationale (SELECT scope = global → lock
+    -- scope = global).
+    PERFORM pg_advisory_xact_lock(hashtext('audit:global'));
+
+    SELECT "selfHash" INTO prev_hash
+      FROM audit_events
+     WHERE "selfHash" IS NOT NULL
+     ORDER BY id DESC
+     LIMIT 1;
+
+    payload_text := json_build_object(
+        'action',       'panorama.pat.resurrected',
+        'resourceType', 'personal_access_token',
+        'resourceId',   NEW.id::text,
+        'tenantId',     NEW."tenantId"::text,
+        'actorUserId',  NULL,
+        'metadata',     json_build_object(
+                            'tokenId',     NEW.id::text,
+                            'tokenPrefix', NEW."tokenPrefix",
+                            'userId',      NEW."userId"::text,
+                            'previousRevokedAt', to_char(OLD."revokedAt" AT TIME ZONE 'UTC',
+                                                         'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+                        ),
+        'occurredAt',   to_char(occurred AT TIME ZONE 'UTC',
+                                'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    )::text;
+    payload_bytes := convert_to(payload_text, 'UTF8');
+
+    IF prev_hash IS NOT NULL THEN
+        self_hash := digest(prev_hash || payload_bytes, 'sha256');
+    ELSE
+        self_hash := digest(payload_bytes, 'sha256');
+    END IF;
+
+    INSERT INTO audit_events (
+        "tenantId", "actorUserId", action, "resourceType", "resourceId",
+        metadata, "occurredAt", "prevHash", "selfHash", "digestPreImage"
+    ) VALUES (
+        NEW."tenantId",
+        NULL,
+        'panorama.pat.resurrected',
+        'personal_access_token',
+        NEW.id::text,
+        json_build_object(
+            'tokenId',     NEW.id::text,
+            'tokenPrefix', NEW."tokenPrefix",
+            'userId',      NEW."userId"::text,
+            'previousRevokedAt', to_char(OLD."revokedAt" AT TIME ZONE 'UTC',
+                                         'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+        ),
+        occurred,
+        prev_hash,
+        self_hash,
+        payload_bytes
+    );
+
+    RETURN NEW;
+END;
+$$;
+
+-- ---------------------------------------------------------------------
+-- 4. Extend the notification trigger's UPDATE OF column list.
+--
+--    Migration 0011 created the trigger with
+--    `AFTER UPDATE OF "status" ON "notification_events"`, so an
+--    UPDATE that flips ONLY `tenantId` (no status change) skips the
+--    trigger entirely — the tenant-immutable RAISE added above
+--    would never run. Extend the fire-list to include `tenantId`
+--    so any column-mention triggers the function. The function's
+--    own predicate (the IF NOT (status transition) RETURN NEW
+--    branch) is unchanged, so status-only updates still hit the
+--    same audit-emission path; tenantId-flipping updates hit the
+--    new RAISE first.
+--
+--    DROP + CREATE under the same name in one statement-batch is
+--    atomic w.r.t. concurrent writers (the underlying ACCESS
+--    EXCLUSIVE lock on `notification_events` covers both).
+-- ---------------------------------------------------------------------
+DROP TRIGGER IF EXISTS emit_notification_tamper_audit_trigger
+    ON "notification_events";
+CREATE TRIGGER emit_notification_tamper_audit_trigger
+    AFTER UPDATE OF "status", "tenantId" ON "notification_events"
+    FOR EACH ROW EXECUTE FUNCTION emit_notification_tamper_audit();
+
+-- The PAT trigger from 0009 fires on every UPDATE (no column list)
+-- so the tenantId-immutable RAISE in emit_pat_resurrected_audit
+-- already reaches every tenantId flip. No trigger DDL change needed
+-- here.
+
+-- ---------------------------------------------------------------------
+-- 5. Cutover marker (apply-time single insert; links into the global
+--    strand). Pre-image is also stored so the marker itself verifies
+--    via the new chain-verify CLI from migration apply forward.
+--
+--    No advisory lock here — a DDL migration is a single-writer
+--    context by definition.
+-- ---------------------------------------------------------------------
+DO $$
+DECLARE
+    occurred       timestamptz := date_trunc('milliseconds', now());
+    metadata_json  jsonb;
+    payload_text   text;
+    payload_bytes  bytea;
+    prev_hash      bytea;
+    self_hash      bytea;
+BEGIN
+    metadata_json := jsonb_build_object(
+        'migration', '0021',
+        'fixes', jsonb_build_array(
+                     'audit_events.digestPreImage column (D1: JSONB recanonicalisation)',
+                     'pg_advisory_xact_lock global on chain-head SELECT (D2: fork race)',
+                     'tenantId-immutable trigger early-RAISE (D3: cross-tenant retarget)',
+                     'WHERE "selfHash" IS NOT NULL chain-head guard'
+                 ),
+        'reason', 'audit_chain_reproducibility_and_concurrency'
+    );
+
+    SELECT "selfHash" INTO prev_hash
+      FROM audit_events
+     WHERE "selfHash" IS NOT NULL
+     ORDER BY id DESC
+     LIMIT 1;
+
+    payload_text := json_build_object(
+        'action',       'panorama.audit.chain_repair',
+        'resourceType', 'audit_chain',
+        'resourceId',   NULL,
+        'tenantId',     NULL,
+        'actorUserId',  NULL,
+        'metadata',     metadata_json,
+        'occurredAt',   to_char(occurred AT TIME ZONE 'UTC',
+                                'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    )::text;
+    payload_bytes := convert_to(payload_text, 'UTF8');
+
+    IF prev_hash IS NOT NULL THEN
+        self_hash := digest(prev_hash || payload_bytes, 'sha256');
+    ELSE
+        self_hash := digest(payload_bytes, 'sha256');
+    END IF;
+
+    INSERT INTO audit_events (
+        "tenantId", "actorUserId", action, "resourceType", "resourceId",
+        metadata, "occurredAt", "prevHash", "selfHash", "digestPreImage"
+    ) VALUES (
+        NULL,
+        NULL,
+        'panorama.audit.chain_repair',
+        'audit_chain',
+        NULL,
+        metadata_json,
+        occurred,
+        prev_hash,
+        self_hash,
+        payload_bytes
+    );
+END $$;

--- a/apps/core-api/prisma/migrations/20260516180117_0021_audit_digest_preimage_chain_lock/rls.sql
+++ b/apps/core-api/prisma/migrations/20260516180117_0021_audit_digest_preimage_chain_lock/rls.sql
@@ -1,0 +1,12 @@
+-- Migration 0021 — no RLS surface change.
+--
+-- Adds a column to `audit_events` and rewrites two SECURITY DEFINER
+-- trigger functions. The column inherits the table's existing RLS
+-- policies (migrations 0001 + #41 follow-ups). The trigger
+-- functions keep SECURITY DEFINER + owner = panorama so the
+-- chain-is-global property from migration 0015 is preserved.
+--
+-- Placeholder kept for grep-greppability of the per-migration RLS
+-- audit pattern.
+
+SELECT 1;

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -556,18 +556,22 @@ enum ReservationStatus {
 // -----------------------------------------------------------------------------
 
 model AuditEvent {
-  id           BigInt   @id @default(autoincrement())
-  tenantId     String?  @db.Uuid
-  actorUserId  String?  @db.Uuid
-  action       String
-  resourceType String
-  resourceId   String?
-  metadata     Json?
-  ipAddress    String?
-  userAgent    String?
-  occurredAt   DateTime @default(now())
-  prevHash     Bytes?
-  selfHash     Bytes
+  id             BigInt   @id @default(autoincrement())
+  tenantId       String?  @db.Uuid
+  actorUserId    String?  @db.Uuid
+  action         String
+  resourceType   String
+  resourceId     String?
+  metadata       Json?
+  ipAddress      String?
+  userAgent      String?
+  occurredAt     DateTime @default(now())
+  prevHash       Bytes?
+  selfHash       Bytes
+  /// Canonical UTF-8 JSON pre-image hashed into selfHash. Migration 0021+.
+  /// Verifier asserts sha256(COALESCE(prevHash, '') || digestPreImage) == selfHash.
+  /// NULL for pre-0021 rows (legacy, unverifiable from columns alone).
+  digestPreImage Bytes?
 
   @@index([tenantId, occurredAt(sort: Desc)])
   @@map("audit_events")

--- a/apps/core-api/src/modules/audit/audit.service.ts
+++ b/apps/core-api/src/modules/audit/audit.service.ts
@@ -95,11 +95,72 @@ export class AuditService {
   /**
    * Emit an audit row inside an already-open transaction. Matches the
    * invariant that domain writes + their audit record commit together.
+   *
+   * Two concurrency-correctness moves land before the chain-head read
+   * (migration 0021 / Wave 0 Round 2B):
+   *
+   *   1. **Global advisory lock.** Two writers seeing the same
+   *      `priorTail.selfHash` would both write rows whose `prevHash`
+   *      points to the same predecessor, forking the chain.
+   *      `pg_advisory_xact_lock(hashtext('audit:global'))` serialises
+   *      all audit writes until the row's INSERT commits. The trigger
+   *      functions in migration 0021 take the SAME lock so trigger-
+   *      driven writes and service-driven writes share the lock space.
+   *      We use a global lock (not per-tenant) because the SECURITY
+   *      DEFINER triggers read the global chain head — a per-tenant
+   *      lock would let two cross-tenant writers both read the same
+   *      global tail and fork the chain.
+   *   2. **Canonical pre-image persistence.** `audit_events.metadata`
+   *      is JSONB and Postgres recanonicalises keys on store, so a
+   *      verifier reading the row back cannot recompute the digest
+   *      input byte-for-byte from the columns alone. We persist the
+   *      exact UTF-8 JSON pre-image hashed into `selfHash` into the
+   *      new `digestPreImage` column. The chain-verify CLI reads
+   *      `prevHash || digestPreImage` and asserts the sha256 equals
+   *      `selfHash`.
+   *
+   * What `digestPreImage` enables (per-row reproducibility):
+   *   - An attacker editing any of `action`, `resourceType`,
+   *     `resourceId`, `tenantId`, `actorUserId`, `metadata`,
+   *     `occurredAt` AFTER write diverges the recomputed digest
+   *     from the stored `selfHash`. Caught by the chain-verify CLI.
+   *
+   * What it does NOT cover (out of scope for Round 2B):
+   *   - **`ipAddress` / `userAgent` are stored but not hashed.** They
+   *     are observational metadata about the actor, not part of the
+   *     audit-row's logical identity. Editing them post-write goes
+   *     undetected by the chain.
+   *   - **Multi-strand prev-link verification** under the documented
+   *     multi-strand semantics. The trigger functions write rows that
+   *     link into the global chain regardless of the row's `tenantId`,
+   *     so a per-tenant verifier filtering to (tenant, NULL) and
+   *     walking `prevHash → predecessor.selfHash` reports false
+   *     mismatches whenever a different tenant's row sits between two
+   *     of the verifier's strand-member rows. Per-row reproducibility
+   *     is the trust anchor this PR ships; prev-link verification at
+   *     multi-strand granularity is deferred.
+   *
+   * Trigger functions in migration 0021 are sister writers — they
+   * build their own canonical pre-image via `json_build_object(...)`
+   * and persist the same `digestPreImage` shape. Drift between this
+   * service's payload and the triggers' payload is caught by the
+   * `migration-0021-audit-chain.test.ts` digest-recomputation
+   * assertions.
    */
   async recordWithin(
     tx: Prisma.TransactionClient,
     event: AuditEventInput,
   ): Promise<void> {
+    await tx.$executeRawUnsafe(
+      `SELECT pg_advisory_xact_lock(hashtext('audit:global'))`,
+    );
+
+    // No `WHERE selfHash IS NOT NULL` filter here — the column is
+    // NOT NULL at the schema level (audit_events.selfHash BYTEA NOT
+    // NULL), so the filter the data-architect recommended for the
+    // chain-head SELECT is redundant in this code path. The trigger
+    // functions keep the filter inline in their raw SQL since the
+    // cost there is zero and it makes the read self-documenting.
     const prev = await tx.auditEvent.findFirst({
       orderBy: { id: 'desc' },
       select: { selfHash: true },
@@ -114,9 +175,10 @@ export class AuditService {
       metadata: event.metadata ?? null,
       occurredAt: occurredAt.toISOString(),
     };
+    const digestPreImage = Buffer.from(JSON.stringify(payload), 'utf8');
     const hash = createHash('sha256');
     if (prev?.selfHash) hash.update(prev.selfHash);
-    hash.update(JSON.stringify(payload));
+    hash.update(digestPreImage);
     const selfHash = hash.digest();
 
     const data: Prisma.AuditEventCreateInput = {
@@ -130,6 +192,7 @@ export class AuditService {
       occurredAt,
       prevHash: prev?.selfHash ?? null,
       selfHash,
+      digestPreImage,
     };
     if (event.metadata !== undefined) {
       data.metadata = event.metadata as Prisma.InputJsonValue;

--- a/apps/core-api/src/scripts/verify-audit-chain.ts
+++ b/apps/core-api/src/scripts/verify-audit-chain.ts
@@ -1,0 +1,226 @@
+#!/usr/bin/env tsx
+/**
+ * verify-audit-chain — per-row hash integrity check for audit_events.
+ *
+ * Usage:
+ *
+ *   pnpm --filter @panorama/core-api chain-verify
+ *   pnpm --filter @panorama/core-api chain-verify --json
+ *
+ * Connects via `DATABASE_PRIVILEGED_URL` (per ADR-0015 v2 the only
+ * role with cross-tenant read capacity via BYPASSRLS — declared
+ * directly on the role attribute on self-hosted, gated by the
+ * SECURITY DEFINER `panorama_enable_bypass_rls()` function on managed
+ * Postgres). Walks every audit row in id order and asserts:
+ *
+ *   sha256(COALESCE(prevHash, '') || digestPreImage) == selfHash
+ *
+ * Rows where `digestPreImage IS NULL` (pre-migration-0021 legacy
+ * rows; post-rollback gap rows) cannot be byte-exact verified from
+ * columns alone and are recorded as "legacy (unverifiable)".
+ *
+ * **Scope** — this CLI verifies per-row tamper integrity only. The
+ * audit chain is intentionally multi-strand under the SECURITY
+ * DEFINER trigger + `runInTenant` RLS contracts (see
+ * `audit.service.ts` docstring): prev_hash links cross tenant
+ * strands by design, so a single-pass prev_link walk would report
+ * false mismatches on cross-tenant adjacency. Per-row reproducibility
+ * IS the trust anchor SECURITY.md promises; multi-strand prev-link
+ * verification at audit-time is a separate workstream.
+ *
+ * Exit code:
+ *
+ *   0 — every non-legacy row's selfHash matches its recomputed digest
+ *   1 — at least one row's selfHash does not match its recomputed
+ *       digest (tamper signal)
+ *   2 — operational error (no DATABASE_PRIVILEGED_URL, query failure,
+ *       empty result when a cutover marker was expected, etc.)
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { createHash } from 'node:crypto';
+
+interface AuditRow {
+  id: bigint;
+  tenantId: string | null;
+  action: string;
+  prevHash: Buffer | null;
+  selfHash: Buffer;
+  digestPreImage: Buffer | null;
+}
+
+interface RowFinding {
+  id: string;
+  tenantId: string | null;
+  action: string;
+  detail: string;
+}
+
+interface Report {
+  generatedAt: string;
+  totalRows: number;
+  verified: number;
+  legacy: number;
+  digestMismatches: number;
+  firstMismatch: RowFinding | null;
+  ok: boolean;
+}
+
+function asBuffer(b: Buffer | null | undefined): Buffer | null {
+  if (b == null) return null;
+  // Prisma 6 returns Bytes as Uint8Array on some drivers; Buffer is a
+  // Uint8Array subclass so structural copy normalises both shapes.
+  return Buffer.isBuffer(b) ? b : Buffer.from(b);
+}
+
+function verifyRow(row: AuditRow): { kind: 'ok' | 'legacy' | 'mismatch'; detail?: string } {
+  const preImage = asBuffer(row.digestPreImage);
+  if (preImage === null) {
+    return { kind: 'legacy' };
+  }
+  const prevHash = asBuffer(row.prevHash);
+  const selfHash = asBuffer(row.selfHash)!;
+  const h = createHash('sha256');
+  if (prevHash) h.update(prevHash);
+  h.update(preImage);
+  const recomputed = h.digest();
+  if (Buffer.compare(recomputed, selfHash) !== 0) {
+    return {
+      kind: 'mismatch',
+      detail: `selfHash = ${selfHash.toString('hex')}, recomputed = ${recomputed.toString('hex')}`,
+    };
+  }
+  return { kind: 'ok' };
+}
+
+async function main(): Promise<number> {
+  const url = process.env.DATABASE_PRIVILEGED_URL;
+  if (!url) {
+    process.stderr.write(
+      'verify-audit-chain: DATABASE_PRIVILEGED_URL is not set. ' +
+        'See docs/runbooks/secrets-inventory.md §Postgres for the value. ' +
+        'Aborting.\n',
+    );
+    return 2;
+  }
+
+  const json = process.argv.includes('--json');
+  const prisma = new PrismaClient({ datasources: { db: { url } } });
+
+  try {
+    // CRITICAL: `panorama_enable_bypass_rls()` sets a tx-local GUC
+    // via `set_config(..., true)`. Outside an explicit $transaction,
+    // each statement runs in its own autocommit tx and the GUC dies
+    // immediately. On managed Postgres where `panorama_super_admin`
+    // is NOBYPASSRLS (ADR-0015 v2), this would silently return zero
+    // rows and report PASS over an empty set. Wrap both calls in
+    // the SAME tx so the bypass stays in scope for the read.
+    const result = await prisma.$transaction(async (tx) => {
+      await tx.$executeRawUnsafe('SELECT panorama_enable_bypass_rls()');
+      return tx.auditEvent.findMany({
+        orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          tenantId: true,
+          action: true,
+          prevHash: true,
+          selfHash: true,
+          digestPreImage: true,
+        },
+      });
+    });
+    const rows = result as unknown as AuditRow[];
+
+    const report: Report = {
+      generatedAt: new Date().toISOString(),
+      totalRows: rows.length,
+      verified: 0,
+      legacy: 0,
+      digestMismatches: 0,
+      firstMismatch: null,
+      ok: false,
+    };
+    for (const row of rows) {
+      const v = verifyRow(row);
+      if (v.kind === 'ok') {
+        report.verified++;
+      } else if (v.kind === 'legacy') {
+        report.legacy++;
+      } else {
+        report.digestMismatches++;
+        report.firstMismatch ??= {
+          id: row.id.toString(),
+          tenantId: row.tenantId,
+          action: row.action,
+          detail: v.detail ?? '',
+        };
+      }
+    }
+    report.ok = report.digestMismatches === 0 && rows.length > 0;
+
+    if (rows.length === 0) {
+      // Empty audit_events is suspect — every prior migration emits
+      // at least a chain-repair cutover marker (0015 / 0020 / 0021).
+      // If the verifier sees zero rows on a real DB, either (a) the
+      // BYPASSRLS path silently filtered everything (the bug this
+      // CLI's $transaction wrap guards against), or (b) someone
+      // truncated audit_events (which is itself a chain-integrity
+      // failure). Either way: do not report PASS over an empty set.
+      process.stderr.write(
+        'verify-audit-chain: audit_events is empty — cannot distinguish ' +
+          '"fresh DB with no migrations" from "RLS-filtered to zero rows" ' +
+          'from "table was truncated". Treat as op-error; investigate.\n',
+      );
+      report.ok = false;
+      if (json) {
+        process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+      } else {
+        writeHumanReport(report);
+      }
+      return 2;
+    }
+
+    if (json) {
+      process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+    } else {
+      writeHumanReport(report);
+    }
+    return report.ok ? 0 : 1;
+  } catch (err) {
+    process.stderr.write(
+      `verify-audit-chain: operational error: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 2;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+function writeHumanReport(report: Report): void {
+  // Three-way status so an on-call eye distinguishes "tamper, page"
+  // from "empty / op-error, investigate." The empty-rows path is the
+  // belt-and-braces for the BYPASS-GUC scope bug — if a future
+  // regression silently filters everything to zero, the operator
+  // sees OP-ERROR (not a misleading FAIL that looks like a tamper).
+  const status = report.totalRows === 0
+    ? 'OP-ERROR (empty result)'
+    : report.ok ? 'PASS' : 'FAIL';
+  const out = process.stdout;
+  out.write(`audit chain verification — ${status}\n`);
+  out.write(`generated:               ${report.generatedAt}\n`);
+  out.write(`total rows:              ${report.totalRows}\n`);
+  out.write(`verified:                ${report.verified}\n`);
+  out.write(`legacy (pre-0021, NULL): ${report.legacy}\n`);
+  out.write(`digest mismatches:       ${report.digestMismatches}\n`);
+  if (report.firstMismatch) {
+    out.write(`\nfirst mismatch:\n`);
+    out.write(`  id:       ${report.firstMismatch.id}\n`);
+    out.write(`  tenantId: ${report.firstMismatch.tenantId ?? '<null>'}\n`);
+    out.write(`  action:   ${report.firstMismatch.action}\n`);
+    out.write(`  detail:   ${report.firstMismatch.detail}\n`);
+  }
+}
+
+void main().then((code) => {
+  process.exit(code);
+});

--- a/apps/core-api/test/audit-chain-integrity.e2e.test.ts
+++ b/apps/core-api/test/audit-chain-integrity.e2e.test.ts
@@ -54,6 +54,7 @@ interface AuditRowSlim {
   occurredAt: Date;
   prevHash: Buffer | null;
   selfHash: Buffer;
+  digestPreImage: Buffer | null;
 }
 
 describe('audit hash-chain integrity — batched recordWithin', () => {
@@ -130,6 +131,7 @@ describe('audit hash-chain integrity — batched recordWithin', () => {
         occurredAt: true,
         prevHash: true,
         selfHash: true,
+        digestPreImage: true,
       },
     })) as unknown as AuditRowSlim[];
 
@@ -158,8 +160,13 @@ describe('audit hash-chain integrity — batched recordWithin', () => {
     // selfHash recomputability: each row's selfHash must equal
     // sha256(prevHash || canonical_payload). If a downstream tool
     // tampers with any field — action, resourceId, tenantId, metadata,
-    // occurredAt — the recomputed hash diverges and verification
-    // tooling (when it ships) will catch it.
+    // occurredAt — the recomputed hash diverges and the chain-verify
+    // CLI catches it. We assert TWO ways:
+    //   (a) recomputing the payload from columns, the way the writer
+    //       does, must match (legacy invariant)
+    //   (b) recomputing from the new `digestPreImage` column, the way
+    //       the chain-verify CLI does, must also match (migration
+    //       0021 reproducibility contract)
     for (const row of rows) {
       const payload = {
         action: row.action,
@@ -170,11 +177,28 @@ describe('audit hash-chain integrity — batched recordWithin', () => {
         metadata: row.metadata ?? null,
         occurredAt: row.occurredAt.toISOString(),
       };
-      const h = createHash('sha256');
-      if (row.prevHash) h.update(row.prevHash);
-      h.update(JSON.stringify(payload));
-      const expected = h.digest();
-      expect(Buffer.compare(row.selfHash, expected)).toBe(0);
+      const hViaColumns = createHash('sha256');
+      if (row.prevHash) hViaColumns.update(row.prevHash);
+      hViaColumns.update(JSON.stringify(payload));
+      expect(Buffer.compare(row.selfHash, hViaColumns.digest())).toBe(0);
+
+      // (b) Migration 0021 contract: digestPreImage must be populated
+      // for every row written by the post-0021 service, and the CLI's
+      // recomputation path must equal selfHash. This is the load-
+      // bearing invariant for the chain-verify CLI.
+      //
+      // Prisma 6 returns Bytes as Uint8Array (no .toString('utf8'));
+      // wrap once via Buffer.from for predictable byte semantics.
+      expect(row.digestPreImage).not.toBeNull();
+      const preImageBuf = Buffer.from(row.digestPreImage!);
+      const hViaPreImage = createHash('sha256');
+      if (row.prevHash) hViaPreImage.update(row.prevHash);
+      hViaPreImage.update(preImageBuf);
+      expect(Buffer.compare(row.selfHash, hViaPreImage.digest())).toBe(0);
+
+      // And the preimage must decode to the same canonical payload
+      // (catches drift between writer's JSON shape and what's stored).
+      expect(JSON.parse(preImageBuf.toString('utf8'))).toEqual(payload);
     }
 
     // Sanity: occurredAt is within the test window.

--- a/apps/core-api/test/migration-0021-audit-chain.test.ts
+++ b/apps/core-api/test/migration-0021-audit-chain.test.ts
@@ -1,0 +1,176 @@
+import 'reflect-metadata';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { createHash } from 'node:crypto';
+import { resetTestDb } from './_reset-db.js';
+import { createTenantForTest } from './_create-tenant.js';
+
+/**
+ * Migration 0021 — audit chain reproducibility + concurrency hardening.
+ *
+ * The service-side invariants (digestPreImage populated for every
+ * row, sha256(prevHash || digestPreImage) == selfHash, advisory
+ * lock visible to per-tenant strands) are covered by
+ * `audit-chain-integrity.e2e.test.ts`. THIS file covers the
+ * trigger-side invariants:
+ *
+ *   1. Notification tamper trigger writes a non-NULL `digestPreImage`
+ *      and the recomputation sha256(prev || preimage) == selfHash.
+ *   2. PAT resurrection trigger same.
+ *   3. Notification UPDATE that flips `tenantId` (regardless of
+ *      status transition) raises `tenantId_immutable_post_create`
+ *      — the cross-tenant retarget block (D3).
+ *   4. PAT UPDATE that flips `tenantId` same.
+ *   5. `digestPreImage` parses back to the canonical JSON the
+ *      trigger built — drift between trigger payload and stored
+ *      pre-image shows up here, not weeks later in production.
+ */
+
+const HOST = process.env.PG_HOST ?? 'localhost';
+const PORT = process.env.PG_PORT ?? '5432';
+const DB = process.env.PG_DB ?? 'panorama';
+const ADMIN_URL = `postgres://panorama_super_admin:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+
+describe('migration 0021 — audit chain reproducibility', () => {
+  const admin = new PrismaClient({ datasources: { db: { url: ADMIN_URL } } });
+  let tenantA: string;
+  let tenantB: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    await resetTestDb(admin);
+    const a = await createTenantForTest(admin, {
+      slug: 'mig21-a',
+      name: 'Mig21 A',
+      displayName: 'Mig21 A',
+    });
+    tenantA = a.id;
+    const aRow = await admin.tenant.findUniqueOrThrow({
+      where: { id: a.id },
+      select: { systemActorUserId: true },
+    });
+    userId = aRow.systemActorUserId;
+
+    const b = await createTenantForTest(admin, {
+      slug: 'mig21-b',
+      name: 'Mig21 B',
+      displayName: 'Mig21 B',
+    });
+    tenantB = b.id;
+  }, 60_000);
+
+  afterAll(async () => {
+    await admin.$disconnect();
+  });
+
+  it('notification tamper trigger writes a non-NULL digestPreImage that reproduces selfHash', async () => {
+    const dedupKey = `mig21-tamper-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const created = await admin.notificationEvent.create({
+      data: {
+        tenantId: tenantA,
+        eventType: 'panorama.test.mig21_tamper',
+        dedupKey,
+        payload: { kind: 'mig21-tamper' },
+        status: 'PENDING',
+      },
+    });
+    await admin.notificationEvent.update({
+      where: { id: created.id },
+      data: { status: 'DISPATCHED' },
+    });
+
+    const row = await admin.auditEvent.findFirstOrThrow({
+      where: {
+        action: 'panorama.notification.status_tampered',
+        resourceId: created.id,
+      },
+      orderBy: { id: 'desc' },
+    });
+
+    // Migration 0021 contract: digestPreImage is populated.
+    expect(row.digestPreImage).not.toBeNull();
+    const preImage = Buffer.from(row.digestPreImage!);
+
+    // Recompute via the same path the chain-verify CLI uses.
+    const h = createHash('sha256');
+    if (row.prevHash) h.update(Buffer.from(row.prevHash));
+    h.update(preImage);
+    expect(Buffer.from(row.selfHash).equals(h.digest())).toBe(true);
+  });
+
+  it('PAT resurrection trigger writes a non-NULL digestPreImage that reproduces selfHash', async () => {
+    // Insert a token directly (we just need a row whose revokedAt
+    // transitions non-NULL → NULL, which is the trigger's predicate).
+    // tokenHash + tokenPrefix + scopes are required; minimal viable
+    // values are fine for a trigger-fire test.
+    const pat = await admin.personalAccessToken.create({
+      data: {
+        tenantId: tenantA,
+        userId,
+        issuerUserId: userId,
+        name: 'mig21-resurrect-target',
+        tokenPrefix: 'pnrm_pat_mig21r',
+        tokenHash: `sha256-mig21-resurrect-${Date.now()}`,
+        scopes: ['snipeit.compat.read'],
+        revokedAt: new Date(),
+      },
+    });
+
+    await admin.personalAccessToken.update({
+      where: { id: pat.id },
+      data: { revokedAt: null },
+    });
+
+    const row = await admin.auditEvent.findFirstOrThrow({
+      where: { action: 'panorama.pat.resurrected', resourceId: pat.id },
+      orderBy: { id: 'desc' },
+    });
+
+    expect(row.digestPreImage).not.toBeNull();
+    const preImage = Buffer.from(row.digestPreImage!);
+
+    const h = createHash('sha256');
+    if (row.prevHash) h.update(Buffer.from(row.prevHash));
+    h.update(preImage);
+    expect(Buffer.from(row.selfHash).equals(h.digest())).toBe(true);
+  });
+
+  it('notification UPDATE that flips tenantId raises tenantId_immutable_post_create', async () => {
+    const created = await admin.notificationEvent.create({
+      data: {
+        tenantId: tenantA,
+        eventType: 'panorama.test.mig21_immutable',
+        dedupKey: `mig21-immut-${Date.now()}`,
+        payload: { kind: 'immutable' },
+        status: 'PENDING',
+      },
+    });
+
+    await expect(
+      admin.notificationEvent.update({
+        where: { id: created.id },
+        data: { tenantId: tenantB },
+      }),
+    ).rejects.toThrowError(/tenantId_immutable_post_create/);
+  });
+
+  it('PAT UPDATE that flips tenantId raises tenantId_immutable_post_create', async () => {
+    const pat = await admin.personalAccessToken.create({
+      data: {
+        tenantId: tenantA,
+        userId,
+        issuerUserId: userId,
+        name: 'mig21-immut-pat',
+        tokenPrefix: 'pnrm_pat_mig21i',
+        tokenHash: `sha256-mig21-immut-${Date.now()}`,
+        scopes: ['snipeit.compat.read'],
+      },
+    });
+    await expect(
+      admin.personalAccessToken.update({
+        where: { id: pat.id },
+        data: { tenantId: tenantB },
+      }),
+    ).rejects.toThrowError(/tenantId_immutable_post_create/);
+  });
+});

--- a/docs/runbooks/verify-audit-chain.md
+++ b/docs/runbooks/verify-audit-chain.md
@@ -1,0 +1,176 @@
+# Runbook — Verify audit-event hash chain (per-row reproducibility)
+
+## What this checks
+
+Every row in `audit_events` carries a `selfHash` =
+`sha256(prevHash || canonical_pre_image)`. Migration 0021 added the
+`digestPreImage` column so a verifier can recompute the digest
+byte-for-byte without needing to reconstruct the canonical pre-image
+from JSONB columns (which Postgres recanonicalises on store).
+
+`pnpm chain-verify` is the operational check. It connects via
+`DATABASE_PRIVILEGED_URL`, takes the BYPASSRLS path inside a single
+transaction (so the GUC stays in scope for the read), and verifies
+each row:
+
+- If `digestPreImage IS NOT NULL`: asserts
+  `sha256(COALESCE(prevHash, '') || digestPreImage) == selfHash`.
+  Mismatch = tamper signal.
+- If `digestPreImage IS NULL`: row is reported as "legacy
+  (unverifiable)" — pre-0021 rows + rows written during a 0021
+  rollback window. Counted but neither pass nor fail.
+
+## Scope — what this verifier DOES NOT check
+
+- **Multi-strand prev-link integrity.** The chain is intentionally
+  multi-strand under the SECURITY DEFINER trigger + `runInTenant`
+  RLS contracts (see `audit.service.ts` docstring). Trigger writes
+  link into the global chain regardless of the row's `tenantId`,
+  so a per-tenant verifier walk would report false mismatches on
+  cross-tenant adjacency. Per-row reproducibility is the trust
+  anchor we ship in Round 2B; multi-strand prev-link verification
+  is a separate workstream.
+- **`ipAddress` / `userAgent` tamper.** Those columns are stored
+  but NOT included in the canonical pre-image (they are
+  observational metadata about the actor, not part of the audit
+  row's logical identity). Editing them post-write goes undetected
+  by this CLI.
+- **Row deletion.** An attacker who DELETEs the latest row leaves
+  no fork — the next row's prevHash points to a row that's gone,
+  but the verifier processes each row in isolation. Detection of
+  missing rows requires the prev-link walk this CLI doesn't do.
+
+## When to run
+
+- **Quarterly** as a scheduled drill. Capture output under
+  `docs/audits/chain-verify-<date>/`.
+- **After any restore** from backup. The restored DB must verify
+  (zero digest mismatches) before traffic resumes.
+- **After a suspected tamper.** The "what changed" answer is in
+  the first mismatch's `id` + `action` — start the investigation
+  there.
+- **As a smoke check** after a deploy that touches
+  `audit.service.ts`, migration files under `prisma/migrations/`,
+  or any of the SECURITY DEFINER trigger functions in migrations
+  0011 / 0015 / 0020 / 0021.
+
+## How to run
+
+```bash
+# Human-readable summary on stdout, exit 0/1/2.
+pnpm --filter @panorama/core-api chain-verify
+
+# Machine-readable JSON for runbook tooling / CI.
+pnpm --filter @panorama/core-api chain-verify --json
+```
+
+The CLI requires `DATABASE_PRIVILEGED_URL` in the environment. The
+value is enumerated under §Postgres in
+[`docs/runbooks/secrets-inventory.md`](./secrets-inventory.md). On
+staging / prod, source the appropriate `.env`:
+
+```bash
+set -a; source apps/core-api/.env.staging; set +a
+pnpm --filter @panorama/core-api chain-verify
+```
+
+## Reading the output
+
+PASS shape:
+
+```
+audit chain verification — PASS
+generated:               2026-05-16T18:30:00.000Z
+total rows:              1284
+verified:                1237
+legacy (pre-0021, NULL): 47
+digest mismatches:       0
+```
+
+FAIL shape:
+
+```
+audit chain verification — FAIL
+total rows:              1284
+verified:                1236
+legacy (pre-0021, NULL): 47
+digest mismatches:       1
+
+first mismatch:
+  id:       905
+  tenantId: 9f6e...c10a
+  action:   panorama.invitation.accepted
+  detail:   selfHash = 0a3b..., recomputed = 9f2c...
+```
+
+## What a digest mismatch means
+
+A row's stored `selfHash` does not equal the sha256 of its
+`prevHash || digestPreImage`. Possible causes:
+
+1. **Tamper.** Someone edited a column AFTER the row was written.
+   The `digestPreImage` was committed with the original values, so
+   the recomputed digest still matches the *original* logical
+   state. If the row's other columns disagree with the pre-image,
+   that's the smoking gun. Compare `metadata` JSONB against
+   `digestPreImage`'s parsed JSON to see which field drifted.
+2. **Bug in the writer.** A future code change miscomputed the
+   digest or mismatched the canonical JSON shape. Diff
+   `audit.service.ts:recordWithin` against the trigger functions in
+   migration 0021 — both must hash the same canonical shape.
+
+## What an empty-result exit-2 means
+
+The CLI exits 2 with a stderr message if `audit_events` is empty,
+because we cannot distinguish:
+
+- A fresh DB before migrations have applied (no cutover markers
+  yet)
+- RLS silently filtered every row to zero (the bug the
+  `$transaction`-wrapped BYPASS path guards against, but if a
+  future regression re-introduces it, this exit-2 catches it)
+- Someone truncated `audit_events` (itself a chain-integrity
+  failure)
+
+Investigate: check `\dt audit_events`, run a manual
+`SELECT count(*) FROM audit_events`, verify the role's BYPASSRLS
+posture on the target DB.
+
+## What to do on FAIL
+
+1. **Do not delete or repair audit rows.** Append-only is the
+   property under audit; "fixing" the chain by editing a row would
+   itself be evidence destruction.
+2. Take a snapshot of the audit_events table (`pg_dump --table`)
+   and store it in the incident folder.
+3. Trace the first failure's `id` + `action` + `tenantId` back
+   through application logs. The audit row records what the
+   application *intended* to record; logs show what the application
+   *saw at the time*. Divergence is the tamper signal.
+4. Open a security incident per
+   `docs/runbooks/incident.md` (when that runbook lands per Round
+   6).
+
+## Known legacy
+
+The "legacy" count reflects rows whose `digestPreImage` is NULL.
+These are rows written before migration 0021 (which adds the
+column) OR rows written during a 0021 rollback window. They cannot
+be byte-exact verified from the columns alone but they are not
+tamper signals — they just predate the column.
+
+The chain-repair markers emitted at migration apply time
+(`action = 'panorama.audit.chain_repair'`, with
+`metadata.migration` identifying which one) are themselves
+verifiable from migration 0021 onward.
+
+## See also
+
+- `apps/core-api/src/modules/audit/audit.service.ts` — the writer
+- `apps/core-api/src/scripts/verify-audit-chain.ts` — the verifier
+- `apps/core-api/prisma/migrations/20260516180117_0021_audit_digest_preimage_chain_lock/migration.sql`
+- `apps/core-api/test/audit-chain-integrity.e2e.test.ts` +
+  `apps/core-api/test/migration-0021-audit-chain.test.ts` — the
+  test-time invariants the CLI mirrors at runtime
+- `docs/adr/0014-public-hosted-instance.md` — the public claim the
+  chain underwrites


### PR DESCRIPTION
## Summary

Closes Cluster 2B from `docs/audits/HANDOFF-2026-05-16-wave0-scan.md` — the last sub-piece of Round 2. Three intertwined defects in the audit chain, fixed together so we emit one cutover marker:

- **D1** (security-reviewer B2): per-row digest unreproducible from columns. JSONB recanonicalises keys on store, so a verifier can't recompute the digest input. New `audit_events.digestPreImage BYTEA` column stores the exact UTF-8 JSON pre-image hashed into `selfHash`. Service + both SECURITY DEFINER triggers populate it. Verifier: `sha256(prevHash || digestPreImage) == selfHash`.
- **D2** (data-architect Blocker 3): concurrent writers could read the same `priorTail` and write rows with identical `prevHash`, forking the chain. `pg_advisory_xact_lock(hashtext('audit:global'))` before the chain-head SELECT in service + both triggers. Global key (not per-tenant) because triggers are SECURITY DEFINER + BYPASSRLS owner and read the global head.
- **D3** (security-reviewer #15-B2): notification trigger only fires on `UPDATE OF "status"`, so a `tenantId`-only UPDATE slipped past unaudited. Fire-list extended to include `tenantId` + early RAISE `tenantId_immutable_post_create` on both triggers (before the transition predicate).

## New operator surface

- `pnpm --filter @panorama/core-api chain-verify` runs per-row reproducibility against `DATABASE_PRIVILEGED_URL`. Wraps `panorama_enable_bypass_rls()` + `findMany` in one `$transaction` so the tx-local GUC stays in scope (otherwise on Supabase NOBYPASSRLS we'd silently filter to zero rows and report a vacuous PASS).
- `docs/runbooks/verify-audit-chain.md` documents scope, exit codes, and what's intentionally out of scope: `ipAddress`/`userAgent` are stored but not hashed (observational metadata); multi-strand prev-link verification is a separate workstream.

SECURITY.md `#41 trigger breaks the chain` admission removed; replaced with a precise claim that matches what the verifier actually checks.

## Review trail

Two PR-gate scans (data-architect + security-reviewer) ran in parallel.

- **v1** surfaced four BLOCKERs: per-strand lock vs global chain-read fork, CLI BYPASS-GUC scope mismatch, verifier false-mismatch on legitimate multi-tenant adjacency, ROLLBACK.md vaporware ("marker-aware traversal" that didn't exist in the verifier).
- **v2** rewrite addressed each (global lock everywhere, CLI `$transaction` wrap, verifier scope reduced to per-row only, ROLLBACK.md cleaned up + CLI moved to `src/scripts/` per project convention).
- **Both reviewers APPROVE** v2; remaining items are CONCERN/NIT and tracked as follow-ups (partial index at scale, NOT-NULL CHECK guard, lock-key registry doc, etc).

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint --max-warnings=0` clean
- [x] Full `pnpm test` suite — 423/423 pass (3 new tests in `migration-0021-audit-chain.test.ts` covering: notification trigger digestPreImage population, PAT trigger digestPreImage population, notification tenantId-immutable RAISE, PAT tenantId-immutable RAISE; existing `audit-chain-integrity.e2e.test.ts` extended to assert per-row reproducibility via the new column)
- [x] `pnpm --filter @panorama/core-api chain-verify` runs PASS on dev DB
- [ ] CI green
- [ ] Apply migration 0021 to staging (Supabase) post-merge