### PR TITLE
feat(audit): Round 3 prereq 1 — registry entries for signup + verification + deletion (ADR-0020 §6)

### DIFF
--- a/apps/core-api/src/modules/audit/audit-actions.ts
+++ b/apps/core-api/src/modules/audit/audit-actions.ts
@@ -48,6 +48,155 @@ export const PanoramaAuditAction = {
    * resolution (see #91 / follow-up #28).
    */
   AuthOidcLogin: 'panorama.auth.oidc_login',
+  /**
+   * Self-serve signup throttler tripped (ADR-0020 §4). Cluster-wide
+   * event (`tenantId=null`) — fires before the tenant exists. The
+   * `bucket` field distinguishes WHICH of the three §4 buckets
+   * tripped so SIEM can alert independently:
+   *   - `ip` — 5/IP/hour (the loud single-source tripwire)
+   *   - `subnet` — 50/IPv4-/24 or IPv6-/64/day (residential proxy)
+   *   - `oidc_sub` — 3/(iss, sub)/24h (single-IdP-account abuse)
+   *
+   * Metadata: `bucket`, `key` (hashed — do NOT log raw IP or sub),
+   * `attemptIndex` (which attempt in the window tripped), `iss`
+   * (only set when `bucket === 'oidc_sub'`).
+   */
+  AuthSignupRateLimitTripped: 'panorama.auth.signup_rate_limit_tripped',
+  /**
+   * Cloudflare Turnstile verification failed server-side (ADR-0020
+   * §5). Cluster-wide event (`tenantId=null`). The user-facing
+   * response is the same generic 400 envelope as all other signup
+   * failures (timing-padded, see ADR-0020 §5); this audit row is
+   * the SERVER-side distinction so operators can tell scripted-
+   * abuse-via-no-CAPTCHA-token from genuine-user-failed-challenge.
+   *
+   * Metadata: `siteverifyErrorCodes` (array from Turnstile's
+   * `error-codes` response field), `hostname` (the rendering host),
+   * `tokenSha256` (hashed — single-use enforcement is in Redis,
+   * this is for replay-attempt detection across logs).
+   */
+  AuthCaptchaFailed: 'panorama.auth.captcha_failed',
+  /**
+   * Self-serve signup OIDC `state` parameter contract violation
+   * (ADR-0020 §1a). Cluster-wide event (`tenantId=null`). This is
+   * the CSRF-on-signup-callback detection signal — SIEM SHOULD
+   * alert on any non-zero rate. Possible causes:
+   *   - `missing` — no state record found in Redis (expired or
+   *     forged)
+   *   - `wrong_purpose` — state record has `purpose !== 'signup'`
+   *     (confused-deputy: login state being replayed against the
+   *     signup callback, or vice versa)
+   *   - `session_attached` — caller arrived with an existing
+   *     authenticated session (signup is logged-out-only)
+   *
+   * Metadata: `reason` (one of the above), `stateKeyPrefix` (first
+   * 8 chars of the state key — full key is sensitive), `iss` (if
+   * the OIDC callback was reached), `hasSession` (boolean).
+   */
+  AuthSignupOidcStateMismatch: 'panorama.auth.signup_oidc_state_mismatch',
+
+  // -------- panorama.tenant.* --------
+  /**
+   * Self-serve signup OIDC flow initiated (ADR-0020 §1). Cluster-
+   * wide event (`tenantId=null`) — the tenant does not exist yet.
+   * Fired at the moment the signup-initiate endpoint accepts the
+   * request and redirects to the IdP.
+   *
+   * Metadata: `provider` (`google` / `microsoft`), `ctaSource`
+   * (`hosted_button` / `selfhost_button` / `direct_url` — per R5
+   * recommendation; the funnel-signal source), `userAgentHash`
+   * (sha256 of the UA string — for bot-pattern detection without
+   * persisting the raw UA), `stateKeyPrefix` (first 8 chars; ties
+   * this row to the corresponding callback row).
+   */
+  TenantSignupInitiated: 'panorama.tenant.signup_initiated',
+  /**
+   * Verification email dispatched after a successful signup
+   * (ADR-0020 §3). Per-tenant event (the tenant exists in
+   * `pending_verification` state by this point). Fired after the
+   * SMTP submit returns success — bounces are tracked separately
+   * (out of scope for this event).
+   *
+   * Metadata: `emailHash` (sha256 of normalized lowercase email —
+   * the raw email is on `actorUser`, no need to duplicate), `ttl`
+   * (token TTL in seconds, currently 86400), `tokenKeyPrefix`
+   * (first 8 chars of the token — ties this row to the consume
+   * row).
+   */
+  TenantVerificationSent: 'panorama.tenant.verification_sent',
+  /**
+   * Verification token consumed via POST /auth/verify (ADR-0020
+   * §3). Per-tenant event. The tenant transitions from
+   * `pending_verification` to `active` in the same transaction
+   * that writes this row. One-time-use is enforced by deleting the
+   * token row in the same transaction.
+   *
+   * Metadata: `tokenKeyPrefix` (ties to the verification_sent
+   * row), `elapsedMs` (time between dispatch and consume — used
+   * for "verification took N hours" UX telemetry without standing
+   * up product analytics).
+   */
+  TenantVerified: 'panorama.tenant.verified',
+  /**
+   * Per-email verification cap (3 pending verifications per email
+   * per 24h, ADR-0020 §3) hit. Cluster-wide event (`tenantId=null`)
+   * — fires before the tenant exists. This is the harassment-
+   * defense signal: an attacker cycling IdP accounts to flood
+   * `victim@acme.com` with "verify your tenant" emails trips this.
+   *
+   * Metadata: `emailHash` (sha256 of normalized lowercase email —
+   * NEVER the raw email; the audit-row reader cross-correlates
+   * with `TenantSignupInitiated` rows by hash if they need to
+   * trace the harassment source).
+   */
+  TenantVerificationThrottled: 'panorama.tenant.verification_throttled',
+  /**
+   * Tenant deletion requested via POST /tenants/:id/delete-request
+   * (ADR-0020 §7 step 1). Per-tenant event. The delete-request
+   * email is fanned out to ALL Owners of the tenant (not just the
+   * requester) — see §7 race B mitigation.
+   *
+   * Metadata: `requestedByUserId`, `ownerCount` (how many Owners
+   * received the confirmation email), `tokenKeyPrefix` (ties to
+   * delete_confirmed or delete_cancelled row).
+   */
+  TenantDeleteRequested: 'panorama.tenant.delete_requested',
+  /**
+   * Tenant deletion confirmed via POST /tenants/:id/delete-confirm
+   * (ADR-0020 §7 step 2). Per-tenant event. The tenant row's
+   * `deletionScheduledAt` is set to T+7d in the same transaction.
+   * The deletion has NOT YET happened — see TenantDeleted for the
+   * terminal state.
+   *
+   * Metadata: `confirmedByUserId`, `scheduledAt` (ISO-8601 of the
+   * scheduled purge), `tokenKeyPrefix` (ties to the request row).
+   */
+  TenantDeleteConfirmed: 'panorama.tenant.delete_confirmed',
+  /**
+   * Tenant deletion cancelled during the 7-day cool-off (ADR-0020
+   * §7). Per-tenant event. IDEMPOTENT — a second cancel call
+   * against an already-cancelled tenant is a no-op and emits
+   * exactly ONE row (deduplication via
+   * `deletionScheduledAt IS NULL` precondition check). See §7
+   * race C for the resolution rule.
+   *
+   * Metadata: `cancelledByUserId`, `previouslyScheduledAt` (the
+   * ISO-8601 the cancel cleared).
+   */
+  TenantDeleteCancelled: 'panorama.tenant.delete_cancelled',
+  /**
+   * Tenant deletion vetoed via POST /tenants/:id/delete-veto
+   * (ADR-0020 §7 race B mitigation). Per-tenant event. Vetoes can
+   * come from a peer Tenant Owner OR from the platform maintainer
+   * via the admin console. Cancels the pending deletion identical
+   * to delete-cancel but emitted as a distinct action so the
+   * "credential-compromise recovery happened" signal is searchable
+   * in the audit trail.
+   *
+   * Metadata: `vetoedByUserId`, `vetoSource` (`peer_owner` /
+   * `platform_maintainer`), `previouslyScheduledAt`.
+   */
+  TenantDeleteVeto: 'panorama.tenant.delete_veto',
 } as const;
 
 export type PanoramaAuditAction =


### PR DESCRIPTION
## Summary

- First of three Round 3 prerequisite PRs (per HANDOFF-2026-05-16 + amended ADR-0020 §6). Adds **11 new entries** to `PanoramaAuditAction` covering the signup, verification, and deletion lifecycles
- Registry-only diff — no call-site changes. The Round 3 signup/verify/delete endpoint PR(s) will use these enum entries from day 1
- Each entry includes a documented metadata shape per R4 (the JSDoc lists which fields are emitted, which are required, which carry hashed/PII data)

## What's added

| Action | Domain | Tenant scope | Notes |
|---|---|---|---|
| `AuthSignupRateLimitTripped` | auth | cluster-wide | `bucket` field distinguishes §4's three buckets (`ip` / `subnet` / `oidc_sub`) |
| `AuthCaptchaFailed` | auth | cluster-wide | Cloudflare Turnstile siteverify error codes captured |
| `AuthSignupOidcStateMismatch` | auth | cluster-wide | The CSRF-on-signup-callback signal — SIEM should alert on any non-zero rate |
| `TenantSignupInitiated` | tenant | cluster-wide | Includes R5 `ctaSource` funnel field |
| `TenantVerificationSent` | tenant | per-tenant | Token TTL captured |
| `TenantVerified` | tenant | per-tenant | `elapsedMs` for UX telemetry |
| `TenantVerificationThrottled` | tenant | cluster-wide | Per-email harassment-defense cap (3/24h) |
| `TenantDeleteRequested` | tenant | per-tenant | `ownerCount` reflects multi-Owner fan-out per §7 |
| `TenantDeleteConfirmed` | tenant | per-tenant | `scheduledAt` is the T+7d ISO-8601 |
| `TenantDeleteCancelled` | tenant | per-tenant | Idempotent (race C resolution) |
| `TenantDeleteVeto` | tenant | per-tenant | `vetoSource: peer_owner | platform_maintainer` (race B mitigation) |

## What's NOT in this PR (by design)

- Migration of existing `panorama.tenant.created` / `panorama.tenant.deleted` string-literal emissions (in `tenant-admin.service.ts:139` and elsewhere) — per the file-level docstring policy: "Migrating those is a sibling cleanup PR."
- The signup, verify, delete endpoints themselves — Round 3 main work
- `TRUST_PROXY_HOPS` env wiring — Round 3 prereq 2 (separate PR)
- Per-IPv4/24 + per-(iss,sub) throttler buckets + signup-flood test — Round 3 prereq 3 (separate PR)

## Test plan

- [x] `pnpm -F core-api typecheck` clean
- [x] `pnpm -F core-api lint` clean
- [ ] CI passes (lint + unit + i18n + community-without-enterprise + Trivy + CodeQL + Gitleaks)
- [ ] Manual review: every new entry's metadata shape is grounded in either §4 / §5 / §6 / §7 of the amended ADR-0020, or in R4/R5 recommendations