### PR TITLE
feat(bootstrap): Round 3 prereq 2 — TRUST_PROXY_HOPS env wiring (ADR-0020 §4)

### DIFF
--- a/apps/core-api/src/bootstrap/trust-proxy-hops.ts
+++ b/apps/core-api/src/bootstrap/trust-proxy-hops.ts
@@ -1,0 +1,34 @@
+/**
+ * Resolve the `trust proxy` hop count from TRUST_PROXY_HOPS env.
+ *
+ * Express's `app.set('trust proxy', n)` reads the Nth-from-the-right
+ * value in `X-Forwarded-For` as `req.ip`. ADR-0020 §4 makes this
+ * contract explicit because the self-serve signup endpoint's per-IP
+ * throttler bucket cannot be defended if hop count is wrong:
+ *
+ *   - Too low: req.ip resolves to an internal proxy, all traffic
+ *     buckets to one IP (fail-united).
+ *   - Too high: req.ip resolves to whatever the upstream client sent
+ *     in X-Forwarded-For, which a remote attacker controls (forged
+ *     identities).
+ *
+ * Default `1` matches the hosted instance topology (Fly edge → app).
+ * Self-hosters running behind extra layers (CDN + LB + app) MUST set
+ * TRUST_PROXY_HOPS explicitly — see secrets-inventory.md.
+ *
+ * Invalid values (non-integer, negative) fail-fast at bootstrap.
+ * `0` is permitted (development mode, no proxy in front).
+ */
+export function resolveTrustProxyHops(env: NodeJS.ProcessEnv): number {
+  const raw = env.TRUST_PROXY_HOPS;
+  if (raw === undefined || raw === '') {
+    return 1;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(
+      `TRUST_PROXY_HOPS must be a non-negative integer; got ${JSON.stringify(raw)}`,
+    );
+  }
+  return parsed;
+}

--- a/apps/core-api/src/main.ts
+++ b/apps/core-api/src/main.ts
@@ -4,18 +4,23 @@ import { ValidationPipe, Logger } from '@nestjs/common';
 import type { NestExpressApplication } from '@nestjs/platform-express';
 import helmet from 'helmet';
 import { AppModule } from './app.module.js';
+import { resolveTrustProxyHops } from './bootstrap/trust-proxy-hops.js';
 
 async function bootstrap(): Promise<void> {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     bufferLogs: true,
   });
 
-  // Trust the first proxy hop (Fly edge → app, or LB → app on self-host).
-  // Without this, req.ip resolves to the proxy IP and the ThrottlerGuard
-  // sees every request as coming from one IP — fail-united, not
-  // fail-closed. Single hop is the conservative choice; bump if you
-  // run multiple LBs in front.
-  app.set('trust proxy', 1);
+  // Trust N proxy hops in front of core-api. Default 1 matches the
+  // hosted instance (Fly edge → app). Self-hosters running behind
+  // additional layers (CDN + LB + app) MUST set TRUST_PROXY_HOPS to
+  // the exact hop count — see docs/runbooks/secrets-inventory.md.
+  //
+  // Without a correct value, req.ip resolves to the wrong layer and
+  // the ThrottlerGuard buckets every request from one IP — fail-
+  // united, not fail-closed. ADR-0020 §4 makes this contract explicit
+  // because the self-serve signup endpoint relies on per-IP buckets.
+  app.set('trust proxy', resolveTrustProxyHops(process.env));
 
   app.use(
     helmet({

--- a/apps/core-api/test/trust-proxy-hops.test.ts
+++ b/apps/core-api/test/trust-proxy-hops.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTrustProxyHops } from '../src/bootstrap/trust-proxy-hops.js';
+
+describe('resolveTrustProxyHops', () => {
+  it('defaults to 1 when TRUST_PROXY_HOPS is unset', () => {
+    expect(resolveTrustProxyHops({})).toBe(1);
+  });
+
+  it('defaults to 1 when TRUST_PROXY_HOPS is empty string', () => {
+    expect(resolveTrustProxyHops({ TRUST_PROXY_HOPS: '' })).toBe(1);
+  });
+
+  it('parses a positive integer', () => {
+    expect(resolveTrustProxyHops({ TRUST_PROXY_HOPS: '2' })).toBe(2);
+    expect(resolveTrustProxyHops({ TRUST_PROXY_HOPS: '5' })).toBe(5);
+  });
+
+  it('permits 0 (development, no proxy)', () => {
+    expect(resolveTrustProxyHops({ TRUST_PROXY_HOPS: '0' })).toBe(0);
+  });
+
+  it('rejects negative integers (no such thing as -1 hops)', () => {
+    expect(() =>
+      resolveTrustProxyHops({ TRUST_PROXY_HOPS: '-1' }),
+    ).toThrowError(/non-negative integer/);
+  });
+
+  it('rejects non-integer numerics (decimal hop counts are meaningless)', () => {
+    expect(() =>
+      resolveTrustProxyHops({ TRUST_PROXY_HOPS: '1.5' }),
+    ).toThrowError(/non-negative integer/);
+  });
+
+  it('rejects non-numeric strings (silent NaN would mis-configure Express)', () => {
+    expect(() =>
+      resolveTrustProxyHops({ TRUST_PROXY_HOPS: 'loopback' }),
+    ).toThrowError(/non-negative integer/);
+    expect(() =>
+      resolveTrustProxyHops({ TRUST_PROXY_HOPS: 'true' }),
+    ).toThrowError(/non-negative integer/);
+  });
+});

--- a/docs/runbooks/secrets-inventory.md
+++ b/docs/runbooks/secrets-inventory.md
@@ -206,6 +206,42 @@ quickly identify what's safe to log.
 - `OAUTH_STATE_COOKIE_NAME`, `SESSION_COOKIE_NAME`,
   `SESSION_MAX_AGE_SECONDS`
 - `INVITE_RATE_ADMIN_HOUR`, `INVITE_RATE_TENANT_DAY`
+- `TRUST_PROXY_HOPS` — see dedicated subsection below
+
+### `TRUST_PROXY_HOPS` — load-bearing for signup rate-limit (ADR-0020 §4)
+
+Not a secret, but **load-bearing for the §4 per-IP throttler bucket
+on `/auth/signup`** and named here so self-hosters cannot miss it.
+
+Express's `app.set('trust proxy', n)` reads the Nth-from-the-right
+value in `X-Forwarded-For` as `req.ip`. Set wrong:
+
+- **Too low** → `req.ip` resolves to an internal proxy; every
+  signup attempt buckets to one IP (fail-united, the entire IP
+  bucket is one shared slot for the whole internet).
+- **Too high** → `req.ip` resolves to whatever the upstream client
+  sent in `X-Forwarded-For`, which a remote attacker controls (the
+  attacker mints arbitrary identities).
+
+| Topology | TRUST_PROXY_HOPS |
+|---|---|
+| Local dev, no proxy | `0` |
+| Fly hosted instance (Fly edge → app) | `1` (default) |
+| Self-host: nginx → app | `1` |
+| Self-host: Cloudflare → nginx → app | `2` |
+| Self-host: Cloudflare → Fly edge → app | `2` |
+| Self-host: ALB → nginx → app | `2` |
+
+Bootstrap validates the value: must be a non-negative integer or
+`app.listen` is preceded by `Error: TRUST_PROXY_HOPS must be a
+non-negative integer; got "loopback"` (or similar). Unset → default
+`1`.
+
+When `FEATURE_SELF_SERVE_SIGNUP=true` (the hosted instance and any
+self-host that opens self-serve signup), this variable becomes
+SECURITY-CRITICAL — the §4 anti-spoof flood test in
+`apps/core-api/test/abuse/signup-flood.e2e.test.ts` asserts the
+bucket behavior assuming a correctly-configured value.
 
 ## Total count
 
@@ -213,7 +249,8 @@ quickly identify what's safe to log.
   Session ×1, OIDC ×2, S3 ×2, SMTP ×2, Redis ×1, SEED ×1)
 - **Future secrets pending ADR implementation:** 2 (Sentry DSN,
   CAPTCHA secret)
-- **Non-secret env vars:** ~18 (listed above)
+- **Non-secret env vars:** ~19 (listed above, including the new
+  `TRUST_PROXY_HOPS` load-bearing config)
 
 ## Maintainer accountability
 


### PR DESCRIPTION
## Summary

- Second of three Round 3 prereq PRs (after #208 audit registry, just merged). Replaces hardcoded `app.set('trust proxy', 1)` with env-driven `app.set('trust proxy', resolveTrustProxyHops(process.env))`
- Default `1` preserves current Fly hosted-instance behavior — no behavior change for production. Self-hosters running behind extra layers (CDN + LB) now have an explicit knob
- Bootstrap fail-fasts on bad values (negative / non-integer / non-numeric) instead of silently passing `NaN` to Express where it gets mis-treated

## Why now

ADR-0020 §4 makes the trust-proxy contract explicit because the §4 per-IP throttler on `/auth/signup` can't be defended without it:

- **Too low** → `req.ip` resolves to an internal proxy; every signup attempt buckets to one IP (fail-united; the per-IP bucket protects nothing)
- **Too high** → `req.ip` resolves to whatever the upstream client put in `X-Forwarded-For`, which a remote attacker controls (mints arbitrary throttler identities)

The §4 anti-spoof flood test (Round 3 prereq 3, next PR) needs this contract in place before it can assert anything meaningful.

## What changed

| File | Change |
|---|---|
| `apps/core-api/src/bootstrap/trust-proxy-hops.ts` (new) | `resolveTrustProxyHops(env)` — returns number, defaults to 1, fail-fasts on invalid input |
| `apps/core-api/src/main.ts` | imports the resolver; replaces literal `1` with `resolveTrustProxyHops(process.env)`; comment refresh pointing at ADR-0020 §4 |
| `apps/core-api/test/trust-proxy-hops.test.ts` (new) | 7 vitest cases — unset, empty, positive int, `0`, negative, decimal, non-numeric strings |
| `docs/runbooks/secrets-inventory.md` | new `TRUST_PROXY_HOPS` subsection under Non-secret config with topology→hop-count table; total-count bumped 18→19 |

## Behavior verification

- `TRUST_PROXY_HOPS` unset → `1` (current production)
- `TRUST_PROXY_HOPS=''` → `1` (treat as unset, common shell quirk)
- `TRUST_PROXY_HOPS=2` → `2` (Cloudflare + Fly self-host topology)
- `TRUST_PROXY_HOPS=0` → `0` (local dev, no proxy)
- `TRUST_PROXY_HOPS=-1` → bootstrap throws `Error: TRUST_PROXY_HOPS must be a non-negative integer; got "-1"`
- `TRUST_PROXY_HOPS=1.5` → bootstrap throws
- `TRUST_PROXY_HOPS=loopback` → bootstrap throws (Express does accept this string but we reject — keep the surface tight)

## Test plan

- [x] `pnpm -F core-api typecheck` clean
- [x] `pnpm -F core-api test trust-proxy-hops` 7/7 pass
- [x] `pnpm -F core-api lint` clean
- [ ] CI passes
- [ ] Manual: smoke staging boots without `TRUST_PROXY_HOPS` set (should resolve to 1, same as before)

## What's NOT in this PR

- Round 3 prereq 3 (per-IPv4/24 + per-(iss,sub) buckets + signup-flood test) — separate PR; relies on this contract being in place
- The signup, verify, delete endpoints themselves — Round 3 main work