### PR TITLE
feat(throttler): Round 3 prereq 3 — subnet-key utility + signup bucket configs (ADR-0020 §4)

### DIFF
--- a/apps/core-api/src/app.module.ts
+++ b/apps/core-api/src/app.module.ts
@@ -86,6 +86,17 @@ const conditionalMaintenance: DynamicModule[] = maintenanceEnabled()
         { name: 'global', ttl: 60_000, limit: 120 },
         { name: 'auth', ttl: 60_000, limit: 10 },
         { name: 'upload', ttl: 60_000, limit: 5 },
+        // Self-serve signup buckets (ADR-0020 §4 first two of three).
+        // Currently declared but not yet decorated on any route — the
+        // signup endpoint (Round 3 main) wires `@Throttle({ signupIp:
+        // ..., signupSubnet: ... })` and a sibling guard handles the
+        // subnet-keyed bucket via `subnetKey(req.ip)` from
+        // shared/throttler/subnet-key.ts. The third §4 bucket
+        // (3/(iss,sub)/24h) is a controller-level Redis check, not
+        // a ThrottlerModule bucket, because it runs post-OIDC-
+        // validation on the callback.
+        { name: 'signupIp', ttl: 3_600_000, limit: 5 },
+        { name: 'signupSubnet', ttl: 86_400_000, limit: 50 },
       ],
       // skipIf is evaluated per-request (NOT per module-load), so
       // existing e2e tests that share a cached AppModule instance

--- a/apps/core-api/src/shared/throttler/subnet-key.ts
+++ b/apps/core-api/src/shared/throttler/subnet-key.ts
@@ -1,0 +1,83 @@
+/**
+ * Subnet-aware IP keying for throttler buckets (ADR-0020 §4 second
+ * bucket: `50 / IPv4-/24 or IPv6-/64 / day`).
+ *
+ * Residential proxy networks rotate IPs per request inside their
+ * pool, but the pool itself clusters in /24 (IPv4) or /64 (IPv6)
+ * ranges. Bucketing by full IP gives an attacker ~1000s of slots
+ * for ~$10/month; bucketing by subnet caps the abuse meaningfully
+ * without punishing legitimate users behind shared CGNAT egress.
+ *
+ * `req.ip` for IPv6 may arrive as the IPv6-mapped IPv4 form
+ * (`::ffff:1.2.3.4`); we normalize to plain IPv4 so the IPv4 /24
+ * mask applies. Invalid/missing input collapses to a single
+ * `'unknown'` bucket — fail-closed (all unparsed traffic shares one
+ * slot rather than each unparsed string getting its own).
+ */
+export function subnetKey(ip: string | undefined | null): string {
+  if (ip === undefined || ip === null || ip === '') {
+    return 'unknown';
+  }
+
+  const v4Mapped = ip.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  const candidate = v4Mapped ? v4Mapped[1]! : ip;
+
+  const v4 = candidate.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.\d{1,3}$/);
+  if (v4) {
+    const [, a, b, c] = v4;
+    const octets = [a, b, c].map((octet) => Number(octet));
+    if (octets.every((n) => Number.isInteger(n) && n >= 0 && n <= 255)) {
+      return `v4:${octets[0]}.${octets[1]}.${octets[2]}.0/24`;
+    }
+    return 'unknown';
+  }
+
+  if (ip.includes(':')) {
+    const v6 = expandIPv6Prefix(ip);
+    if (v6 !== null) {
+      return `v6:${v6}::/64`;
+    }
+  }
+
+  return 'unknown';
+}
+
+/**
+ * Returns the first 4 hextets of an IPv6 address (the /64 prefix),
+ * joined with `:` and unpadded, or null if the input is not a
+ * parseable IPv6 address. Does not implement full RFC 4291
+ * normalization; only what's needed to derive a stable /64 bucket
+ * key. Inputs with zone IDs (e.g., `fe80::1%eth0`) have the zone
+ * stripped before parsing.
+ */
+function expandIPv6Prefix(ip: string): string | null {
+  const withoutZone = ip.split('%')[0]!;
+  if (!/^[0-9a-fA-F:]+$/.test(withoutZone)) {
+    return null;
+  }
+  const doubleColonCount = (withoutZone.match(/::/g) ?? []).length;
+  if (doubleColonCount > 1) {
+    return null;
+  }
+
+  let head: string[];
+  let tail: string[];
+  if (doubleColonCount === 1) {
+    const [headStr, tailStr] = withoutZone.split('::');
+    head = headStr === '' ? [] : headStr!.split(':');
+    tail = tailStr === '' ? [] : tailStr!.split(':');
+  } else {
+    head = withoutZone.split(':');
+    tail = [];
+  }
+
+  const totalGiven = head.length + tail.length;
+  if (totalGiven > 8) return null;
+  const missing = 8 - totalGiven;
+  const expanded = [...head, ...Array<string>(missing).fill('0'), ...tail];
+  if (expanded.length !== 8) return null;
+  if (!expanded.every((h) => /^[0-9a-fA-F]{1,4}$/.test(h))) return null;
+
+  const prefix64 = expanded.slice(0, 4).map((h) => h.toLowerCase().replace(/^0+(?=.)/, ''));
+  return prefix64.join(':');
+}

--- a/apps/core-api/test/subnet-key.test.ts
+++ b/apps/core-api/test/subnet-key.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { subnetKey } from '../src/shared/throttler/subnet-key.js';
+
+describe('subnetKey — IPv4', () => {
+  it('keys distinct IPs in same /24 to the same bucket', () => {
+    expect(subnetKey('203.0.113.5')).toBe('v4:203.0.113.0/24');
+    expect(subnetKey('203.0.113.250')).toBe('v4:203.0.113.0/24');
+    expect(subnetKey('203.0.113.5')).toBe(subnetKey('203.0.113.99'));
+  });
+
+  it('keys distinct /24 ranges to different buckets', () => {
+    expect(subnetKey('203.0.113.5')).not.toBe(subnetKey('203.0.114.5'));
+    expect(subnetKey('10.0.0.1')).not.toBe(subnetKey('10.0.1.1'));
+  });
+
+  it('rejects malformed IPv4 (octets > 255) as unknown', () => {
+    expect(subnetKey('999.0.0.1')).toBe('unknown');
+    expect(subnetKey('256.256.256.256')).toBe('unknown');
+  });
+
+  it('treats loopback as its own bucket (still useful for dev isolation)', () => {
+    expect(subnetKey('127.0.0.1')).toBe('v4:127.0.0.0/24');
+  });
+});
+
+describe('subnetKey — IPv6', () => {
+  it('keys distinct addresses in same /64 to the same bucket', () => {
+    expect(subnetKey('2001:db8:1234:5678::1')).toBe(
+      subnetKey('2001:db8:1234:5678::ffff'),
+    );
+  });
+
+  it('keys distinct /64 ranges to different buckets', () => {
+    expect(subnetKey('2001:db8:1234:5678::1')).not.toBe(
+      subnetKey('2001:db8:1234:9999::1'),
+    );
+  });
+
+  it('handles fully-expanded form', () => {
+    expect(
+      subnetKey('2001:0db8:1234:5678:0000:0000:0000:0001'),
+    ).toBe('v6:2001:db8:1234:5678::/64');
+  });
+
+  it('handles :: at the end', () => {
+    expect(subnetKey('2001:db8:1234:5678::')).toBe('v6:2001:db8:1234:5678::/64');
+  });
+
+  it('handles :: at the start', () => {
+    expect(subnetKey('::1')).toBe('v6:0:0:0:0::/64');
+  });
+
+  it('strips zone ID', () => {
+    expect(subnetKey('fe80::1%eth0')).toBe('v6:fe80:0:0:0::/64');
+  });
+
+  it('rejects too-many double-colons', () => {
+    expect(subnetKey('2001::db8::1')).toBe('unknown');
+  });
+
+  it('rejects too-many hextets', () => {
+    expect(subnetKey('1:2:3:4:5:6:7:8:9')).toBe('unknown');
+  });
+
+  it('rejects non-hex characters', () => {
+    expect(subnetKey('2001:zzzz::1')).toBe('unknown');
+  });
+});
+
+describe('subnetKey — IPv6-mapped IPv4', () => {
+  it('normalizes ::ffff:1.2.3.4 to its IPv4 /24 bucket', () => {
+    expect(subnetKey('::ffff:203.0.113.5')).toBe('v4:203.0.113.0/24');
+    expect(subnetKey('::ffff:203.0.113.5')).toBe(subnetKey('203.0.113.250'));
+  });
+
+  it('is case-insensitive on the ::ffff: prefix', () => {
+    expect(subnetKey('::FFFF:203.0.113.5')).toBe('v4:203.0.113.0/24');
+  });
+});
+
+describe('subnetKey — edge cases', () => {
+  it('returns unknown for undefined / null / empty', () => {
+    expect(subnetKey(undefined)).toBe('unknown');
+    expect(subnetKey(null)).toBe('unknown');
+    expect(subnetKey('')).toBe('unknown');
+  });
+
+  it('returns unknown for garbage strings', () => {
+    expect(subnetKey('not-an-ip')).toBe('unknown');
+    expect(subnetKey('1.2.3')).toBe('unknown');
+  });
+
+  it('collapses all unknown inputs to ONE shared bucket (fail-closed)', () => {
+    expect(subnetKey('garbage1')).toBe(subnetKey('garbage2'));
+    expect(subnetKey('garbage1')).toBe(subnetKey(undefined));
+  });
+});


### PR DESCRIPTION
## Summary

- Third (and final) Round 3 prerequisite PR. Adds the building blocks for the §4 multi-bucket signup throttler — `subnetKey()` pure utility + two new named buckets registered in the ThrottlerModule
- The buckets are **declared but not yet decorated on any route** (same harmless state the existing `auth` bucket was in between registration and first usage). The signup endpoint PR (Round 3 main) wires the `@Throttle` decorators + sibling guard
- Closes the three Round 3 prereqs declared by amended ADR-0020 §§4 + 6

## What's in this PR

| File | Change |
|---|---|
| `apps/core-api/src/shared/throttler/subnet-key.ts` (new) | `subnetKey(ip)` pure function — IPv4 → /24, IPv6 → /64, IPv6-mapped-IPv4 normalized to v4 /24, malformed inputs collapse to shared `'unknown'` bucket (fail-closed) |
| `apps/core-api/test/subnet-key.test.ts` (new) | 18 vitest cases covering IPv4 canonical, IPv6 canonical/compressed/zone-stripped/mapped, malformed inputs, and the fail-closed collapse invariant |
| `apps/core-api/src/app.module.ts` | Two new named buckets in `ThrottlerModule.forRoot`: `signupIp` (5/IP/hour) and `signupSubnet` (50/subnet/day) |

## What's NOT in this PR (by design)

- `@Throttle({ signupIp: ..., signupSubnet: ... })` decorators — only meaningful when the signup endpoint exists
- A `SubnetThrottlerGuard` (or extension to `PerTenantThrottlerGuard`) that calls `subnetKey(req.ip)` for the subnet bucket — designed at use site, where the endpoint's shape determines the right integration
- The third §4 bucket (`3/(iss, sub)/24h`) — runs post-OIDC-validation on the callback, so it's a controller-level Redis check rather than a ThrottlerModule bucket
- The signup-flood e2e test at `apps/core-api/test/abuse/signup-flood.e2e.test.ts` — needs the endpoint to actually flood

## Why "médio" scope (utility + bucket configs, no guard wiring)

Considered three scopes:
1. **Mínimo** — just the subnet-key utility. Endpoint PR does everything else
2. **Médio (this PR)** — utility + bucket configs registered. Endpoint PR adds decorators + guard
3. **Cheio** — utility + buckets + sibling `SubnetThrottlerGuard`. Endpoint PR only adds decorators

Médio is the goldilocks: the throttler infrastructure that's purely declarative (named bucket configs) lands now where it's a one-line addition; the integration design (which guard touches which bucket, how the request flows) defers to the endpoint PR where the use site dictates the shape. Avoids designing-without-use while still front-loading the safe parts.

## Test plan

- [x] `pnpm -F core-api typecheck` clean
- [x] `pnpm -F core-api test subnet-key` 18/18 pass
- [x] `pnpm -F core-api lint` clean
- [ ] CI passes — existing tests should be unaffected because (a) no decorators reference the new buckets and (b) `skipIf` bypass for `NODE_ENV=test` covers all bucket names equally

## Closes Round 3 prereqs

| Prereq | PR | Status |
|---|---|---|
| 1: Audit registry entries | #208 | merged a49ef78 |
| 2: TRUST_PROXY_HOPS env wiring | #209 | merged 992d5ad |
| 3: Subnet-key + signup buckets (this PR) | #210 | open |

After merge, Round 3 main work (signup + verify + delete endpoints + signup-flood test) is unblocked.