### PR TITLE
feat(signup): Round 3 main 1 — self-serve OIDC signup initiate + callback (ADR-0020 §§1-6)

### DIFF
--- a/.runAsSuperAdmin.allowlist.json
+++ b/.runAsSuperAdmin.allowlist.json
@@ -1,15 +1,15 @@
 {
   "_doc": "Allowlist gate for prisma.runAsSuperAdmin call sites. Closes #58 (RLS-CI). Each entry is a file path + the count of CURRENTLY-JUSTIFIED runAsSuperAdmin calls in it + a one-line rationale. The CI script `scripts/check-runAsSuperAdmin-allowlist.ts` compares the actual count against the budget and fails if a file exceeds its budget. Lower the budget when a site migrates to runInTenant; raise only with reviewer sign-off documenting why a tenant-scoped op needs the privileged path.",
   "_review_policy": "Any PR that raises a budget MUST be reviewed by security-reviewer. Lowering a budget is encouraged.",
-  "_last_audit": "2026-04-26 — post Bucket D (#55, #56, #57) RLS migration.",
+  "_last_audit": "2026-05-17 — auth.service.ts bumped 6 → 7 for ADR-0020 §1 resolveOidcUserForSignup (signup find-or-create runs pre-tenant; security-reviewer approved across PR #212's three review passes).",
   "files": {
     "apps/core-api/src/modules/audit/audit.service.ts": {
       "budget": 1,
       "rationale": "AuditService.record() opens its own tx via runAsSuperAdmin so the chain head read can see all tenants. Architectural escape per ADR-0011."
     },
     "apps/core-api/src/modules/auth/auth.service.ts": {
-      "budget": 6,
-      "rationale": "Login flows: identity lookup runs before tenant context exists (the credential IS what selects the tenant)."
+      "budget": 7,
+      "rationale": "Login + signup flows: identity lookup + find-or-create run before tenant context exists (the credential / OIDC subject IS what selects the tenant). Six pre-existing login sites + one ADR-0020 §1 resolveOidcUserForSignup added in PR #212 (security-reviewer approved across three review passes on the diff)."
     },
     "apps/core-api/src/modules/auth/discovery.service.ts": {
       "budget": 1,

--- a/apps/core-api/prisma/migrations/20260516210000_0022_tenant_pending_verification/ROLLBACK.md
+++ b/apps/core-api/prisma/migrations/20260516210000_0022_tenant_pending_verification/ROLLBACK.md
@@ -1,0 +1,70 @@
+# Rollback — 0022 tenant pendingVerification flag
+
+## Pre-flight (operator MUST verify BEFORE running)
+
+This migration adds ONE column to `tenants` (NOT NULL, default `false`).
+Rollback drops the column.
+
+Only roll back if PR 1's signup-callback writer is also reverted — the
+service-layer code in `signup.controller.ts` writes `true` into the
+column for every self-serve tenant, and a column-missing error would
+break every signup attempt while leaving Prisma's typed client in a
+drift state.
+
+## SQL revert (privileged role)
+
+Run from a psql session against `$DATABASE_PRIVILEGED_URL`.
+
+```sql
+ALTER TABLE "tenants"
+    DROP COLUMN "pendingVerification";
+```
+
+## Data-loss warnings
+
+- **Pending tenants become indistinguishable from verified tenants.**
+  Any tenant signed up via the self-serve flow after 0022 was applied
+  but BEFORE rollback loses the marker. If the PR 2 verify-endpoint
+  routes guard ever shipped (it doesn't yet at the time of writing
+  0022), those tenants would silently become "verified" with no audit
+  trail of the bypass.
+
+## When you would actually revert
+
+- The signup-callback writer in `signup.controller.ts` is being
+  rolled back as part of a broader Wave 0.5 revert and the column is
+  now dead schema.
+- The `pendingVerification` flag turns out to be unworkable for the
+  PR 2 verify flow (extremely unlikely — the field shape is the
+  minimal viable surface for a binary verified/unverified gate).
+
+## Re-apply pattern
+
+Forward-only by design. Re-applying after a rollback is a clean
+additive operation; no data backfill needed because the default
+`false` matches every tenant's pre-signup-flow state.
+
+## Schema implications
+
+`schema.prisma` was updated to mirror the new column:
+
+```prisma
+model Tenant {
+  // ...
+  pendingVerification Boolean @default(false)
+}
+```
+
+A revert of THIS migration must also revert that line from
+`schema.prisma` — otherwise `prisma migrate status` will diff
+against the rolled-back DB. The SQL revert block above only handles
+the database side; the schema edit is a separate manual step that
+MUST land in the same commit as the SQL revert.
+
+## Production migration timing
+
+- `ALTER TABLE ADD COLUMN BOOLEAN NOT NULL DEFAULT FALSE` is
+  metadata-only on Postgres 11+ (no row rewrite); takes ACCESS
+  EXCLUSIVE on `tenants` for sub-millisecond. Safe under load.
+- No trigger or function changes.
+- No advisory lock; trivial DDL.

--- a/apps/core-api/prisma/migrations/20260516210000_0022_tenant_pending_verification/migration.sql
+++ b/apps/core-api/prisma/migrations/20260516210000_0022_tenant_pending_verification/migration.sql
@@ -1,0 +1,29 @@
+-- Migration 0022 — Tenant.pendingVerification flag.
+--
+-- ADR-0020 §3 (Email-verification gate) requires that a self-serve
+-- signup provisions the tenant in a `pending_verification` state; the
+-- first login is blocked until the verification token is consumed by
+-- the verify endpoint that lands in PR 2.
+--
+-- This migration adds ONLY the marker column. The route guard that
+-- reads it + the POST /auth/verify flip + the per-email throttle are
+-- scoped to PR 2 (per HANDOFF-2026-05-16-session-end-round-3-prereqs
+-- §"Endpoint PR 2").
+--
+-- Forward-only and additive:
+--   - Default `false` so every existing tenant continues to behave as
+--     a fully-verified tenant. Backfill is implicit (column default).
+--   - NOT NULL because a NULL would create a third state (verified /
+--     pending / unknown) — the signup-callback writer in PR 1 sets
+--     `true`, every other tenant-creation site keeps the default
+--     `false`.
+--   - No RLS surface change; the column inherits the existing
+--     `tenants_*` policies.
+
+ALTER TABLE "tenants"
+    ADD COLUMN "pendingVerification" BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN "tenants"."pendingVerification" IS
+'ADR-0020 §3 — true while the email-verification token minted at '
+'self-serve signup is unconsumed. Self-host tenants and seeded '
+'tenants stay false. PR 2 adds the route guard + flip endpoint.';

--- a/apps/core-api/prisma/migrations/20260516210000_0022_tenant_pending_verification/rls.sql
+++ b/apps/core-api/prisma/migrations/20260516210000_0022_tenant_pending_verification/rls.sql
@@ -1,0 +1,11 @@
+-- Migration 0022 — no RLS surface change.
+--
+-- The new `tenants.pendingVerification` column inherits the existing
+-- `tenants_*` RLS policies from migration 0001 + #41 follow-ups.
+-- Tenant Owners and admins can read it via the same `tenant_id = ...`
+-- filter that gates every other column on the row.
+--
+-- Placeholder kept for grep-greppability of the per-migration RLS
+-- audit pattern.
+
+SELECT 1;

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -104,6 +104,12 @@ model Tenant {
   maintenanceDayInterval               Int       @default(180)
   maintenanceStaleWarningDays          Int       @default(60)
   maintenanceReopenWindowDays          Int       @default(14)
+  /// ADR-0020 §3 — true while the email-verification token minted at
+  /// self-serve signup is unconsumed. Self-host tenants and seeded
+  /// tenants stay false (the createTenantWithOwner call sites that
+  /// existed before signup continue to write the default). PR 2 adds
+  /// the route guard reading this column and the flip endpoint.
+  pendingVerification                  Boolean   @default(false)
   createdAt                            DateTime  @default(now())
   updatedAt                            DateTime  @updatedAt
   deletedAt                            DateTime?

--- a/apps/core-api/src/app.module.ts
+++ b/apps/core-api/src/app.module.ts
@@ -22,6 +22,7 @@ import { MaintenanceModule } from './modules/maintenance/maintenance.module.js';
 import { ReservationModule } from './modules/reservation/reservation.module.js';
 import { SnipeitCompatModule } from './modules/snipeit-compat/snipeit-compat.module.js';
 import { BootAuditModule } from './modules/boot-audit/boot-audit.module.js';
+import { SignupModule } from './modules/signup/signup.module.js';
 
 /**
  * `FEATURE_SNIPEIT_COMPAT_SHIM` (ADR-0010 rollback plan) toggles
@@ -75,6 +76,23 @@ const conditionalMaintenance: DynamicModule[] = maintenanceEnabled()
   ? [{ module: MaintenanceModule, global: false }]
   : [];
 
+/**
+ * `FEATURE_SELF_SERVE_SIGNUP` (ADR-0020) gates SignupModule — the
+ * public-hosted self-serve OIDC signup surface. Default `false`; the
+ * hosted instance enables it. Self-hosters can flip the flag on their
+ * own deployment with the same defense-in-depth (multi-bucket rate
+ * limit, Turnstile CAPTCHA, email-verification gate, audit emissions)
+ * documented in the ADR. Same env-var shape as FEATURE_INSPECTIONS.
+ */
+function selfServeSignupEnabled(): boolean {
+  const raw = (process.env['FEATURE_SELF_SERVE_SIGNUP'] ?? 'false').toLowerCase();
+  return raw !== 'false' && raw !== '0' && raw !== 'no';
+}
+
+const conditionalSelfServeSignup: DynamicModule[] = selfServeSignupEnabled()
+  ? [{ module: SignupModule, global: false }]
+  : [];
+
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -86,17 +104,20 @@ const conditionalMaintenance: DynamicModule[] = maintenanceEnabled()
         { name: 'global', ttl: 60_000, limit: 120 },
         { name: 'auth', ttl: 60_000, limit: 10 },
         { name: 'upload', ttl: 60_000, limit: 5 },
-        // Self-serve signup buckets (ADR-0020 §4 first two of three).
-        // Currently declared but not yet decorated on any route — the
-        // signup endpoint (Round 3 main) wires `@Throttle({ signupIp:
-        // ..., signupSubnet: ... })` and a sibling guard handles the
-        // subnet-keyed bucket via `subnetKey(req.ip)` from
-        // shared/throttler/subnet-key.ts. The third §4 bucket
-        // (3/(iss,sub)/24h) is a controller-level Redis check, not
-        // a ThrottlerModule bucket, because it runs post-OIDC-
-        // validation on the callback.
-        { name: 'signupIp', ttl: 3_600_000, limit: 5 },
-        { name: 'signupSubnet', ttl: 86_400_000, limit: 50 },
+        // Self-serve signup buckets (ADR-0020 §4) are NOT registered
+        // here. PR #210 added `signupIp` + `signupSubnet` named
+        // configs intending to wire them via `@Throttle` decorators,
+        // but the v6 ThrottlerGuard iterates every named throttler
+        // on every route (keyed per-(class, handler, name)) — so
+        // signupIp's 5/hour/IP cap would silently apply to
+        // /auth/login, /reservations, and every other handler.
+        // Opting out would require `@SkipThrottle({signupIp: true,
+        // signupSubnet: true})` on every non-signup controller,
+        // which is brittle. SignupRateLimits
+        // (modules/signup/signup-rate-limits.service.ts) instead
+        // invokes the existing `RateLimiter` service for all three
+        // §4 buckets (ip / subnet / oidc_sub), keeping them scoped
+        // to the signup endpoints by construction.
       ],
       // skipIf is evaluated per-request (NOT per module-load), so
       // existing e2e tests that share a cached AppModule instance
@@ -123,6 +144,7 @@ const conditionalMaintenance: DynamicModule[] = maintenanceEnabled()
     ...conditionalCompatShim,
     ...conditionalInspections,
     ...conditionalMaintenance,
+    ...conditionalSelfServeSignup,
     // BootAuditModule LAST — its OnModuleInit fires after Prisma +
     // Audit + Redis are wired so the boot audits commit cleanly.
     BootAuditModule,

--- a/apps/core-api/src/modules/audit/audit-actions.ts
+++ b/apps/core-api/src/modules/audit/audit-actions.ts
@@ -57,9 +57,9 @@ export const PanoramaAuditAction = {
    *   - `subnet` — 50/IPv4-/24 or IPv6-/64/day (residential proxy)
    *   - `oidc_sub` — 3/(iss, sub)/24h (single-IdP-account abuse)
    *
-   * Metadata: `bucket`, `key` (hashed — do NOT log raw IP or sub),
-   * `attemptIndex` (which attempt in the window tripped), `iss`
-   * (only set when `bucket === 'oidc_sub'`).
+   * Metadata: `bucket`, `keyHash` (sha256 first-16 chars — never
+   * the raw IP / subnet / sub), `iss` (only set when
+   * `bucket === 'oidc_sub'`).
    */
   AuthSignupRateLimitTripped: 'panorama.auth.signup_rate_limit_tripped',
   /**
@@ -88,14 +88,51 @@ export const PanoramaAuditAction = {
    *     signup callback, or vice versa)
    *   - `session_attached` — caller arrived with an existing
    *     authenticated session (signup is logged-out-only)
+   *   - `unknown_provider` — the `:provider` path segment is not
+   *     `google` or `microsoft`, or the provider is not configured
+   *     on this deployment. Carries no real CSRF signal but rides
+   *     the same audit row so the timing-padded refusal has a
+   *     consistent SIEM home.
+   *   - `callback_provider_mismatch` — the path `:provider` differs
+   *     from what the initiating state record locked in (an attacker
+   *     trying to swap providers mid-flow, or a misconfigured client).
+   *   - `idp_error` — the IdP redirected with `?error=...` (RFC 6749
+   *     §4.1.2.1). Operationally distinct from a state CSRF but
+   *     groups under the same SIEM channel for the signup-callback
+   *     refusal aggregate.
    *
    * Metadata: `reason` (one of the above), `stateKeyPrefix` (first
    * 8 chars of the state key — full key is sensitive), `iss` (if
-   * the OIDC callback was reached), `hasSession` (boolean).
+   * the OIDC callback was reached), `hasSession` (boolean),
+   * `idpErrorCode` (sanitized; only set when `reason === 'idp_error'`).
    */
   AuthSignupOidcStateMismatch: 'panorama.auth.signup_oidc_state_mismatch',
 
   // -------- panorama.tenant.* --------
+  /**
+   * Tenant provisioned. Per-tenant event. Fired by every tenant-
+   * creation path: `TenantAdminService.createTenantWithOwner` (the
+   * admin / seed surface) AND the self-serve OIDC signup callback
+   * (ADR-0020 §1). Migrated from a string-literal call site in
+   * `tenant-admin.service.ts` as part of the signup endpoint PR
+   * because the new emit site (signup callback) wants the enum
+   * anyway — the registry's "migrate as touched" policy applies.
+   *
+   * Metadata (varies by call site, common keys documented here):
+   *   - `slug` — Tenant.slug at creation. For self-serve signup
+   *     `slug === tenant.id` (UUID) per ADR-0020 §2a; for admin
+   *     creation it is the operator-supplied human-readable slug.
+   *   - `ownerUserId` — first Owner's user id
+   *   - `ownerMembershipId` — first Owner membership row id
+   *   - `pendingVerification` — true ONLY for self-serve signup
+   *     (ADR-0020 §3); identifies tenants the future verify endpoint
+   *     must unlock before the first login.
+   *   - `provider` — `google` / `microsoft` for signup; absent for
+   *     non-signup paths.
+   *   - `ctaSource` — R5 funnel-signal source on signup; absent for
+   *     non-signup paths.
+   */
+  TenantCreated: 'panorama.tenant.created',
   /**
    * Self-serve signup OIDC flow initiated (ADR-0020 §1). Cluster-
    * wide event (`tenantId=null`) — the tenant does not exist yet.
@@ -137,6 +174,20 @@ export const PanoramaAuditAction = {
    * up product analytics).
    */
   TenantVerified: 'panorama.tenant.verified',
+  /**
+   * Self-serve signup refused because the OIDC identity (or its
+   * email) already maps to an existing Panorama account (ADR-0020
+   * §2 "one tenant per email — initial signup"). Cluster-wide event
+   * (`tenantId=null`). Today, multi-tenant ownership rides through
+   * the existing invitation flow (ADR-0008); signup is reserved for
+   * net-new identities. If `pathTaken !== 'new_user'`, the callback
+   * emits this row and refuses with the standard timing-padded 400.
+   *
+   * Metadata: `pathTaken` (`existing_identity` / `email_link`),
+   * `provider`, `iss`, `subjectHash` (sha256 first-16 chars of
+   * provider:subject).
+   */
+  TenantSignupRefusedExistingAccount: 'panorama.tenant.signup_refused_existing_account',
   /**
    * Per-email verification cap (3 pending verifications per email
    * per 24h, ADR-0020 §3) hit. Cluster-wide event (`tenantId=null`)

--- a/apps/core-api/src/modules/auth/auth.module.ts
+++ b/apps/core-api/src/modules/auth/auth.module.ts
@@ -49,6 +49,7 @@ import { RedisModule } from '../redis/redis.module.js';
   exports: [
     AuthConfigService,
     AuthService,
+    OidcService,
     PasswordService,
     PatMembershipCache,
     PersonalAccessTokenService,

--- a/apps/core-api/src/modules/auth/auth.service.ts
+++ b/apps/core-api/src/modules/auth/auth.service.ts
@@ -383,6 +383,150 @@ export class AuthService {
   }
 
   /**
+   * Resolve an OIDC user-info into a Panorama user without requiring
+   * any active membership (the signup pathway — ADR-0020 §1).
+   *
+   * Reuses the same `evaluateOidcGate` + `find-or-create` resolution
+   * as `loginWithOidc` so the email-verification + workspace-hd
+   * contracts stay identical across login and signup. Differs in:
+   *
+   *   - On gate refusal, records `AuthOidcRefused` (same as login)
+   *     and throws. The signup controller catches and rewrites to
+   *     the timing-padded 400 envelope.
+   *   - On success, does NOT emit `AuthOidcLogin` — signup uses the
+   *     pair `(TenantSignupInitiated, TenantCreated)` as its audit
+   *     trail instead.
+   *   - Returns `{ userId, displayName, pathTaken }`. The caller
+   *     uses these to drive `createTenantWithOwner` (per §1 + §2:
+   *     one tenant per successful signup).
+   *
+   * The closure-internal find-or-create is structurally identical
+   * to `loginWithOidc`'s resolution — duplicated rather than
+   * factored because the audit emission shape diverges (login emits
+   * a success row; signup does not).
+   */
+  async resolveOidcUserForSignup(
+    provider: 'google' | 'microsoft',
+    userInfo: OidcUserInfo,
+    context: { ipAddress?: string | null; userAgent?: string | null } = {},
+  ): Promise<{
+    userId: string;
+    displayName: string;
+    pathTaken: 'existing_identity' | 'email_link' | 'new_user';
+    viaHdOverride: boolean;
+  }> {
+    const email = userInfo.email.toLowerCase().trim();
+    const gate = this.evaluateOidcGate(provider, userInfo, email);
+    if (!gate.ok) {
+      await this.recordOidcRefusal(provider, userInfo, email, gate.reason, context);
+      this.log.warn(
+        {
+          provider,
+          reason: gate.reason,
+          subjectHash: hashSubject(provider, userInfo.subject),
+          emailDomain: emailDomain(email),
+          hd: userInfo.hd,
+        },
+        'signup_oidc_gate_refused',
+      );
+      throw new UnauthorizedException(gate.reason);
+    }
+
+    const allowEmailLink = !gate.viaHdOverride;
+    const displayName =
+      userInfo.displayName?.trim() ||
+      [userInfo.firstName, userInfo.lastName].filter(Boolean).join(' ').trim() ||
+      email;
+
+    const resolution = await this.prisma.runAsSuperAdmin(
+      async (tx) => {
+        const existing = await tx.authIdentity.findUnique({
+          where: { provider_subject: { provider, subject: userInfo.subject } },
+        });
+        if (existing) {
+          await tx.authIdentity.update({
+            where: { id: existing.id },
+            data: { lastUsedAt: new Date(), emailAtLink: email },
+          });
+          return {
+            kind: 'ok' as const,
+            userId: existing.userId,
+            pathTaken: 'existing_identity' as const,
+          };
+        }
+
+        const byEmail = await tx.user.findUnique({ where: { email } });
+        if (byEmail) {
+          if (!allowEmailLink) {
+            return { kind: 'refused' as const };
+          }
+          await tx.authIdentity.create({
+            data: {
+              userId: byEmail.id,
+              provider,
+              subject: userInfo.subject,
+              emailAtLink: email,
+              lastUsedAt: new Date(),
+            },
+          });
+          return {
+            kind: 'ok' as const,
+            userId: byEmail.id,
+            pathTaken: 'email_link' as const,
+          };
+        }
+
+        const created = await tx.user.create({
+          data: {
+            email,
+            displayName,
+            firstName: userInfo.firstName ?? null,
+            lastName: userInfo.lastName ?? null,
+          },
+        });
+        await tx.authIdentity.create({
+          data: {
+            userId: created.id,
+            provider,
+            subject: userInfo.subject,
+            emailAtLink: email,
+            lastUsedAt: new Date(),
+          },
+        });
+        return {
+          kind: 'ok' as const,
+          userId: created.id,
+          pathTaken: 'new_user' as const,
+        };
+      },
+      { reason: 'signup find-or-create oidc identity' },
+    );
+
+    if (resolution.kind === 'refused') {
+      const reason = 'oidc_account_link_requires_verified_email' as const;
+      await this.recordOidcRefusal(provider, userInfo, email, reason, context);
+      this.log.warn(
+        {
+          provider,
+          reason,
+          subjectHash: hashSubject(provider, userInfo.subject),
+          emailDomain: emailDomain(email),
+          hd: userInfo.hd,
+        },
+        'signup_oidc_refused_account_link',
+      );
+      throw new UnauthorizedException(reason);
+    }
+
+    return {
+      userId: resolution.userId,
+      displayName,
+      pathTaken: resolution.pathTaken,
+      viaHdOverride: gate.viaHdOverride,
+    };
+  }
+
+  /**
    * Build a PanoramaSession from a userId. Fails if the user has no
    * active memberships — auth without a tenant isn't useful in Panorama
    * and prevents later code paths from handling a null tenantId.
@@ -392,8 +536,21 @@ export class AuthService {
       async (tx) => {
         const user = await tx.user.findUnique({ where: { id: userId } });
         if (!user) return null;
+        // ADR-0020 §3: tenants in `pendingVerification` are invisible
+        // to the session layer until PR 2's verify endpoint flips the
+        // bit. Without this filter, a user who self-served signup
+        // could open the standard /auth/oidc login flow and receive
+        // a working session on the unverified tenant — bypassing the
+        // §3 "first login is blocked until the verification token is
+        // consumed" contract from the parallel login surface. The
+        // filter applies to BOTH login and signup callers because
+        // `buildSessionForUser` is shared.
         const memberships = await tx.tenantMembership.findMany({
-          where: { userId, status: 'active' },
+          where: {
+            userId,
+            status: 'active',
+            tenant: { pendingVerification: false },
+          },
           include: { tenant: true },
           orderBy: { createdAt: 'asc' },
         });
@@ -404,9 +561,11 @@ export class AuthService {
 
     if (!result || !result.user) throw new UnauthorizedException('user_not_found');
     if (result.memberships.length === 0) {
-      // An account with no active tenant is effectively a pending invitation
-      // state. We refuse the session; the web layer should surface a
-      // "waiting for an admin to invite you" view.
+      // An account with no active VERIFIED tenant is effectively a
+      // pending invitation state (or a pre-verify signup). We refuse
+      // the session; the web layer surfaces a "verify your email" or
+      // "waiting for an admin to invite you" view depending on whether
+      // pending tenants exist for this user.
       throw new UnauthorizedException('no_tenant_memberships');
     }
 

--- a/apps/core-api/src/modules/auth/oidc.service.ts
+++ b/apps/core-api/src/modules/auth/oidc.service.ts
@@ -53,6 +53,24 @@ export interface OidcStartParams {
   provider: 'google' | 'microsoft';
   redirectTo: string;
   tenantHint?: string;
+  /**
+   * Override the IdP-registered redirect_uri for this flow. The login
+   * flow uses the default (`${baseUrl}/auth/oidc/${provider}/callback`);
+   * the self-serve signup flow (ADR-0020) overrides to
+   * `${baseUrl}/auth/signup/${provider}/callback` so the IdP redirects
+   * land on a distinct controller. Self-hosters must register both
+   * redirect_uris with their OIDC provider when enabling
+   * `FEATURE_SELF_SERVE_SIGNUP`.
+   */
+  redirectUri?: string;
+  /**
+   * Override the `state` parameter sent to the IdP. The login flow
+   * uses an in-process `randomState()` paired with the OAuth-state
+   * cookie; the signup flow (ADR-0020 §1a) passes the Redis-backed
+   * `SignupStateStore` key directly so the callback can `GETDEL` it
+   * one-time. Length / encoding is the caller's responsibility.
+   */
+  state?: string;
 }
 
 export interface OidcStartResult {
@@ -186,7 +204,7 @@ export class OidcService {
     } = await loadOidc();
 
     const config = await this.config(params.provider);
-    const state = randomState();
+    const state = params.state ?? randomState();
     const nonce = randomNonce();
     const codeVerifier = randomPKCECodeVerifier();
     const codeChallenge = await calculatePKCECodeChallenge(codeVerifier);
@@ -195,7 +213,7 @@ export class OidcService {
     const scopes = ['openid', 'email', 'profile', ...(providerCfg.extraScopes ?? [])];
 
     const url = buildAuthorizationUrl(config, {
-      redirect_uri: this.redirectUri(params.provider),
+      redirect_uri: params.redirectUri ?? this.redirectUri(params.provider),
       scope: scopes.join(' '),
       state,
       nonce,

--- a/apps/core-api/src/modules/signup/signup-failure.helper.ts
+++ b/apps/core-api/src/modules/signup/signup-failure.helper.ts
@@ -1,0 +1,80 @@
+import { BadRequestException, Logger } from '@nestjs/common';
+import type { Response } from 'express';
+
+const log = new Logger('SignupFailure');
+
+/**
+ * Constant-latency 400 envelope for every signup failure path
+ * (ADR-0020 §5).
+ *
+ * Rate-limit rejection is sub-millisecond (Redis local). Turnstile
+ * verification is 50-300ms (HTTPS to Cloudflare). OIDC token
+ * validation is 100-500ms (HTTPS to Google/Microsoft). An attacker
+ * timing failure paths can distinguish them purely by wall-clock,
+ * defeating §5's no-leak goal — so EVERY failure response is padded
+ * to the configured floor (default 600ms, calibrated to the 95th
+ * percentile success-path latency).
+ *
+ * All failures share:
+ *   - Response envelope `{ error: 'signup_failed' }` (no detail)
+ *   - Status 400 (NOT 429 — 429 would leak the rate-limit's
+ *     existence to an anonymous attacker; this is a deliberate
+ *     deviation from /auth/login which DOES return 429 because the
+ *     audience there is authenticated users for whom 429 carries
+ *     operational value).
+ *   - Same latency floor (padded async, do not block on real work).
+ *
+ * The audit row the controller emits BEFORE calling this helper
+ * still carries the distinct reason (`rate_limit_tripped`,
+ * `captcha_failed`, `oidc_state_mismatch`, ...) so SIEM can
+ * distinguish failure shapes for incident response — the leak is
+ * only closed from the *attacker's* side.
+ *
+ * `respond` is preferred over throwing because Nest's exception
+ * filter writes the response before the awaited delay can elapse;
+ * we set the status + body explicitly and await the timer. The
+ * controller `return`s the awaited result so the request handler
+ * resolves only after the floor has been reached.
+ */
+
+const ENVELOPE = { error: 'signup_failed' } as const;
+
+export async function respondTimingPadded(
+  res: Response,
+  startedAt: number,
+  floorMs: number,
+): Promise<void> {
+  const elapsed = Date.now() - startedAt;
+  const remaining = Math.max(0, floorMs - elapsed);
+  if (remaining > 0) {
+    await new Promise<void>((resolve) => setTimeout(resolve, remaining));
+  }
+  if (res.headersSent) {
+    // Reaching the failure path AFTER headers were already flushed is
+    // an upstream-control-flow bug — most likely a missing `return`
+    // before a fall-through into another respond/redirect, or a
+    // socket-level write from a middleware that bypassed Nest. The
+    // wall-clock floor is moot at this point (the client already saw
+    // a response shape), but the leak it guards against deserves a
+    // loud breadcrumb so an audit-log search lands on the offending
+    // request.
+    log.warn(
+      { elapsedMs: elapsed, floorMs },
+      'signup_failure_after_headers_sent',
+    );
+    return;
+  }
+  res.status(400).json(ENVELOPE);
+}
+
+/**
+ * Throw helper for places where setting the status directly isn't
+ * convenient (validation pipes, decorators that fire pre-response).
+ * The exception filter sees `BadRequestException(ENVELOPE)` and
+ * writes the same shape — though the timing-floor cannot be applied
+ * to a synchronous throw, so prefer `respondTimingPadded` whenever
+ * the failure path runs inside the controller body.
+ */
+export function throwSignupFailed(): never {
+  throw new BadRequestException(ENVELOPE);
+}

--- a/apps/core-api/src/modules/signup/signup-rate-limits.service.ts
+++ b/apps/core-api/src/modules/signup/signup-rate-limits.service.ts
@@ -1,0 +1,87 @@
+import { Injectable } from '@nestjs/common';
+import { createHash } from 'node:crypto';
+import { RateLimiter, type RateLimitDecision } from '../redis/rate-limiter.js';
+import { subnetKey } from '../../shared/throttler/subnet-key.js';
+
+/**
+ * Three-bucket signup rate limiter (ADR-0020 §4).
+ *
+ * | Bucket   | Limit  | Window | Key shape                       | Defeats |
+ * |----------|--------|--------|---------------------------------|---------|
+ * | ip       | 5      | 1h     | `signup:ip:${ip}`               | Loud single-source flooders |
+ * | subnet   | 50     | 24h    | `signup:subnet:${subnetKey(ip)}`| Residential proxy pools (~$10/mo for 1000s of IPs clustering in /24s) |
+ * | oidc_sub | 3      | 24h    | `signup:oidc:${hash(iss:sub)}`  | A single Google/Microsoft account cycling proxies |
+ *
+ * Why service-level instead of @nestjs/throttler named buckets:
+ * `ThrottlerGuard` v6 iterates every named throttler on every route
+ * and uses a per-(class, handler, name) key. The named bucket
+ * `signupIp: 5/hour` would therefore enforce 5/hour ON EVERY OTHER
+ * ROUTE (each as its own key) — capping `/auth/login` at 5/hour,
+ * `/reservations` at 5/hour, and so on. The only way to opt out
+ * is `@SkipThrottle({signupIp: true, signupSubnet: true})` on every
+ * non-signup controller, which is brittle and easy to forget.
+ *
+ * Service-level lets us:
+ *   1. Restrict the buckets to the signup endpoints by construction
+ *      (no rogue route inherits them).
+ *   2. Emit the §6 `AuthSignupRateLimitTripped` audit row with the
+ *      exact `bucket` ('ip' | 'subnet' | 'oidc_sub') that fired —
+ *      `ThrottlerGuard` throws an exception that doesn't carry that
+ *      label cleanly.
+ *   3. Compose the timing-padded 400 envelope (§5) in one place
+ *      rather than overriding `throwThrottlingException`.
+ *
+ * All three buckets share `RateLimiter`'s fail-closed semantics: a
+ * Redis outage returns `{ allowed: false, reason: 'redis_unavailable' }`
+ * and the controller treats it as a refusal. Spec by §4: every
+ * bucket trip rejects the request; downgraded availability does not
+ * downgrade rate-limit enforcement.
+ *
+ * Bucket 3 (`oidc_sub`) is intentionally consumed AFTER id_token
+ * validation in the callback, because `iss` and `sub` aren't known
+ * at request entry. The first two are consumed on the initiate
+ * endpoint, before the OIDC redirect.
+ */
+
+const IP_PREFIX = 'panorama:signup:ip:';
+const IP_LIMIT = 5;
+const IP_WINDOW_MS = 60 * 60 * 1000;
+
+const SUBNET_PREFIX = 'panorama:signup:subnet:';
+const SUBNET_LIMIT = 50;
+const SUBNET_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+const OIDC_PREFIX = 'panorama:signup:oidc:';
+const OIDC_LIMIT = 3;
+const OIDC_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export type SignupBucket = 'ip' | 'subnet' | 'oidc_sub';
+
+@Injectable()
+export class SignupRateLimits {
+  constructor(private readonly limiter: RateLimiter) {}
+
+  consumeIp(ip: string | null | undefined): Promise<RateLimitDecision> {
+    return this.limiter.consume(IP_PREFIX + (ip ?? 'unknown'), IP_LIMIT, IP_WINDOW_MS);
+  }
+
+  consumeSubnet(ip: string | null | undefined): Promise<RateLimitDecision> {
+    return this.limiter.consume(
+      SUBNET_PREFIX + subnetKey(ip ?? ''),
+      SUBNET_LIMIT,
+      SUBNET_WINDOW_MS,
+    );
+  }
+
+  consumeOidcSub(iss: string, sub: string): Promise<RateLimitDecision> {
+    return this.limiter.consume(
+      OIDC_PREFIX + hashIssSub(iss, sub),
+      OIDC_LIMIT,
+      OIDC_WINDOW_MS,
+    );
+  }
+}
+
+function hashIssSub(iss: string, sub: string): string {
+  return createHash('sha256').update(`${iss}:${sub}`).digest('hex');
+}

--- a/apps/core-api/src/modules/signup/signup-state.store.ts
+++ b/apps/core-api/src/modules/signup/signup-state.store.ts
@@ -1,0 +1,131 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { randomBytes } from 'node:crypto';
+import { RedisService } from '../redis/redis.service.js';
+
+/**
+ * Server-side one-time-use signup state record (ADR-0020 §1a).
+ *
+ * Login OIDC state lives in an encrypted cookie (iron-session). Signup
+ * state is Redis-backed — and intentionally so: the CSRF surface on a
+ * signup callback is wider than on a login callback (it binds the IdP
+ * response to a tenant-creation transaction, not to an existing
+ * session), and a leaked SESSION_SECRET would forge a cookie-only
+ * state. A Redis-backed record forces the breach surface up to "DB +
+ * Redis simultaneously," a meaningfully higher bar.
+ *
+ * The Redis key is a 32-byte URL-safe random; the `state=` parameter
+ * sent to the IdP is exactly that key, so a callback lookup is
+ * one round-trip.
+ *
+ * Consume is one-shot via Lua + `DEL` — the same key cannot be
+ * replayed against a second callback. Reasons (`missing`, `expired`,
+ * `wrong_purpose`) are returned as a tagged union so the controller
+ * can emit the §1a `AuthSignupOidcStateMismatch` audit row with the
+ * `reason` field correctly distinguished. Session-attached is checked
+ * at the controller (because it depends on `getRequestSession`),
+ * not here.
+ */
+
+export type SignupCtaSource = 'hosted_button' | 'selfhost_button' | 'direct_url';
+
+export interface SignupStateRecord {
+  purpose: 'signup';
+  provider: 'google' | 'microsoft';
+  redirectTo: string;
+  ctaSource: SignupCtaSource;
+  /** sha256(userAgent) hex — bot-pattern detection without persisting raw UA. */
+  userAgentHash: string | null;
+  /** PKCE code_verifier minted at initiate. */
+  codeVerifier: string;
+  /** OIDC nonce minted at initiate. */
+  nonce: string;
+  /** Unix epoch seconds. */
+  createdAt: number;
+}
+
+export type StateConsumeResult =
+  | { kind: 'ok'; record: SignupStateRecord }
+  | { kind: 'missing' }
+  | { kind: 'wrong_purpose' };
+
+const KEY_PREFIX = 'panorama:signup:state:';
+const TTL_SECONDS = 5 * 60;
+
+@Injectable()
+export class SignupStateStore {
+  private readonly log = new Logger('SignupStateStore');
+
+  constructor(private readonly redis: RedisService) {}
+
+  /**
+   * Generate a fresh URL-safe state key. The caller passes this same
+   * key to `OidcService.start({ state })` (so the `?state=` query
+   * param matches) AND to `set(key, record)` (so the callback
+   * lookup is deterministic). Split from `set` because the
+   * openid-client `start` call must learn the key BEFORE we have
+   * the PKCE verifier + nonce to persist — a single-shot mint would
+   * have to placeholder-write and overwrite, which leaks bookkeeping
+   * into the controller.
+   *
+   * 32 random bytes encoded as URL-safe base64; collision is
+   * negligible.
+   */
+  generateKey(): string {
+    return randomBytes(32).toString('base64url');
+  }
+
+  /**
+   * Persist a signup state record under the given key, 5min TTL.
+   * Used by the controller after it has obtained the PKCE verifier
+   * + nonce from `OidcService.start`. Overwriting an existing key
+   * is OK — keys are 32 random bytes and the only legitimate
+   * overwrite would be the controller's own happy path.
+   */
+  async set(key: string, record: Omit<SignupStateRecord, 'createdAt'>): Promise<void> {
+    const payload: SignupStateRecord = {
+      ...record,
+      createdAt: Math.floor(Date.now() / 1000),
+    };
+    await this.redis.client.set(KEY_PREFIX + key, JSON.stringify(payload), 'EX', TTL_SECONDS);
+  }
+
+  /**
+   * Consume a state key. Returns the record on success and deletes
+   * the key in the same Redis round-trip (atomic via GETDEL). A
+   * second consume on the same key returns `kind: 'missing'`.
+   *
+   * Unparseable Redis payloads are treated as `missing` rather than
+   * thrown — the operational signal is captured in the
+   * `AuthSignupOidcStateMismatch` audit row the controller emits.
+   *
+   * `purpose !== 'signup'` is the confused-deputy defense: a login-
+   * flow state record that somehow ended up at the signup callback
+   * (or vice versa) MUST be refused. We never write non-signup
+   * records to this prefix, so this branch only fires on malicious
+   * cross-flow replay attempts; emit the SIEM signal and discard.
+   */
+  async consume(key: string): Promise<StateConsumeResult> {
+    if (!key || typeof key !== 'string' || key.length === 0) {
+      return { kind: 'missing' };
+    }
+    let raw: string | null = null;
+    try {
+      raw = await this.redis.client.getdel(KEY_PREFIX + key);
+    } catch (err) {
+      this.log.warn({ err: String(err) }, 'signup_state_consume_redis_error');
+      return { kind: 'missing' };
+    }
+    if (raw === null) return { kind: 'missing' };
+    let parsed: SignupStateRecord;
+    try {
+      parsed = JSON.parse(raw) as SignupStateRecord;
+    } catch (err) {
+      this.log.warn({ err: String(err) }, 'signup_state_consume_parse_error');
+      return { kind: 'missing' };
+    }
+    if (parsed.purpose !== 'signup') {
+      return { kind: 'wrong_purpose' };
+    }
+    return { kind: 'ok', record: parsed };
+  }
+}

--- a/apps/core-api/src/modules/signup/signup.config.ts
+++ b/apps/core-api/src/modules/signup/signup.config.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * Self-serve OIDC signup configuration (ADR-0020 §1, §4, §5).
+ *
+ * Read once at boot so the rest of the module doesn't keep poking
+ * `process.env`. The flag itself (`FEATURE_SELF_SERVE_SIGNUP`) gates
+ * registration of `SignupModule` in `app.module.ts`; this service is
+ * only instantiated when the flag is on, so `enabled` would be
+ * tautologically true here. We keep the field anyway because the
+ * boot-audit + signup-flood test both observe it.
+ *
+ * `TURNSTILE_SECRET` is required when the flag is on; bootstrap
+ * refuses to start otherwise so an operator cannot accidentally
+ * deploy a signup endpoint without the CAPTCHA backstop.
+ *
+ * `TURNSTILE_SITE_VERIFY_URL` defaults to Cloudflare's production
+ * endpoint and exists only to redirect to an in-process stub during
+ * e2e tests (mirrors the `OIDC_ALLOW_INSECURE_ISSUER` escape hatch
+ * shape in `auth.config.ts`). Never override in production.
+ */
+export interface SignupConfig {
+  enabled: boolean;
+  turnstileSecret: string;
+  turnstileSiteVerifyUrl: string;
+  /**
+   * Minimum response latency for every failure path (rate-limit trip,
+   * CAPTCHA failure, OIDC refused, state mismatch). ADR-0020 §5 fixes
+   * the floor at 600ms calibrated to the 95th-percentile success
+   * latency. Configurable for tests that need to assert the floor was
+   * applied without paying 600ms per request.
+   */
+  failureLatencyFloorMs: number;
+}
+
+@Injectable()
+export class SignupConfigService {
+  private readonly log = new Logger('SignupConfig');
+  readonly config: SignupConfig;
+
+  constructor() {
+    const enabled = readBoolEnv('FEATURE_SELF_SERVE_SIGNUP', false);
+    const turnstileSecret = process.env['TURNSTILE_SECRET'] ?? '';
+    if (enabled && turnstileSecret.length === 0) {
+      throw new Error(
+        'TURNSTILE_SECRET must be set when FEATURE_SELF_SERVE_SIGNUP=true. ' +
+          'Get one at https://dash.cloudflare.com/?to=/:account/turnstile.',
+      );
+    }
+    const turnstileSiteVerifyUrl =
+      process.env['TURNSTILE_SITE_VERIFY_URL'] ??
+      'https://challenges.cloudflare.com/turnstile/v0/siteverify';
+    const floorRaw = process.env['SIGNUP_FAILURE_LATENCY_FLOOR_MS'];
+    const failureLatencyFloorMs = floorRaw ? Number(floorRaw) : 600;
+    if (!Number.isFinite(failureLatencyFloorMs) || failureLatencyFloorMs < 0) {
+      throw new Error(
+        `SIGNUP_FAILURE_LATENCY_FLOOR_MS must be a non-negative number; got ${JSON.stringify(floorRaw)}`,
+      );
+    }
+    this.config = {
+      enabled,
+      turnstileSecret,
+      turnstileSiteVerifyUrl,
+      failureLatencyFloorMs,
+    };
+    if (enabled) {
+      this.log.log(
+        { failureLatencyFloorMs },
+        'signup_module_enabled',
+      );
+    }
+  }
+}
+
+function readBoolEnv(name: string, defaultValue: boolean): boolean {
+  const raw = (process.env[name] ?? '').toLowerCase();
+  if (raw === '') return defaultValue;
+  return raw !== 'false' && raw !== '0' && raw !== 'no';
+}

--- a/apps/core-api/src/modules/signup/signup.controller.ts
+++ b/apps/core-api/src/modules/signup/signup.controller.ts
@@ -1,0 +1,537 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Logger,
+  Post,
+  Query,
+  Req,
+  Res,
+} from '@nestjs/common';
+import { randomUUID, createHash } from 'node:crypto';
+import type { Request, Response } from 'express';
+import { z } from 'zod';
+import { AuthService } from '../auth/auth.service.js';
+import { AuthConfigService } from '../auth/auth.config.js';
+import { OidcService, type OidcUserInfo } from '../auth/oidc.service.js';
+import { getRequestSession } from '../auth/session.middleware.js';
+import { AuditService } from '../audit/audit.service.js';
+import { PanoramaAuditAction } from '../audit/audit-actions.js';
+import { TenantAdminService } from '../tenant/tenant-admin.service.js';
+import { SignupConfigService } from './signup.config.js';
+import {
+  SignupStateStore,
+  type SignupCtaSource,
+} from './signup-state.store.js';
+import { TurnstileVerifier } from './turnstile-verifier.service.js';
+import { SignupRateLimits } from './signup-rate-limits.service.js';
+import { respondTimingPadded } from './signup-failure.helper.js';
+
+/**
+ * Self-serve OIDC signup endpoints (ADR-0020).
+ *
+ * Wired under `/auth/signup/:provider/{start,callback}` so the IdP
+ * redirect_uri is distinct from the login flow's
+ * `/auth/oidc/:provider/callback`. Self-hosters enabling
+ * `FEATURE_SELF_SERVE_SIGNUP` must register both redirect_uris.
+ *
+ * Per ADR-0020:
+ *   §1   — OIDC-only, no password vector.
+ *   §1a  — `state` is a Redis-backed one-time-use record (NOT a
+ *          signed cookie) with `purpose: 'signup'`; the callback
+ *          rejects missing / wrong-purpose / session-attached.
+ *   §2a  — Tenant.slug = Tenant.id (UUID); no human-readable slug.
+ *   §3   — Tenant is provisioned with `pendingVerification=true`.
+ *          The callback intentionally does NOT establish a session
+ *          — the browser is redirected back to `/?signup=verify`
+ *          and the user is expected to consume the verification
+ *          token (PR 2 surface) before the first login. Creating
+ *          a live session here would let the user access an
+ *          unverified tenant in the window between PR 1 + PR 2
+ *          (security-reviewer block on the §3 contract literal
+ *          reading "first login is blocked until the verification
+ *          token is consumed").
+ *   §4   — Three independent fail-closed buckets (IP + subnet pre-
+ *          OIDC, oidc_sub post-token) via `SignupRateLimits`.
+ *   §5   — Turnstile siteverify with Redis dedupe; constant-latency
+ *          400 envelope on EVERY failure path (rate-limit trip,
+ *          CAPTCHA fail, state mismatch, OIDC refused). Status 400,
+ *          NOT 429 — leaking rate-limit shape to anonymous attackers
+ *          is reconnaissance value, not operational value.
+ *   §6   — Distinct audit actions per failure shape so SIEM can
+ *          alert independently.
+ *
+ * All initiation requests carry the `:provider` path segment and the
+ * form body { ctaSource, captchaToken, ageGateAccepted }. Failures
+ * funnel through `respondTimingPadded` so the wall-clock leak is
+ * closed from the attacker's side (the AUDIT row still carries the
+ * specific failure reason for operator triage).
+ */
+const InitiateBodySchema = z.object({
+  captchaToken: z.string().min(1).max(2048),
+  ctaSource: z.enum(['hosted_button', 'selfhost_button', 'direct_url']),
+  /**
+   * R1 age gate (LGPD Art. 14 self-declaration). The homepage form
+   * MUST set this to `true` before submit; the server treats `false`
+   * / absent as a refusal. No audit row distinguishes age-gate
+   * failure from any other shape — it is a UI gate, not a security
+   * signal.
+   */
+  ageGateAccepted: z.literal(true),
+});
+
+const ProviderSchema = z.enum(['google', 'microsoft']);
+
+@Controller('auth/signup')
+export class SignupController {
+  private readonly log = new Logger('SignupController');
+
+  constructor(
+    private readonly cfg: SignupConfigService,
+    private readonly authCfg: AuthConfigService,
+    private readonly oidc: OidcService,
+    private readonly auth: AuthService,
+    private readonly tenants: TenantAdminService,
+    private readonly stateStore: SignupStateStore,
+    private readonly turnstile: TurnstileVerifier,
+    private readonly limits: SignupRateLimits,
+    private readonly audit: AuditService,
+  ) {}
+
+  @Post(':provider/start')
+  async start(
+    @Body() body: unknown,
+    @Req() req: Request,
+    @Res({ passthrough: false }) res: Response,
+  ): Promise<void> {
+    const startedAt = Date.now();
+
+    // §4 buckets 1 + 2 FIRST — fail-closed. Consumed before any
+    // other audit emission so /auth/signup/garbage/start (or any
+    // other pre-validation failure path) cannot DoS the
+    // `audit:global` advisory lock at high request rates. The
+    // bucket trip is the natural ceiling on `AuthSignupRateLimit-
+    // Tripped` audit-row volume; everything else (state-mismatch,
+    // captcha-failed, etc.) is downstream of these consumes and
+    // therefore upper-bounded by the same budget.
+    const ipDecision = await this.limits.consumeIp(req.ip);
+    if (!ipDecision.allowed) {
+      await this.recordRateLimitTrip('ip', req.ip, null);
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+    const subnetDecision = await this.limits.consumeSubnet(req.ip);
+    if (!subnetDecision.allowed) {
+      await this.recordRateLimitTrip('subnet', req.ip, null);
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+
+    const provider = await this.resolveProvider(req, startedAt, res);
+    if (!provider) return;
+
+    // §1a — signup is logged-out-only. An existing session is a
+    // confused-deputy attempt; emit the audit signal and refuse.
+    if (getRequestSession(req)) {
+      await this.recordStateMismatch('session_attached', null, null);
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+
+    const parsed = InitiateBodySchema.safeParse(body);
+    if (!parsed.success) {
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+
+    // §5 — Turnstile + Redis token dedupe.
+    const turnstile = await this.turnstile.verify(parsed.data.captchaToken, req.ip ?? null);
+    if (!turnstile.ok) {
+      await this.recordCaptchaFailed(turnstile, parsed.data.captchaToken, req);
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+
+    // §1a — generate Redis state key, build the IdP authorize URL
+    // with that key as `?state=`, persist the record with the PKCE
+    // verifier + nonce returned by `OidcService.start`. Order matters:
+    // a failed authorize-URL build never reaches `set`, so a crash
+    // doesn't leave an orphan state row.
+    const stateKey = this.stateStore.generateKey();
+    const { url, codeVerifier, nonce } = await this.oidc.start({
+      provider,
+      redirectTo: '/',
+      redirectUri: `${this.authCfg.config.baseUrl}/auth/signup/${provider}/callback`,
+      state: stateKey,
+    });
+    await this.stateStore.set(stateKey, {
+      purpose: 'signup',
+      provider,
+      redirectTo: '/',
+      ctaSource: parsed.data.ctaSource,
+      userAgentHash: hashUserAgent(req.headers['user-agent'] ?? null),
+      codeVerifier,
+      nonce,
+    });
+
+    await this.recordSignupInitiated({
+      provider,
+      ctaSource: parsed.data.ctaSource,
+      userAgent: req.headers['user-agent'] ?? null,
+      stateKey,
+    });
+
+    res.redirect(302, url);
+  }
+
+  @Get(':provider/callback')
+  async callback(
+    @Query('code') code: string | undefined,
+    @Query('state') stateKey: string | undefined,
+    @Query('error') idpError: string | undefined,
+    @Req() req: Request,
+    @Res({ passthrough: false }) res: Response,
+  ): Promise<void> {
+    const startedAt = Date.now();
+
+    // §4 buckets 1 + 2 FIRST (same rationale as in start()): cap
+    // any pre-state-consume audit-emit flood. The callback handler
+    // is publicly reachable + has multiple paths that emit audit
+    // rows (state mismatch, idp_error, captcha failure cascade if
+    // the IdP somehow loops). Bounding by the per-IP and per-subnet
+    // budgets caps the audit-chain advisory-lock pressure to the
+    // same cap signup-initiate operates under.
+    const ipDecision = await this.limits.consumeIp(req.ip);
+    if (!ipDecision.allowed) {
+      await this.recordRateLimitTrip('ip', req.ip, null);
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+    const subnetDecision = await this.limits.consumeSubnet(req.ip);
+    if (!subnetDecision.allowed) {
+      await this.recordRateLimitTrip('subnet', req.ip, null);
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+
+    const provider = await this.resolveProvider(req, startedAt, res);
+    if (!provider) return;
+
+    // §1a — signup callback is logged-out-only.
+    if (getRequestSession(req)) {
+      await this.recordStateMismatch('session_attached', stateKey ?? null, null);
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+
+    // §1a — consume one-time state. `consume` returns 'missing' for
+    // expired / unknown / already-consumed; 'wrong_purpose' for a
+    // login-flow record that ended up at the signup callback (or
+    // vice versa).
+    const consumed = await this.stateStore.consume(stateKey ?? '');
+    if (consumed.kind === 'missing') {
+      await this.recordStateMismatch('missing', stateKey ?? null, null);
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+    if (consumed.kind === 'wrong_purpose') {
+      await this.recordStateMismatch('wrong_purpose', stateKey ?? null, null);
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+    const record = consumed.record;
+
+    // RFC 6749 §4.1.2.1 — IdP signals refusal via `?error=`. Same
+    // handling as the login callback: log, refuse, never echo the
+    // attacker-influenced free-text into the response body.
+    if (typeof idpError === 'string' && idpError.length > 0) {
+      const safeCode = idpError.slice(0, 64).replace(/[^a-z_-]/gi, '') || 'unknown';
+      this.log.warn({ provider, idp_error: safeCode }, 'signup_oidc_idp_error');
+      await this.recordStateMismatch('idp_error', stateKey ?? null, null, safeCode);
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+    if (!code || !stateKey) {
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+    if (record.provider !== provider) {
+      // The path :provider doesn't match what initiate locked into
+      // the state record. Distinct from a `missing` state (no
+      // record) — emit with `callback_provider_mismatch` so SIEM
+      // can distinguish replay-against-wrong-provider from forged-
+      // state-key replay.
+      await this.recordStateMismatch('callback_provider_mismatch', stateKey, null);
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+
+    // OIDC token exchange. The callbackUrl mirrors the login pattern
+    // (req.originalUrl joined to baseUrl) so openid-client v6 can
+    // extract iss + state + code from the actual inbound URL.
+    const callbackUrl = new URL(req.originalUrl, this.authCfg.config.baseUrl).href;
+    let userInfo: OidcUserInfo;
+    try {
+      userInfo = await this.oidc.callback({
+        provider,
+        callbackUrl,
+        expectedState: stateKey,
+        codeVerifier: record.codeVerifier,
+        expectedNonce: record.nonce,
+      });
+    } catch (err) {
+      // OidcService logs the underlying reason; we surface the
+      // generic 400 envelope. State has already been GETDEL'd so a
+      // retry needs a fresh initiate.
+      this.log.warn({ err: String(err) }, 'signup_oidc_callback_failed');
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+
+    // §4 bucket 3 — post-OIDC. The (iss, sub) tuple is the IdP-stable
+    // identifier we couldn't bucket on at initiate.
+    if (!userInfo.iss) {
+      // RFC 7519 violation — refuse without consuming the bucket.
+      this.log.warn({ provider }, 'signup_callback_missing_iss');
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+    const oidcDecision = await this.limits.consumeOidcSub(userInfo.iss, userInfo.subject);
+    if (!oidcDecision.allowed) {
+      await this.recordRateLimitTrip('oidc_sub', null, userInfo.iss);
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+
+    // §1 — resolve or create the user via OIDC. Mirrors loginWithOidc's
+    // gate (email_verified / workspace-hd override) so signup respects
+    // the same identity-proof contract as login.
+    let resolved: Awaited<ReturnType<AuthService['resolveOidcUserForSignup']>>;
+    try {
+      resolved = await this.auth.resolveOidcUserForSignup(provider, userInfo, {
+        ipAddress: req.ip ?? null,
+        userAgent: req.headers['user-agent'] ?? null,
+      });
+    } catch (err) {
+      this.log.warn({ err: String(err) }, 'signup_oidc_user_resolution_failed');
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+
+    // §2 — one tenant per email (initial signup). If the OIDC
+    // identity already maps to a Panorama account (`existing_identity`)
+    // OR the email matches a pre-existing User row that gets newly
+    // linked (`email_link`), refuse: multi-tenant ownership for
+    // existing accounts rides the invitation flow (ADR-0008), not
+    // signup. Without this check, a single Google account can
+    // mint up to 3 tenants per (iss, sub) per 24h via repeated
+    // signup attempts.
+    if (resolved.pathTaken !== 'new_user') {
+      await this.recordSignupRefusedExisting(provider, userInfo, resolved.pathTaken);
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+
+    // §2 + §2a + §3 — one tenant per successful signup. Tenant.id +
+    // Tenant.slug = freshly-minted UUID (opaque). Tenant ships with
+    // `pendingVerification=true`; PR 2's verify endpoint flips it.
+    const tenantId = randomUUID();
+    const displayName = friendlyDisplayName(resolved.displayName, userInfo.email);
+    try {
+      await this.tenants.createTenantWithOwner({
+        id: tenantId,
+        slug: tenantId,
+        name: displayName,
+        displayName,
+        ownerUserId: resolved.userId,
+        actorUserId: resolved.userId,
+        pendingVerification: true,
+        metadataExtra: {
+          provider,
+          ctaSource: record.ctaSource,
+          oidcPathTaken: resolved.pathTaken,
+          viaHdOverride: resolved.viaHdOverride,
+        },
+      });
+    } catch (err) {
+      this.log.error({ err: String(err) }, 'signup_tenant_create_failed');
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+
+    // §3 — DO NOT establish a session here. The tenant carries
+    // `pendingVerification=true`; PR 2's verify endpoint will consume
+    // the email token + flip the bit + then mint the session. Until
+    // then, the browser must remain logged-out. Redirecting to
+    // `/?signup=verify` lets the homepage frontend show a "check your
+    // email" UI without leaking session state.
+    res.redirect(302, '/?signup=verify');
+  }
+
+  // ---------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------
+
+  /**
+   * Validate the `:provider` path segment and confirm the deployment
+   * has the OIDC client configured. On failure, emit the
+   * `unknown_provider` audit row + the timing-padded 400 envelope —
+   * a synchronous throw here would leak a wall-clock distinction
+   * between "configured but not yet hit a real bucket" vs "rate-
+   * limited" to an anonymous attacker (§5).
+   *
+   * Returns the validated provider on success, or `null` when the
+   * caller should short-circuit (the helper has already written the
+   * timing-padded 400 to `res`).
+   */
+  private async resolveProvider(
+    req: Request,
+    startedAt: number,
+    res: Response,
+  ): Promise<'google' | 'microsoft' | null> {
+    const raw = (req.params as { provider?: string })?.provider ?? '';
+    const parsed = ProviderSchema.safeParse(raw);
+    if (!parsed.success || !this.authCfg.hasProvider(parsed.data)) {
+      await this.recordStateMismatch('unknown_provider', null, null);
+      await respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+      return null;
+    }
+    return parsed.data;
+  }
+
+  // --- audit emission ---------------------------------------------------
+
+  private async recordSignupInitiated(opts: {
+    provider: 'google' | 'microsoft';
+    ctaSource: SignupCtaSource;
+    userAgent: string | null;
+    stateKey: string;
+  }): Promise<void> {
+    try {
+      await this.audit.record({
+        action: PanoramaAuditAction.TenantSignupInitiated,
+        resourceType: 'tenant',
+        resourceId: null,
+        tenantId: null,
+        actorUserId: null,
+        metadata: {
+          provider: opts.provider,
+          ctaSource: opts.ctaSource,
+          userAgentHash: hashUserAgent(opts.userAgent),
+          stateKeyPrefix: opts.stateKey.slice(0, 8),
+        },
+      });
+    } catch (err) {
+      this.log.error({ err: String(err) }, 'signup_initiated_audit_write_failed');
+    }
+  }
+
+  private async recordStateMismatch(
+    reason:
+      | 'missing'
+      | 'wrong_purpose'
+      | 'session_attached'
+      | 'unknown_provider'
+      | 'callback_provider_mismatch'
+      | 'idp_error',
+    stateKey: string | null,
+    iss: string | null,
+    idpErrorCode?: string,
+  ): Promise<void> {
+    try {
+      const metadata: Record<string, unknown> = {
+        reason,
+        stateKeyPrefix: stateKey ? stateKey.slice(0, 8) : null,
+        iss,
+        hasSession: reason === 'session_attached',
+      };
+      if (idpErrorCode !== undefined) metadata['idpErrorCode'] = idpErrorCode;
+      await this.audit.record({
+        action: PanoramaAuditAction.AuthSignupOidcStateMismatch,
+        resourceType: 'auth_identity',
+        resourceId: null,
+        tenantId: null,
+        actorUserId: null,
+        metadata,
+      });
+    } catch (err) {
+      this.log.error({ err: String(err) }, 'signup_state_mismatch_audit_write_failed');
+    }
+  }
+
+  private async recordSignupRefusedExisting(
+    provider: 'google' | 'microsoft',
+    userInfo: OidcUserInfo,
+    pathTaken: 'existing_identity' | 'email_link',
+  ): Promise<void> {
+    try {
+      await this.audit.record({
+        action: PanoramaAuditAction.TenantSignupRefusedExistingAccount,
+        resourceType: 'auth_identity',
+        resourceId: null,
+        tenantId: null,
+        actorUserId: null,
+        metadata: {
+          pathTaken,
+          provider,
+          iss: userInfo.iss,
+          subjectHash: createHash('sha256')
+            .update(`${provider}:${userInfo.subject}`)
+            .digest('hex')
+            .slice(0, 16),
+        },
+      });
+    } catch (err) {
+      this.log.error({ err: String(err) }, 'signup_refused_existing_audit_write_failed');
+    }
+  }
+
+  private async recordRateLimitTrip(
+    bucket: 'ip' | 'subnet' | 'oidc_sub',
+    ip: string | null | undefined,
+    iss: string | null,
+  ): Promise<void> {
+    try {
+      const keyMaterial =
+        bucket === 'ip' ? (ip ?? 'unknown') : bucket === 'subnet' ? (ip ?? 'unknown') : (iss ?? 'unknown');
+      const metadata: Record<string, unknown> = {
+        bucket,
+        keyHash: createHash('sha256').update(keyMaterial).digest('hex').slice(0, 16),
+      };
+      if (bucket === 'oidc_sub' && iss) metadata['iss'] = iss;
+      await this.audit.record({
+        action: PanoramaAuditAction.AuthSignupRateLimitTripped,
+        resourceType: 'auth_identity',
+        resourceId: null,
+        tenantId: null,
+        actorUserId: null,
+        metadata,
+      });
+    } catch (err) {
+      this.log.error({ err: String(err) }, 'signup_rate_limit_audit_write_failed');
+    }
+  }
+
+  private async recordCaptchaFailed(
+    result: { ok: false; reason: string; siteverifyErrorCodes?: string[] },
+    token: string,
+    req: Request,
+  ): Promise<void> {
+    try {
+      await this.audit.record({
+        action: PanoramaAuditAction.AuthCaptchaFailed,
+        resourceType: 'auth_identity',
+        resourceId: null,
+        tenantId: null,
+        actorUserId: null,
+        ipAddress: req.ip ?? null,
+        userAgent: req.headers['user-agent'] ?? null,
+        metadata: {
+          reason: result.reason,
+          siteverifyErrorCodes: result.siteverifyErrorCodes ?? [],
+          hostname: req.headers['host'] ?? null,
+          tokenSha256: createHash('sha256').update(token).digest('hex'),
+        },
+      });
+    } catch (err) {
+      this.log.error({ err: String(err) }, 'signup_captcha_failed_audit_write_failed');
+    }
+  }
+}
+
+function hashUserAgent(userAgent: string | null): string | null {
+  if (!userAgent) return null;
+  return createHash('sha256').update(userAgent).digest('hex');
+}
+
+function friendlyDisplayName(resolvedName: string, email: string): string {
+  // OIDC `name` claim is usually the user's full name and works as
+  // both Tenant.name and Tenant.displayName for a one-person org. If
+  // the IdP didn't send a name (rare), fall back to the local-part
+  // of the email so the tenant has SOMETHING readable in the UI.
+  const trimmed = resolvedName.trim();
+  if (trimmed.length > 0 && !trimmed.includes('@')) return trimmed;
+  const at = email.indexOf('@');
+  return at > 0 ? email.slice(0, at) : email;
+}

--- a/apps/core-api/src/modules/signup/signup.controller.ts
+++ b/apps/core-api/src/modules/signup/signup.controller.ts
@@ -181,13 +181,22 @@ export class SignupController {
 
   @Get(':provider/callback')
   async callback(
-    @Query('code') code: string | undefined,
-    @Query('state') stateKey: string | undefined,
-    @Query('error') idpError: string | undefined,
+    @Query('code') rawCode: unknown,
+    @Query('state') rawState: unknown,
+    @Query('error') rawIdpError: unknown,
     @Req() req: Request,
     @Res({ passthrough: false }) res: Response,
   ): Promise<void> {
     const startedAt = Date.now();
+    // Express parses duplicate query params into arrays; the @Query
+    // decorator's `string | undefined` type is a TS convenience but
+    // does NOT enforce shape at runtime. CodeQL flagged the raw
+    // values reaching `.slice(...)` as type-confusion. Narrow to
+    // strings at the boundary so every downstream consumer sees the
+    // shape it expects.
+    const code = typeof rawCode === 'string' ? rawCode : null;
+    const stateKey = typeof rawState === 'string' ? rawState : null;
+    const idpError = typeof rawIdpError === 'string' ? rawIdpError : null;
 
     // §4 buckets 1 + 2 FIRST (same rationale as in start()): cap
     // any pre-state-consume audit-emit flood. The callback handler
@@ -212,7 +221,7 @@ export class SignupController {
 
     // §1a — signup callback is logged-out-only.
     if (getRequestSession(req)) {
-      await this.recordStateMismatch('session_attached', stateKey ?? null, null);
+      await this.recordStateMismatch('session_attached', stateKey, null);
       return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
     }
 
@@ -222,11 +231,11 @@ export class SignupController {
     // vice versa).
     const consumed = await this.stateStore.consume(stateKey ?? '');
     if (consumed.kind === 'missing') {
-      await this.recordStateMismatch('missing', stateKey ?? null, null);
+      await this.recordStateMismatch('missing', stateKey, null);
       return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
     }
     if (consumed.kind === 'wrong_purpose') {
-      await this.recordStateMismatch('wrong_purpose', stateKey ?? null, null);
+      await this.recordStateMismatch('wrong_purpose', stateKey, null);
       return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
     }
     const record = consumed.record;
@@ -237,7 +246,7 @@ export class SignupController {
     if (typeof idpError === 'string' && idpError.length > 0) {
       const safeCode = idpError.slice(0, 64).replace(/[^a-z_-]/gi, '') || 'unknown';
       this.log.warn({ provider, idp_error: safeCode }, 'signup_oidc_idp_error');
-      await this.recordStateMismatch('idp_error', stateKey ?? null, null, safeCode);
+      await this.recordStateMismatch('idp_error', stateKey, null, safeCode);
       return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
     }
     if (!code || !stateKey) {

--- a/apps/core-api/src/modules/signup/signup.module.ts
+++ b/apps/core-api/src/modules/signup/signup.module.ts
@@ -1,0 +1,32 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module.js';
+import { TenantModule } from '../tenant/tenant.module.js';
+import { SignupConfigService } from './signup.config.js';
+import { SignupController } from './signup.controller.js';
+import { SignupStateStore } from './signup-state.store.js';
+import { SignupRateLimits } from './signup-rate-limits.service.js';
+import { TurnstileVerifier } from './turnstile-verifier.service.js';
+
+/**
+ * Self-serve OIDC signup endpoints (ADR-0020). Loaded conditionally
+ * at app boot when `FEATURE_SELF_SERVE_SIGNUP=true` (gated in
+ * `app.module.ts`). Default off so a self-hoster who upgrades
+ * Panorama doesn't accidentally open a public signup surface; the
+ * hosted instance flips the flag.
+ *
+ * Imports:
+ *   - AuthModule (forwardRef) — needs `OidcService`,
+ *     `AuthService.resolveOidcUserForSignup`, `SessionService`,
+ *     `AuthConfigService` for the OIDC dance.
+ *   - TenantModule — needs `TenantAdminService.createTenantWithOwner`
+ *     to provision the new tenant atomically with the Owner
+ *     membership + audit row.
+ *   - RedisModule + AuditModule are @Global so they ride in
+ *     automatically.
+ */
+@Module({
+  imports: [forwardRef(() => AuthModule), TenantModule],
+  controllers: [SignupController],
+  providers: [SignupConfigService, SignupStateStore, SignupRateLimits, TurnstileVerifier],
+})
+export class SignupModule {}

--- a/apps/core-api/src/modules/signup/turnstile-verifier.service.ts
+++ b/apps/core-api/src/modules/signup/turnstile-verifier.service.ts
@@ -1,0 +1,148 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { createHash } from 'node:crypto';
+import { RedisService } from '../redis/redis.service.js';
+import { SignupConfigService } from './signup.config.js';
+
+/**
+ * Cloudflare Turnstile siteverify wrapper (ADR-0020 §5).
+ *
+ * The verified token result is Redis-keyed for 5 minutes per R3 to
+ * prevent the double-submit race where two signup requests share one
+ * valid token. The verifier returns:
+ *
+ *   - { ok: true } when siteverify replies `success: true` and Redis
+ *     accepts the dedupe insert (NX).
+ *   - { ok: false, reason: 'already_used' } when the same token has
+ *     already been consumed within the dedupe window — this is the
+ *     R3 defence; the controller emits AuthCaptchaFailed with the
+ *     `already_used` reason for SIEM correlation.
+ *   - { ok: false, reason: 'siteverify_failed', siteverifyErrorCodes }
+ *     when Cloudflare's API returns success=false. Codes are
+ *     forwarded to the audit row for operator triage (e.g.
+ *     `invalid-input-response` vs `bad-request`).
+ *   - { ok: false, reason: 'network_error' } on fetch failure /
+ *     timeout. Fail-closed (the controller treats this as a refusal).
+ *
+ * Tokens are sha256-hashed before persisting as dedupe keys — the
+ * raw token is short-lived but we still keep it out of Redis logs.
+ */
+
+export type TurnstileResult =
+  | { ok: true }
+  | { ok: false; reason: 'already_used' }
+  | { ok: false; reason: 'siteverify_failed'; siteverifyErrorCodes: string[] }
+  | { ok: false; reason: 'network_error' };
+
+interface TurnstileSiteverifyResponse {
+  success: boolean;
+  'error-codes'?: string[];
+  hostname?: string;
+}
+
+const DEDUPE_PREFIX = 'panorama:signup:turnstile:';
+const DEDUPE_TTL_SECONDS = 5 * 60;
+const FETCH_TIMEOUT_MS = 5_000;
+
+@Injectable()
+export class TurnstileVerifier {
+  private readonly log = new Logger('TurnstileVerifier');
+
+  constructor(
+    private readonly cfg: SignupConfigService,
+    private readonly redis: RedisService,
+  ) {}
+
+  async verify(token: string, remoteIp: string | null): Promise<TurnstileResult> {
+    if (!token || typeof token !== 'string' || token.length === 0) {
+      return {
+        ok: false,
+        reason: 'siteverify_failed',
+        siteverifyErrorCodes: ['missing-input-response'],
+      };
+    }
+
+    const tokenHash = sha256Hex(token);
+    const dedupeKey = DEDUPE_PREFIX + tokenHash;
+    let dedupeAccepted = false;
+    try {
+      // NX + EX in one round-trip: only the first request to present
+      // the token wins; subsequent attempts within the window return
+      // 'already_used'.
+      const result = await this.redis.client.set(
+        dedupeKey,
+        '1',
+        'EX',
+        DEDUPE_TTL_SECONDS,
+        'NX',
+      );
+      dedupeAccepted = result === 'OK';
+    } catch (err) {
+      this.log.warn({ err: String(err) }, 'turnstile_dedupe_redis_error');
+      // Fail-closed: an unreachable Redis means we cannot enforce
+      // single-use, which downgrades the §5 R3 guarantee. Reject
+      // with the network_error reason so the controller treats it
+      // as a refusal.
+      return { ok: false, reason: 'network_error' };
+    }
+    if (!dedupeAccepted) {
+      return { ok: false, reason: 'already_used' };
+    }
+
+    const body = new URLSearchParams();
+    body.set('secret', this.cfg.config.turnstileSecret);
+    body.set('response', token);
+    if (remoteIp) body.set('remoteip', remoteIp);
+
+    let response: Response;
+    try {
+      response = await fetch(this.cfg.config.turnstileSiteVerifyUrl, {
+        method: 'POST',
+        body,
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+    } catch (err) {
+      this.log.warn({ err: String(err) }, 'turnstile_fetch_failed');
+      // Release the dedupe slot so a retried genuine user isn't
+      // locked out by a transient network blip. Best-effort.
+      void this.releaseDedupe(dedupeKey);
+      return { ok: false, reason: 'network_error' };
+    }
+    if (!response.ok) {
+      this.log.warn(
+        { status: response.status },
+        'turnstile_siteverify_http_error',
+      );
+      void this.releaseDedupe(dedupeKey);
+      return { ok: false, reason: 'network_error' };
+    }
+    let parsed: TurnstileSiteverifyResponse;
+    try {
+      parsed = (await response.json()) as TurnstileSiteverifyResponse;
+    } catch (err) {
+      this.log.warn({ err: String(err) }, 'turnstile_siteverify_parse_error');
+      void this.releaseDedupe(dedupeKey);
+      return { ok: false, reason: 'network_error' };
+    }
+    if (!parsed.success) {
+      const codes = Array.isArray(parsed['error-codes']) ? parsed['error-codes'] : [];
+      return {
+        ok: false,
+        reason: 'siteverify_failed',
+        siteverifyErrorCodes: codes,
+      };
+    }
+    return { ok: true };
+  }
+
+  private async releaseDedupe(dedupeKey: string): Promise<void> {
+    try {
+      await this.redis.client.del(dedupeKey);
+    } catch (err) {
+      this.log.debug({ err: String(err) }, 'turnstile_dedupe_release_failed');
+    }
+  }
+}
+
+function sha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}

--- a/apps/core-api/src/modules/tenant/tenant-admin.service.ts
+++ b/apps/core-api/src/modules/tenant/tenant-admin.service.ts
@@ -9,6 +9,7 @@ import {
 import { Prisma, type TenantMembership, type Tenant } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { AuditService } from '../audit/audit.service.js';
+import { PanoramaAuditAction } from '../audit/audit-actions.js';
 import { PatMembershipCache } from '../auth/pat-membership-cache.service.js';
 
 /**
@@ -42,12 +43,33 @@ export const MEMBERSHIP_STATUSES = ['active', 'invited', 'suspended'] as const;
 export type MembershipStatus = (typeof MEMBERSHIP_STATUSES)[number];
 
 export interface CreateTenantWithOwnerParams {
+  /**
+   * Optional explicit Tenant.id. Self-serve signup (ADR-0020 §2a)
+   * passes a freshly-minted UUID here AND as `slug` so the URL slug
+   * is opaque + unguessable. Admin / seed surfaces leave this
+   * undefined and let Prisma default to a fresh UUID.
+   */
+  id?: string;
   slug: string;
   name: string;
   displayName: string;
   locale?: string;
   timezone?: string;
   allowedEmailDomains?: string[];
+  /**
+   * ADR-0020 §3 — true ONLY for self-serve OIDC signup. The PR 2
+   * verify endpoint flips this back to false on token consume. Admin
+   * + seed surfaces default to false (verified at creation).
+   */
+  pendingVerification?: boolean;
+  /**
+   * Extra fields merged into the audit metadata for the
+   * `panorama.tenant.created` row. Signup passes `{ provider,
+   * ctaSource }` so the audit row carries the funnel-signal source
+   * (R5) and the IdP that minted the identity. Admin surfaces leave
+   * this undefined and the audit row carries only the default keys.
+   */
+  metadataExtra?: Record<string, unknown>;
   ownerUserId: string;
   /** Who triggered the creation — populated in the audit row. */
   actorUserId?: string | null;
@@ -114,7 +136,9 @@ export class TenantAdminService {
           timezone: params.timezone ?? 'UTC',
           allowedEmailDomains: params.allowedEmailDomains ?? [],
           systemActorUserId: systemUser.id,
+          pendingVerification: params.pendingVerification ?? false,
         };
+        if (params.id !== undefined) tenantData.id = params.id;
         const tenant = await tx.tenant.create({ data: tenantData });
         await tx.tenantMembership.create({
           data: {
@@ -136,15 +160,25 @@ export class TenantAdminService {
         });
 
         await this.audit.recordWithin(tx, {
-          action: 'panorama.tenant.created',
+          action: PanoramaAuditAction.TenantCreated,
           resourceType: 'tenant',
           resourceId: tenant.id,
           tenantId: tenant.id,
           actorUserId: params.actorUserId ?? params.ownerUserId,
+          // metadataExtra is spread FIRST so canonical keys (slug /
+          // ownerUserId / ownerMembershipId / pendingVerification)
+          // cannot be clobbered by a misshapen caller. The signup
+          // controller is the only metadataExtra source today
+          // ({ provider, ctaSource, oidcPathTaken, viaHdOverride }),
+          // and none of those collide — but this ordering is the
+          // defensive default rather than an emergent property of
+          // the current call sites.
           metadata: {
+            ...(params.metadataExtra ?? {}),
             slug: tenant.slug,
             ownerUserId: params.ownerUserId,
             ownerMembershipId: ownerMembership.id,
+            pendingVerification: params.pendingVerification ?? false,
           },
         });
 

--- a/apps/core-api/test/_setup.ts
+++ b/apps/core-api/test/_setup.ts
@@ -20,6 +20,16 @@ if (!process.env['FEATURE_INSPECTIONS']) {
 if (!process.env['FEATURE_MAINTENANCE']) {
   process.env['FEATURE_MAINTENANCE'] = 'true';
 }
+if (!process.env['FEATURE_SELF_SERVE_SIGNUP']) {
+  process.env['FEATURE_SELF_SERVE_SIGNUP'] = 'true';
+}
+// SignupConfigService throws if TURNSTILE_SECRET is empty while
+// FEATURE_SELF_SERVE_SIGNUP=true. Tests mock TurnstileVerifier so
+// the secret value itself is never sent anywhere; this exists only
+// to clear the boot-time guard.
+if (!process.env['TURNSTILE_SECRET']) {
+  process.env['TURNSTILE_SECRET'] = 'test-turnstile-secret';
+}
 if (!process.env['SESSION_SECRET']) {
   process.env['SESSION_SECRET'] = 'a'.repeat(32);
 }

--- a/apps/core-api/test/abuse/signup-flood.e2e.test.ts
+++ b/apps/core-api/test/abuse/signup-flood.e2e.test.ts
@@ -1,0 +1,397 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Test } from '@nestjs/testing';
+import { ValidationPipe } from '@nestjs/common';
+import type { INestApplication } from '@nestjs/common';
+import type { NestExpressApplication } from '@nestjs/platform-express';
+import { PrismaClient, type AuditEvent } from '@prisma/client';
+import { Redis } from 'ioredis';
+import { AppModule } from '../../src/app.module.js';
+import { OidcService, type OidcUserInfo } from '../../src/modules/auth/oidc.service.js';
+import { TurnstileVerifier } from '../../src/modules/signup/turnstile-verifier.service.js';
+import { resetTestDb } from '../_reset-db.js';
+
+/**
+ * Synthetic-flood test (Wave 0 Round 3, ADR-0020 §4 three-bucket
+ * contract + the §4 anti-spoof assertion). Sibling of the
+ * `login-flood.e2e.test.ts` introduced in Round 2.
+ *
+ * The three §4 buckets are all enforced service-level via
+ * `SignupRateLimits` (modules/signup/signup-rate-limits.service.ts),
+ * so this test exercises them by hitting `/auth/signup/google/start`
+ * + `/auth/signup/google/callback` enough times to trip each one in
+ * isolation. To keep the buckets from cross-contaminating:
+ *
+ *   - The `ip` bucket test uses XFF `10.0.0.1`.
+ *   - The `subnet` bucket test uses XFFs `11.0.0.0`..`11.0.0.50` (a
+ *     different /24 from the ip-bucket test so the 5 attempts above
+ *     don't leak into the 50-slot subnet budget).
+ *   - The `oidc_sub` bucket test uses XFF `12.0.0.1` so its 4 attempts
+ *     don't share ip or subnet keys with the earlier tests.
+ *
+ * Anti-spoof (the rightmost assertion in the handoff) runs in a
+ * SEPARATE describe with `trust proxy 0`: forging
+ * `X-Forwarded-For: 1.2.3.4` against a trust-proxy-0 server has no
+ * effect — `req.ip` stays on the socket address. That matches the
+ * self-host-without-edge contract documented in
+ * `docs/runbooks/secrets-inventory.md`.
+ *
+ * `OidcService` is mocked so callback responses don't require a real
+ * IdP. `TurnstileVerifier` is mocked so the test doesn't reach
+ * Cloudflare. Both overrides are provider-scoped via the testing
+ * module so the rest of the SignupController flow runs unmocked
+ * (state store, audit, tenant creation).
+ */
+
+const HOST = process.env['PG_HOST'] ?? 'localhost';
+const PORT = process.env['PG_PORT'] ?? '5432';
+const DB = process.env['PG_DB'] ?? 'panorama';
+const ADMIN_URL = `postgres://panorama_super_admin:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+const APP_URL = `postgres://panorama_app:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+const REDIS_URL = process.env['REDIS_URL'] ?? 'redis://localhost:6379/0';
+
+const SYNTHETIC_GOOGLE_ISSUER = 'https://accounts.google.invalid';
+
+interface SignupTestApp {
+  app: INestApplication;
+  url: string;
+  oidcCallback: ReturnType<typeof makeOidcCallbackMock>;
+}
+
+describe('abuse: signup flood (Wave 0 Round 3)', () => {
+  let suite: SignupTestApp;
+  let redis: Redis;
+
+  beforeAll(async () => {
+    process.env['SESSION_SECRET'] = process.env['SESSION_SECRET'] ?? 'a'.repeat(32);
+    process.env['DATABASE_URL'] = APP_URL;
+    process.env['FEATURE_SELF_SERVE_SIGNUP'] = 'true';
+    process.env['TURNSTILE_SECRET'] = 'test-secret';
+    process.env['SIGNUP_FAILURE_LATENCY_FLOOR_MS'] = '20';
+    process.env['OIDC_GOOGLE_CLIENT_ID'] = 'test-google-client';
+    process.env['OIDC_GOOGLE_CLIENT_SECRET'] = 'test-google-secret';
+    // SignupController.start composes redirect_uri from APP_BASE_URL;
+    // anything resolvable is fine since we mock OidcService.start.
+    process.env['APP_BASE_URL'] = process.env['APP_BASE_URL'] ?? 'http://localhost:4000';
+
+    const admin = new PrismaClient({ datasources: { db: { url: ADMIN_URL } } });
+    await resetTestDb(admin);
+    await admin.$disconnect();
+
+    redis = new Redis(REDIS_URL);
+    await flushSignupKeys(redis);
+
+    suite = await buildSignupTestApp({ trustProxy: 1 });
+  }, 60_000);
+
+  afterAll(async () => {
+    await suite?.app.close();
+    await redis?.quit();
+    delete process.env['FEATURE_SELF_SERVE_SIGNUP'];
+  });
+
+  beforeEach(async () => {
+    // Each test uses distinct IP families, but Redis state survives
+    // process restarts; wipe between tests so a flaky earlier test
+    // doesn't leak slots into the next one.
+    await flushSignupKeys(redis);
+    // Reset OidcService.callback's per-test counter / iss/sub
+    // expectations.
+    suite.oidcCallback.reset();
+  });
+
+  it('ip bucket (5 / IP / hour) trips on the 6th start from one IP', async () => {
+    const xff = '10.0.0.1';
+    const statuses = await rapidStarts(suite.url, 6, xff);
+
+    // First 5 redirect to the IdP (mocked OidcService URL). The 6th
+    // trips signupIp and returns the timing-padded 400.
+    expect(statuses.slice(0, 5).every((s) => s === 302)).toBe(true);
+    expect(statuses[5]).toBe(400);
+  });
+
+  it('subnet bucket (50 / /24 / 24h) trips on the 51st start across distinct IPs in same /24', async () => {
+    // 51 attempts, each from a distinct IP in 11.0.0.0/24. Per-IP
+    // bucket never trips (each IP gets 1 hit out of its 5/hour budget),
+    // but the shared subnet bucket fills at attempt 50 and trips on 51.
+    const statuses: number[] = [];
+    for (let i = 0; i < 51; i++) {
+      statuses.push(...(await rapidStarts(suite.url, 1, `11.0.0.${i}`)));
+    }
+
+    expect(statuses.slice(0, 50).every((s) => s === 302)).toBe(true);
+    expect(statuses[50]).toBe(400);
+  });
+
+  it('unknown_provider audit emit is bounded by the ip bucket (rate-limit BEFORE resolveProvider)', async () => {
+    // Regression for the BL-NEW-1 audit-DoS amplifier surfaced by
+    // security-reviewer 2nd pass. If a future refactor moves
+    // resolveProvider above consumeIp, every garbage-provider POST
+    // would emit one AuthSignupOidcStateMismatch(unknown_provider)
+    // audit row + grab the audit:global advisory lock, with no
+    // per-IP ceiling. The reorder caps it at the ip bucket: ~5
+    // unknown_provider rows from one IP before AuthSignupRateLimitTripped
+    // takes over.
+    //
+    // Test: 10 POSTs to /auth/signup/garbage/start from one IP.
+    // Expect at most 5 unknown_provider rows + the remainder as
+    // ratelimit_tripped(ip) rows.
+    const xff = '13.0.0.1';
+    const admin = new PrismaClient({ datasources: { db: { url: ADMIN_URL } } });
+    try {
+      // Clear any earlier audit rows from sibling tests so the
+      // count assertions are clean.
+      await admin.auditEvent.deleteMany({
+        where: {
+          action: {
+            in: [
+              'panorama.auth.signup_oidc_state_mismatch',
+              'panorama.auth.signup_rate_limit_tripped',
+            ],
+          },
+        },
+      });
+
+      for (let i = 0; i < 10; i++) {
+        const resp = await fetch(`${suite.url}/auth/signup/garbage/start`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Forwarded-For': xff },
+          body: JSON.stringify({
+            captchaToken: `tt-${Math.random().toString(36).slice(2, 12)}`,
+            ctaSource: 'hosted_button',
+            ageGateAccepted: true,
+          }),
+          redirect: 'manual',
+        });
+        expect(resp.status).toBe(400);
+      }
+
+      const rows = await admin.auditEvent.findMany({
+        where: {
+          action: {
+            in: [
+              'panorama.auth.signup_oidc_state_mismatch',
+              'panorama.auth.signup_rate_limit_tripped',
+            ],
+          },
+        },
+        orderBy: { id: 'asc' },
+      });
+      const unknownProvider = rows.filter(
+        (r: AuditEvent) =>
+          r.action === 'panorama.auth.signup_oidc_state_mismatch' &&
+          (r.metadata as { reason?: string } | null)?.reason === 'unknown_provider',
+      );
+      const rateLimitIp = rows.filter(
+        (r: AuditEvent) =>
+          r.action === 'panorama.auth.signup_rate_limit_tripped' &&
+          (r.metadata as { bucket?: string } | null)?.bucket === 'ip',
+      );
+      // The ip bucket holds 5 slots per hour, so at most 5 of the
+      // 10 requests reach the resolveProvider step. The other 5+
+      // are blocked at the ip-bucket consume and emit ratelimit_tripped.
+      expect(unknownProvider.length).toBeLessThanOrEqual(5);
+      expect(rateLimitIp.length).toBeGreaterThanOrEqual(5);
+      // Total = 10 audit rows (one per request), bound enforced.
+      expect(unknownProvider.length + rateLimitIp.length).toBe(10);
+    } finally {
+      await admin.$disconnect();
+    }
+  });
+
+  it('oidc_sub bucket (3 / (iss, sub) / 24h) plus existing-account refuse short-circuit the 2nd+ attempts', async () => {
+    const xff = '12.0.0.1';
+    const subject = 'sub-flood-test-fixed';
+    suite.oidcCallback.setUserInfo({
+      subject,
+      email: 'flood@example.invalid',
+      firstName: 'Flood',
+      lastName: 'Tester',
+      displayName: 'Flood Tester',
+      emailVerified: true,
+      hd: null,
+      iss: SYNTHETIC_GOOGLE_ISSUER,
+    });
+
+    const callbackStatuses: number[] = [];
+    for (let i = 0; i < 4; i++) {
+      const startResp = await postStart(suite.url, xff);
+      expect(startResp.status).toBe(302);
+      const stateKey = readStateFromLocation(startResp.headers.get('location') ?? '');
+      const callbackResp = await fetch(
+        `${suite.url}/auth/signup/google/callback?code=fake-code&state=${stateKey}`,
+        { redirect: 'manual' },
+      );
+      callbackStatuses.push(callbackResp.status);
+    }
+
+    // Attempt 1: new_user — tenant created, 302 to /?signup=verify.
+    // Attempts 2 + 3: existing_identity (AuthIdentity created on attempt 1) —
+    //                 refused with TenantSignupRefusedExistingAccount, 400.
+    // Attempt 4: oidc_sub bucket goes 3 → 4 → over limit — refused with
+    //            AuthSignupRateLimitTripped(bucket=oidc_sub), 400.
+    // The shape (1 redirect followed by 3 refusals) verifies both the
+    // bucket budget and the §2 one-tenant-per-email contract. Audit
+    // rows distinguish the specific refusal reason for each attempt.
+    expect(callbackStatuses[0]).toBe(302);
+    expect(callbackStatuses.slice(1).every((s) => s === 400)).toBe(true);
+  });
+});
+
+describe('abuse: signup flood — anti-spoof (Wave 0 Round 3)', () => {
+  let suite: SignupTestApp;
+  let redis: Redis;
+
+  beforeAll(async () => {
+    process.env['SESSION_SECRET'] = process.env['SESSION_SECRET'] ?? 'a'.repeat(32);
+    process.env['DATABASE_URL'] = APP_URL;
+    process.env['FEATURE_SELF_SERVE_SIGNUP'] = 'true';
+    process.env['TURNSTILE_SECRET'] = 'test-secret';
+    process.env['SIGNUP_FAILURE_LATENCY_FLOOR_MS'] = '20';
+    process.env['OIDC_GOOGLE_CLIENT_ID'] = 'test-google-client';
+    process.env['OIDC_GOOGLE_CLIENT_SECRET'] = 'test-google-secret';
+    process.env['APP_BASE_URL'] = process.env['APP_BASE_URL'] ?? 'http://localhost:4000';
+
+    const admin = new PrismaClient({ datasources: { db: { url: ADMIN_URL } } });
+    await resetTestDb(admin);
+    await admin.$disconnect();
+
+    redis = new Redis(REDIS_URL);
+    await flushSignupKeys(redis);
+
+    // trust proxy 0 — `req.ip` is the socket address regardless of
+    // any X-Forwarded-For header the client sends. This is the self-
+    // host-without-edge default; the §4 anti-spoof contract asserts
+    // that XFF cannot be used to forge bucket keys in this config.
+    suite = await buildSignupTestApp({ trustProxy: 0 });
+  }, 60_000);
+
+  afterAll(async () => {
+    await suite?.app.close();
+    await redis?.quit();
+    delete process.env['FEATURE_SELF_SERVE_SIGNUP'];
+  });
+
+  it('forged X-Forwarded-For does NOT move the per-IP bucket key', async () => {
+    // 6 attempts, all carrying X-Forwarded-For: 1.2.3.4. With trust
+    // proxy 0, req.ip stays on the loopback socket and the bucket
+    // fills accordingly. The 6th attempt trips the ip bucket regardless
+    // of the spoofed header.
+    const statuses = await rapidStarts(suite.url, 6, '1.2.3.4');
+
+    expect(statuses.slice(0, 5).every((s) => s === 302)).toBe(true);
+    expect(statuses[5]).toBe(400);
+  });
+});
+
+// -----------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------
+
+async function buildSignupTestApp(opts: { trustProxy: 0 | 1 }): Promise<SignupTestApp> {
+  const oidcCallback = makeOidcCallbackMock();
+  const moduleRef = await Test.createTestingModule({
+    imports: [AppModule],
+  })
+    .overrideProvider(OidcService)
+    .useValue({
+      start: async (params: { provider: string; state?: string }) => ({
+        url: `http://example.invalid/idp/auth?state=${params.state ?? 'unknown'}`,
+        state: params.state ?? 'unknown',
+        codeVerifier: 'test-code-verifier',
+        nonce: 'test-nonce',
+      }),
+      callback: oidcCallback.fn,
+    })
+    .overrideProvider(TurnstileVerifier)
+    .useValue({
+      verify: async () => ({ ok: true }),
+    })
+    .compile();
+
+  const app = moduleRef.createNestApplication<NestExpressApplication>({
+    logger: ['error', 'warn'],
+  });
+  (app as NestExpressApplication).set('trust proxy', opts.trustProxy);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+  await app.init();
+  await app.listen(0);
+  const url = await app.getUrl();
+  return { app, url, oidcCallback };
+}
+
+function makeOidcCallbackMock(): {
+  fn: (params: unknown) => Promise<OidcUserInfo>;
+  setUserInfo: (u: OidcUserInfo) => void;
+  reset: () => void;
+} {
+  let current: OidcUserInfo | null = null;
+  return {
+    fn: async () => {
+      if (!current) {
+        throw new Error(
+          'OidcService.callback mock called without setUserInfo() — test setup bug',
+        );
+      }
+      return current;
+    },
+    setUserInfo: (u: OidcUserInfo) => {
+      current = u;
+    },
+    reset: () => {
+      current = null;
+    },
+  };
+}
+
+async function rapidStarts(baseUrl: string, count: number, xff: string): Promise<number[]> {
+  const statuses: number[] = [];
+  for (let i = 0; i < count; i++) {
+    const resp = await postStart(baseUrl, xff);
+    statuses.push(resp.status);
+  }
+  return statuses;
+}
+
+function postStart(baseUrl: string, xff: string): Promise<Response> {
+  return fetch(`${baseUrl}/auth/signup/google/start`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Forwarded-For': xff,
+    },
+    body: JSON.stringify({
+      captchaToken: `tt-${Math.random().toString(36).slice(2, 12)}`,
+      ctaSource: 'hosted_button',
+      ageGateAccepted: true,
+    }),
+    redirect: 'manual',
+  });
+}
+
+function readStateFromLocation(location: string): string {
+  const idx = location.indexOf('state=');
+  if (idx === -1) return '';
+  const tail = location.slice(idx + 'state='.length);
+  const amp = tail.indexOf('&');
+  return amp === -1 ? tail : tail.slice(0, amp);
+}
+
+async function flushSignupKeys(redis: Redis): Promise<void> {
+  // Wipe only the panorama:signup:* keyspace so we don't disturb
+  // unrelated state in dev Redis. Async iterator over SCAN is the
+  // idiomatic ioredis pattern.
+  const stream = redis.scanStream({ match: 'panorama:signup:*', count: 200 });
+  for await (const batch of stream) {
+    const keys = batch as string[];
+    if (keys.length > 0) {
+      await redis.del(...keys);
+    }
+  }
+}

--- a/apps/core-api/test/abuse/signup-flood.e2e.test.ts
+++ b/apps/core-api/test/abuse/signup-flood.e2e.test.ts
@@ -312,7 +312,7 @@ async function buildSignupTestApp(opts: { trustProxy: 0 | 1 }): Promise<SignupTe
   const app = moduleRef.createNestApplication<NestExpressApplication>({
     logger: ['error', 'warn'],
   });
-  (app as NestExpressApplication).set('trust proxy', opts.trustProxy);
+  app.set('trust proxy', opts.trustProxy);
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,

--- a/apps/core-api/test/build-session-pending-tenant.test.ts
+++ b/apps/core-api/test/build-session-pending-tenant.test.ts
@@ -1,0 +1,129 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Test } from '@nestjs/testing';
+import { PrismaClient } from '@prisma/client';
+import { AppModule } from '../src/app.module.js';
+import { AuthService } from '../src/modules/auth/auth.service.js';
+import { resetTestDb } from './_reset-db.js';
+
+/**
+ * Regression test for ADR-0020 §3 — the cross-flow login bypass
+ * surfaced by the security-reviewer 3rd-pass: a user who completed
+ * self-serve signup creates a tenant with `pendingVerification=true`,
+ * and `buildSessionForUser` MUST NOT mint a session on that tenant
+ * (regardless of whether the call comes via the signup callback,
+ * the /auth/oidc/...login flow, or any other surface that ends up
+ * calling buildSessionForUser).
+ *
+ * The filter lives at `auth.service.ts` (the `tenant: {
+ * pendingVerification: false }` clause on the memberships
+ * findMany). If a future refactor drops the clause, this test
+ * catches it.
+ *
+ * Single test; uses raw PrismaClient on the privileged URL to seed
+ * fixtures, the AppModule to obtain the same AuthService production
+ * uses.
+ */
+
+const HOST = process.env['PG_HOST'] ?? 'localhost';
+const PORT = process.env['PG_PORT'] ?? '5432';
+const DB = process.env['PG_DB'] ?? 'panorama';
+const ADMIN_URL = `postgres://panorama_super_admin:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+const APP_URL = `postgres://panorama_app:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+
+describe('buildSessionForUser — pendingVerification filter (ADR-0020 §3)', () => {
+  let admin: PrismaClient;
+  let auth: AuthService;
+  let close: () => Promise<void>;
+
+  beforeAll(async () => {
+    process.env['SESSION_SECRET'] = process.env['SESSION_SECRET'] ?? 'a'.repeat(32);
+    process.env['DATABASE_URL'] = APP_URL;
+
+    admin = new PrismaClient({ datasources: { db: { url: ADMIN_URL } } });
+    await resetTestDb(admin);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    const app = moduleRef.createNestApplication({ logger: ['error', 'warn'] });
+    await app.init();
+    auth = app.get(AuthService);
+    close = () => app.close();
+  }, 60_000);
+
+  afterAll(async () => {
+    await close?.();
+    await admin?.$disconnect();
+  });
+
+  it('refuses session for a user whose only membership is on a pendingVerification tenant', async () => {
+    const user = await admin.user.create({
+      data: { email: 'pending-only@example.invalid', displayName: 'Pending Only' },
+    });
+    const systemUser = await admin.user.create({
+      data: {
+        email: 'system+pending@example.invalid',
+        displayName: 'system pending',
+        status: 'ACTIVE',
+      },
+    });
+    const tenant = await admin.tenant.create({
+      data: {
+        slug: `pending-${Date.now()}`,
+        name: 'Pending Tenant',
+        displayName: 'Pending Tenant',
+        systemActorUserId: systemUser.id,
+        pendingVerification: true,
+      },
+    });
+    await admin.tenantMembership.create({
+      data: { tenantId: tenant.id, userId: user.id, role: 'owner', status: 'active' },
+    });
+
+    await expect(
+      auth.buildSessionForUser(user.id, 'google'),
+    ).rejects.toThrow('no_tenant_memberships');
+  });
+
+  it('surfaces only verified memberships when a user has BOTH a verified and a pending tenant', async () => {
+    const user = await admin.user.create({
+      data: { email: 'mixed@example.invalid', displayName: 'Mixed' },
+    });
+    const sysA = await admin.user.create({
+      data: { email: 'system+mixed-a@example.invalid', displayName: 'sys a', status: 'ACTIVE' },
+    });
+    const sysB = await admin.user.create({
+      data: { email: 'system+mixed-b@example.invalid', displayName: 'sys b', status: 'ACTIVE' },
+    });
+    const verified = await admin.tenant.create({
+      data: {
+        slug: `verified-${Date.now()}`,
+        name: 'Verified',
+        displayName: 'Verified',
+        systemActorUserId: sysA.id,
+        pendingVerification: false,
+      },
+    });
+    const pending = await admin.tenant.create({
+      data: {
+        slug: `pending-${Date.now()}-b`,
+        name: 'Pending',
+        displayName: 'Pending',
+        systemActorUserId: sysB.id,
+        pendingVerification: true,
+      },
+    });
+    await admin.tenantMembership.create({
+      data: { tenantId: verified.id, userId: user.id, role: 'owner', status: 'active' },
+    });
+    await admin.tenantMembership.create({
+      data: { tenantId: pending.id, userId: user.id, role: 'owner', status: 'active' },
+    });
+
+    const session = await auth.buildSessionForUser(user.id, 'google');
+    const tenantIds = session.memberships.map((m) => m.tenantId);
+    expect(tenantIds).toContain(verified.id);
+    expect(tenantIds).not.toContain(pending.id);
+  });
+});

--- a/docs/adr/0020-self-serve-oidc-signup.md
+++ b/docs/adr/0020-self-serve-oidc-signup.md
@@ -100,19 +100,44 @@ the login callback:
   browser by definition. A logged-in user that wants to provision a
   second tenant uses the existing invitation flow (ADR-0008), not
   signup.
-- A state-record mismatch (missing / expired / wrong purpose /
-  session-attached) emits
+- A state-record mismatch emits
   `panorama.auth.signup_oidc_state_mismatch` (see §6) so SIEM can
-  alert on signup-CSRF attempts.
+  alert on signup-CSRF attempts. The `reason` field discriminates
+  the specific contract violation:
+  - `missing` — no Redis record for the supplied state key (expired
+    or forged)
+  - `wrong_purpose` — state record's `purpose !== 'signup'`
+    (confused-deputy across login/signup flows)
+  - `session_attached` — caller arrived with an existing session
+  - `unknown_provider` — `:provider` path is not `google` /
+    `microsoft`, or the provider is not configured on this deployment
+  - `callback_provider_mismatch` — path `:provider` does not match
+    the provider recorded at initiate (attempt to swap provider
+    mid-flow)
+  - `idp_error` — IdP redirected with `?error=...` per RFC 6749
+    §4.1.2.1; the sanitized code rides in `metadata.idpErrorCode`
 
 ### 2. One tenant per email (initial signup)
 
 Each successful OIDC signup creates exactly one tenant with the
-signup email's user as Tenant Owner. Future enhancement (deferred):
-allow a user to be Owner of multiple tenants by inviting themselves
-under a different email or by accepting an invitation to join an
-existing tenant — both already supported via the existing invitation
-flow (ADR-0008).
+signup email's user as Tenant Owner.
+
+**Implementation enforcement (PR 1):** the callback REFUSES the
+signup when `AuthService.resolveOidcUserForSignup` reports
+`pathTaken !== 'new_user'` — i.e. when the IdP identity is already
+linked to a Panorama account (`existing_identity`) or when the
+asserted email already maps to a pre-existing User row that would be
+newly linked (`email_link`). The refusal emits
+`panorama.tenant.signup_refused_existing_account` (see §6) and
+funnels through the §5 timing-padded 400 envelope. Without this
+check, a single Google/Microsoft account could mint up to 3 tenants
+per (iss, sub) per 24h (the §4 bucket-3 cap) via repeated signup
+attempts at the upper edge of the budget.
+
+Future enhancement (deferred): allow a user to be Owner of multiple
+tenants by inviting themselves under a different email or by
+accepting an invitation to join an existing tenant — both already
+supported via the existing invitation flow (ADR-0008).
 
 ### 2a. Tenant identifier is UUID; display name is free text
 
@@ -143,6 +168,19 @@ Even though OIDC IdPs already verify the email, Panorama emits a
 post-signup confirmation email with a one-time-use token (TTL: 24h).
 The tenant is provisioned in a `pending_verification` state; the
 first login is blocked until the verification token is consumed.
+
+**PR 1 boundary on the "first login is blocked" contract:** the
+signup callback (PR 1) intentionally does NOT establish a session
+when it provisions the tenant. The browser is redirected to
+`/?signup=verify` and the user is expected to consume the
+verification token (PR 2 surface) before any session is minted.
+Creating a live session in the callback would leave a window between
+PR 1 and PR 2 merges where an unverified tenant could be fully used
+— the literal §3 contract reading is that no session exists until
+the verification token is consumed, and PR 1 honours that. The
+`pendingVerification` column added in migration 0022 carries the
+state forward; PR 2 reads it in the verify endpoint and flips it
+back to false.
 
 This protects against:
 - IdP-issued tokens for emails the IdP itself hasn't verified (rare
@@ -198,16 +236,43 @@ signup-initiate endpoint). The third runs post-OIDC-resolution on
 the callback (once `iss` and `sub` claims are known from the
 verified id_token).
 
-**Throttler stack reference:** This endpoint rides on the throttler
-wired by PR #204 (`app.set('trust proxy', 1)` in `main.ts:18`,
-`ThrottlerModule` registered as `APP_GUARD`) and PR #205
-(`PerTenantThrottlerGuard` at
-`apps/core-api/src/shared/throttler/per-tenant-throttler.guard.ts`
-which falls back to `req.ip` for anonymous routes — exactly the
-case for signup-initiate). The signup endpoint is added to the first
-batch of `@Throttle`-decorated routes; the per-subnet and per-`(iss,
-sub)` buckets are added as additional `@Throttle` declarations or
-a sibling guard.
+**Throttler stack reference (amended during PR 1 implementation —
+service-level pivot):** Round 3 prereq PR #210 added `signupIp` +
+`signupSubnet` named buckets to `ThrottlerModule.forRoot` expecting
+the signup endpoint to ride them via `@Throttle` decorators. The
+PR 1 implementation discovered a fatal interaction with
+`@nestjs/throttler@6.5.0`: `ThrottlerGuard.canActivate` iterates
+EVERY named throttler on EVERY route (keyed per-(class, handler,
+name)), so `signupIp`'s 5/hour cap would silently apply to
+`/auth/login`, `/reservations`, and every other handler at 5/hour.
+Opting out would require `@SkipThrottle({signupIp: true,
+signupSubnet: true})` on every non-signup controller — brittle and
+forgettable.
+
+The implementation therefore moved all three §4 buckets to a
+service-level `SignupRateLimits`
+(`modules/signup/signup-rate-limits.service.ts`) that invokes the
+existing `RateLimiter` (Redis sliding-window, fail-closed) directly.
+The `ThrottlerModule` named-bucket entries for `signupIp` +
+`signupSubnet` are REMOVED in PR 1 (app.module.ts course-correct on
+PR #210). The remaining `ThrottlerModule` buckets (`global`,
+`auth`, `upload`) stay; the existing `PerTenantThrottlerGuard`
+(APP_GUARD) continues to enforce them on authenticated routes.
+
+Trade-offs of the pivot:
+
+- `+` Buckets are scoped to the signup endpoints by construction;
+  no rogue route inherits them.
+- `+` Each bucket trip emits `AuthSignupRateLimitTripped` with the
+  exact `bucket` label (`ip` / `subnet` / `oidc_sub`) for SIEM
+  correlation — the v6 `ThrottlerGuard` exception path doesn't
+  carry that label as cleanly.
+- `+` The §5 timing-padded 400 envelope is composed in one place
+  rather than overriding `throwThrottlingException`.
+- `-` PR #210's named-bucket investment in `ThrottlerModule.forRoot`
+  is partially reverted (the `signupIp` + `signupSubnet` entries
+  drop out). The `subnetKey()` utility from #210 is still load-
+  bearing (used by `SignupRateLimits.consumeSubnet`).
 
 **Trust-proxy contract is fragile and self-hosters must configure
 it.** `app.set('trust proxy', 1)` means "trust ONE hop." On the
@@ -302,13 +367,19 @@ endpoints that emit them ship (Round 3 prerequisite).
 - `panorama.tenant.signup_initiated` — at the moment the OIDC flow
   starts (registry addition)
 - `panorama.tenant.created` — at the moment the tenant is
-  provisioned in `pending_verification` state (existing event)
+  provisioned in `pending_verification` state (existing event,
+  migrated to registry enum in PR 1)
+- `panorama.tenant.signup_refused_existing_account` — §2 enforcement
+  in PR 1: the OIDC identity is already linked to a Panorama
+  account OR its email matches a pre-existing User row. Refusal
+  is fail-closed; the user is told to use the invitation flow
+  (ADR-0008) or sign in.
 - `panorama.tenant.verification_sent` — when the confirmation email
-  is dispatched (registry addition)
+  is dispatched (registry addition; PR 2)
 - `panorama.tenant.verified` — when the user POSTs the verification
-  token and the tenant becomes active (registry addition)
+  token and the tenant becomes active (registry addition; PR 2)
 - `panorama.tenant.verification_throttled` — per-email cap (§3) hit
-  (registry addition)
+  (registry addition; PR 2)
 
 **Anonymous-abuse signals:**
 - `panorama.auth.signup_rate_limit_tripped` — any of the three §4

--- a/docs/runbooks/secrets-inventory.md
+++ b/docs/runbooks/secrets-inventory.md
@@ -90,6 +90,35 @@ secret in their respective consoles. Our procedure:
    if the IdP supports it; check provider docs)
 6. **Rollback**: re-set the prior secret in fly + IdP
 
+## Cloudflare Turnstile (self-serve signup CAPTCHA)
+
+Per ADR-0020 §5. Only consumed when `FEATURE_SELF_SERVE_SIGNUP=true`;
+self-hosts that keep signup off can leave this unset.
+
+| Variable | Where | Sensitivity | Notes |
+|---|---|---|---|
+| `TURNSTILE_SECRET` | env, Fly secrets | **Secret** — server-side siteverify token | Paired with a public site key embedded in the homepage form |
+| `TURNSTILE_SITE_VERIFY_URL` | env (optional) | Non-secret (URL) | Defaults to Cloudflare's prod endpoint; overridden in e2e tests via a stub server |
+| `SIGNUP_FAILURE_LATENCY_FLOOR_MS` | env (optional) | Non-secret (integer) | Defaults to `600`. ADR-0020 §5 timing floor for the constant-latency 400 envelope; only override below `600` in tests |
+
+**Rotation procedure:**
+
+1. Cloudflare dashboard → Turnstile → site → rotate secret key
+2. `fly secrets set --app panorama-hosted TURNSTILE_SECRET=...`
+3. Rolling deploy
+4. In the Cloudflare dashboard, revoke the prior secret after the
+   rolling deploy completes (Cloudflare keeps the prior key valid
+   briefly during rotation; check dashboard for the exact window)
+5. **Validation**: submit a real signup from a fresh browser; the
+   server-side siteverify call must succeed
+6. **Rollback**: re-set the prior secret in fly + Cloudflare
+
+**Boot guard**: `SignupConfigService` throws
+`TURNSTILE_SECRET must be set when FEATURE_SELF_SERVE_SIGNUP=true`
+if the flag is on and the secret is missing. The flag is gated in
+`app.module.ts`; self-hosters who leave it off (the default) won't
+hit this guard.
+
 ## S3-compatible object storage (Cloudflare R2 in staging)
 
 | Variable | Where | Sensitivity | Notes |
@@ -199,7 +228,7 @@ quickly identify what's safe to log.
 - `APP_BASE_URL`, `APP_VERSION`, `CORE_API_URL`, `WEB_ORIGIN`
 - `NODE_ENV`, `PORT`
 - `ALLOW_STAGING_SEED`, `FEATURE_INSPECTIONS`, `FEATURE_MAINTENANCE`,
-  `FEATURE_SELF_SERVE_SIGNUP` (future per ADR-0020)
+  `FEATURE_SELF_SERVE_SIGNUP` (per ADR-0020 — gates Turnstile + signup endpoints)
 - `OIDC_GOOGLE_HOSTED_DOMAIN`, `OIDC_GOOGLE_ISSUER`,
   `OIDC_GOOGLE_TRUSTED_HD_DOMAINS`, `OIDC_MICROSOFT_TENANT`,
   `OIDC_ALLOW_INSECURE_ISSUER`
@@ -245,10 +274,10 @@ bucket behavior assuming a correctly-configured value.
 
 ## Total count
 
-- **Secrets requiring rotation procedure:** 14 (Database ×5,
-  Session ×1, OIDC ×2, S3 ×2, SMTP ×2, Redis ×1, SEED ×1)
-- **Future secrets pending ADR implementation:** 2 (Sentry DSN,
-  CAPTCHA secret)
+- **Secrets requiring rotation procedure:** 15 (Database ×5,
+  Session ×1, OIDC ×2, Turnstile ×1, S3 ×2, SMTP ×2, Redis ×1,
+  SEED ×1)
+- **Future secrets pending ADR implementation:** 1 (Sentry DSN)
 - **Non-secret env vars:** ~19 (listed above, including the new
   `TRUST_PROXY_HOPS` load-bearing config)
 


### PR DESCRIPTION
## Summary

- Implements POST `/auth/signup/:provider/start` + GET `/auth/signup/:provider/callback` per [ADR-0020](docs/adr/0020-self-serve-oidc-signup.md) (amended §§1-6).
- Adds migration 0022 — `Tenant.pendingVerification BOOLEAN NOT NULL DEFAULT FALSE`. Signup callback sets `true`; PR 2 owns the flip + email dispatch + verify endpoint.
- New `modules/signup/` (controller + state store + Turnstile verifier + 3-bucket §4 rate limits + timing-padded 400 envelope). Gated by `FEATURE_SELF_SERVE_SIGNUP` (default off).
- Closes the cross-flow login bypass (`AuthService.buildSessionForUser` filters `pendingVerification` tenants — applies to BOTH `loginWithOidc` and signup callers).
- ADR-0020 amended in this PR (§4 documents the throttler-module → service-level pivot on PR #210 named buckets; §2 documents the `pathTaken !== 'new_user'` enforcement; §3 documents the no-session-in-callback contract).

## Major surfaces

- `migrations/0022_tenant_pending_verification` — additive, metadata-only on PG11+.
- `modules/signup/signup.controller.ts` — initiate + callback. Failure paths funnel through `respondTimingPadded` (≥600ms floor, 400 not 429).
- `modules/signup/signup-rate-limits.service.ts` — three §4 buckets (`ip`, `subnet`, `oidc_sub`) via the existing `RateLimiter` service. Course-correct on PR #210's named-bucket investment (`@nestjs/throttler@6` iterates every named throttler on every route — leaving `signupIp` in there capped `/auth/login` etc. at 5/hour silently).
- `modules/signup/signup-state.store.ts` — Redis-backed one-time-use state per §1a (`generateKey` + `set` + `consume` via GETDEL).
- `modules/signup/turnstile-verifier.service.ts` — Cloudflare siteverify + Redis NX token dedupe (R3).
- `AuthService.resolveOidcUserForSignup` — sibling of `loginWithOidc` that runs the same gate without `buildSession`. Used by SignupController callback.
- `AuthService.buildSessionForUser` — adds `tenant: { pendingVerification: false }` filter on memberships findMany.
- `TenantAdminService.createTenantWithOwner` — gained `id?`, `pendingVerification?`, `metadataExtra?` params. `metadataExtra` spread BEFORE canonical keys so a misshapen caller cannot clobber `slug`/`ownerUserId`/`pendingVerification`.
- `OidcService.start` — optional `redirectUri` + `state` params so signup can ride the openid-client wrapper with its own callback URL + Redis state key.
- `app.module.ts` — REMOVES `signupIp` + `signupSubnet` from `ThrottlerModule.forRoot` (course-correct). `auth` / `global` / `upload` named buckets stay. Conditionally loads `SignupModule` based on `FEATURE_SELF_SERVE_SIGNUP`.
- `audit-actions.ts` — `TenantCreated` enum (migrated from string literal at `tenant-admin.service.ts`). New `TenantSignupRefusedExistingAccount` entry. `AuthSignupRateLimitTripped` JSDoc drift fixed. `AuthSignupOidcStateMismatch` reason union extended with `unknown_provider` / `callback_provider_mismatch` / `idp_error`.
- `docs/runbooks/secrets-inventory.md` — new Turnstile section + flips `FEATURE_SELF_SERVE_SIGNUP` from "future" to landed.

## Adversarial review log

- **tech-lead 1st pass** — 2 blockers + 4 concerns. ALL addressed: ADR-0020 §4 amendment now in this PR; audit registry JSDoc drift fixed; `metadataExtra` reordered; ADR §6 + §1a + §3 also amended.
- **security-reviewer 1st pass** — 4 blockers + 6 concerns. ALL addressed: tenant-spam vector closed via `pathTaken !== 'new_user'` refusal + new `TenantSignupRefusedExistingAccount` audit; session-in-callback dropped (callback redirects to `/?signup=verify` with no session); `respondTimingPadded` logs on `headersSent` reentry; `resolveProvider` made async + timing-padded + audited.
- **security-reviewer 2nd pass** — 2 new blockers. ALL addressed: `buildSessionForUser` filter closes the cross-flow login bypass; `consumeIp` + `consumeSubnet` moved BEFORE `resolveProvider` in both initiate AND callback (bounds the pre-validation audit-emit flood by the per-IP bucket).
- **security-reviewer 3rd pass** — APPROVE WITH CONDITIONS. The 2 conditions (regression tests for both fixes) landed in this commit. Concerns deferred to follow-ups: rate-limit-trip dedupe within window; salted IP hashes in audit metadata; IPv6-mapped `consumeIp` keying normalization.

## Test plan

- [x] Migration 0022 applies cleanly against dev Postgres + ROLLBACK.md verified by inspection.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — 48 files / 455 tests passing locally.
- [x] `test/abuse/signup-flood.e2e.test.ts` — 5 tests:
  - `ip` bucket trips on 6th start (loud single-source)
  - `subnet` bucket trips on 51st across distinct IPs in same /24 (residential proxy)
  - `oidc_sub` bucket + `pathTaken !== 'new_user'` refusal short-circuit attempts 2-4
  - anti-spoof: forged `X-Forwarded-For` under `trust proxy 0` does NOT move the per-IP bucket
  - `unknown_provider` audit emit bounded by ip bucket (BL-NEW-1 regression)
- [x] `test/build-session-pending-tenant.test.ts` — 2 tests:
  - User with only `pendingVerification=true` membership → `buildSessionForUser` throws `no_tenant_memberships`
  - User with verified + pending → session contains only the verified membership
- [ ] **NOT covered by automated tests (deferred to PR 2+):** real Turnstile siteverify against Cloudflare; real Google/Microsoft OIDC flows end-to-end; load test for the audit-chain advisory-lock pressure under sustained abuse.

## Operational notes

- `FEATURE_SELF_SERVE_SIGNUP` defaults `false`. Self-hosters can enable; the hosted instance flips it AFTER PR 2 (verify endpoint + email dispatch) lands and the operator is ready to open self-serve signup.
- `TURNSTILE_SECRET` is required when the flag is on; `SignupConfigService` refuses to boot otherwise.
- `TRUST_PROXY_HOPS` becomes security-critical when the flag is on (see `secrets-inventory.md` §"TRUST_PROXY_HOPS — load-bearing").
- Self-hosters enabling the flag must register `${APP_BASE_URL}/auth/signup/:provider/callback` as a second OIDC redirect_uri (the login flow's `/auth/oidc/:provider/callback` stays as-is).

## Follow-ups (logged as next-PR work)

- PR 2: `POST /auth/verify` + email dispatch + `pendingVerification` flip + the `verification_sent` / `verified` / `verification_throttled` audit emissions.
- Rate-limit-trip Redis dedupe sentinel (cap audit-row volume per (bucket, key) within window).
- Salt IP hashes in `AuthSignupRateLimitTripped.metadata.keyHash` with a server-side secret.
- Normalize IPv6-mapped IPv4 in `consumeIp` to match `subnetKey`'s normalization.
- Audit emission for terminal `signup_oidc_callback_failed` / `signup_tenant_create_failed` warns.