### PR TITLE
feat(verify): Round 3 main 2 — email verification + flip pendingVerification (ADR-0020 §3)

### DIFF
--- a/.runAsSuperAdmin.allowlist.json
+++ b/.runAsSuperAdmin.allowlist.json
@@ -1,7 +1,7 @@
 {
   "_doc": "Allowlist gate for prisma.runAsSuperAdmin call sites. Closes #58 (RLS-CI). Each entry is a file path + the count of CURRENTLY-JUSTIFIED runAsSuperAdmin calls in it + a one-line rationale. The CI script `scripts/check-runAsSuperAdmin-allowlist.ts` compares the actual count against the budget and fails if a file exceeds its budget. Lower the budget when a site migrates to runInTenant; raise only with reviewer sign-off documenting why a tenant-scoped op needs the privileged path.",
   "_review_policy": "Any PR that raises a budget MUST be reviewed by security-reviewer. Lowering a budget is encouraged.",
-  "_last_audit": "2026-05-17 — auth.service.ts bumped 6 → 7 for ADR-0020 §1 resolveOidcUserForSignup (signup find-or-create runs pre-tenant; security-reviewer approved across PR #212's three review passes).",
+  "_last_audit": "2026-05-17 — email-verification.service.ts added budget 2 for ADR-0020 §3 mint/consume; auth.service.ts at 7 from ADR-0020 §1 resolveOidcUserForSignup.",
   "files": {
     "apps/core-api/src/modules/audit/audit.service.ts": {
       "budget": 1,
@@ -10,6 +10,10 @@
     "apps/core-api/src/modules/auth/auth.service.ts": {
       "budget": 7,
       "rationale": "Login + signup flows: identity lookup + find-or-create run before tenant context exists (the credential / OIDC subject IS what selects the tenant). Six pre-existing login sites + one ADR-0020 §1 resolveOidcUserForSignup added in PR #212 (security-reviewer approved across three review passes on the diff)."
+    },
+    "apps/core-api/src/modules/email-verification/email-verification.service.ts": {
+      "budget": 2,
+      "rationale": "ADR-0020 §3 mint+consume paths. Both run from a logged-out browser (no session, no tenant context): mintAndDispatch is invoked by the signup callback before the session would exist; consume is invoked by POST /auth/verify which the user reaches via the email-link page also pre-session. panorama_app has no GRANT on email_verifications, so super-admin is the only viable role."
     },
     "apps/core-api/src/modules/auth/discovery.service.ts": {
       "budget": 1,

--- a/apps/core-api/prisma/migrations/20260517010000_0023_email_verification/ROLLBACK.md
+++ b/apps/core-api/prisma/migrations/20260517010000_0023_email_verification/ROLLBACK.md
@@ -1,0 +1,66 @@
+# Rollback — 0023 email_verifications
+
+## Pre-flight (operator MUST verify BEFORE running)
+
+This migration creates ONE table (`email_verifications`) used by the
+ADR-0020 §3 self-serve signup verify-endpoint pair. Rollback drops
+the table.
+
+Only roll back if PR 2's verify endpoint + signup-callback
+mint-dispatch hook are also reverted — the EmailVerificationService
+references `prisma.emailVerification` and a missing table would crash
+every signup callback while leaving Prisma's typed client in a drift
+state.
+
+## SQL revert (privileged role)
+
+Run from a psql session against `$DATABASE_PRIVILEGED_URL`.
+
+```sql
+DROP TABLE "email_verifications";
+```
+
+The FKs ON DELETE CASCADE keep the table self-contained — dropping
+the table does not affect `users` or `tenants`.
+
+## Data-loss warnings
+
+- **All pending verification tokens are dropped.** Tenants that signed
+  up via PR 1 + PR 2 but did not yet consume their verification token
+  lose the token row entirely. Without the table, those tenants
+  cannot be verified through the standard flow.
+- **`Tenant.pendingVerification` flag stays in place** (migration
+  0022). Pending tenants remain in `pendingVerification=true`
+  state, which means `buildSessionForUser` (PR 1) refuses sessions on
+  them. Operator-driven workaround: super-admin can UPDATE
+  `tenants.pendingVerification = false` directly.
+
+## When you would actually revert
+
+- PR 2 (verify endpoint + signup-callback mint-dispatch hook) is
+  being rolled back as part of a broader Wave 0.5 revert and the
+  table is now dead schema.
+- The `email_verifications` shape turns out to be unworkable for the
+  verify flow (extremely unlikely — the field set is the minimal
+  viable surface for a token + TTL + one-time-use pattern).
+
+## Re-apply pattern
+
+Forward-only by design. Re-applying after a rollback is a clean
+additive operation; no data backfill needed.
+
+## Schema implications
+
+`schema.prisma` was updated to add the `EmailVerification` model +
+back-relations on `User` and `Tenant`. A revert of THIS migration
+must also revert those edits — otherwise `prisma migrate status`
+will diff against the rolled-back DB.
+
+## Production migration timing
+
+- `CREATE TABLE` is fast; on Postgres it takes ACCESS EXCLUSIVE on
+  the new relation only (which doesn't exist yet, so no contention).
+- The FK references `users(id)` + `tenants(id)` validate the FK
+  constraint against existing rows — instantaneous on a new empty
+  table.
+- No trigger, function, or RLS policy changes.

--- a/apps/core-api/prisma/migrations/20260517010000_0023_email_verification/migration.sql
+++ b/apps/core-api/prisma/migrations/20260517010000_0023_email_verification/migration.sql
@@ -1,0 +1,45 @@
+-- Migration 0023 — Email verification table.
+--
+-- ADR-0020 §3 implementation surface for the self-serve signup
+-- verify-endpoint pair (PR 2 endpoint at POST /auth/verify;
+-- companion mint+dispatch lives in
+-- modules/email-verification/email-verification.service.ts).
+--
+-- Forward-only and additive:
+--   - panorama_app does NOT receive any GRANTs on the table; every
+--     access path routes through `prisma.runAsSuperAdmin`. The verify
+--     endpoint runs from a logged-out browser with no tenant context,
+--     and no operator workflow needs to inspect verification rows
+--     from the tenant-scoped surface.
+--   - No RLS policies for the same reason — the table is super-admin-
+--     only by GRANT, and adding policies for an audience that has
+--     no SELECT privilege anyway would be dead config.
+--   - The per-email cap (3 / 24h) is enforced via Redis (`RateLimiter`),
+--     NOT a DB-side partial unique, because the cap counts DISPATCH
+--     ATTEMPTS regardless of token state. A partial unique on
+--     (tenantId, consumedAt IS NULL) would conflate "open" rows with
+--     "throttled" semantics.
+--
+-- Cleanup of expired+consumed rows is out of scope for PR 2; a
+-- sweep job lives in Round 5 (observability) work.
+
+CREATE TABLE "email_verifications" (
+    "id"         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    "userId"     UUID NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "tenantId"  UUID NOT NULL REFERENCES "tenants"("id") ON DELETE CASCADE,
+    "emailLower" TEXT NOT NULL,
+    "tokenHash"  TEXT NOT NULL UNIQUE,
+    "expiresAt"  TIMESTAMPTZ NOT NULL,
+    "consumedAt" TIMESTAMPTZ,
+    "createdAt"  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX "email_verifications_tenantId_idx"
+    ON "email_verifications"("tenantId");
+
+COMMENT ON TABLE "email_verifications" IS
+'ADR-0020 §3 — one-time-use email-verification tokens minted at '
+'self-serve signup. Consumed by POST /auth/verify; flips '
+'tenants.pendingVerification to false in the same transaction. '
+'panorama_app has NO grants on this table — all access via '
+'prisma.runAsSuperAdmin. Per-email cap (3/24h) lives in Redis.';

--- a/apps/core-api/prisma/migrations/20260517010000_0023_email_verification/rls.sql
+++ b/apps/core-api/prisma/migrations/20260517010000_0023_email_verification/rls.sql
@@ -1,0 +1,12 @@
+-- Migration 0023 — no RLS surface change.
+--
+-- `email_verifications` is intentionally NOT granted to panorama_app.
+-- The verify endpoint runs from a logged-out browser (no tenant
+-- context) and routes through `prisma.runAsSuperAdmin`, so the
+-- super-admin role is the only access path. Adding an RLS policy
+-- for an audience that has no underlying GRANT would be dead config.
+--
+-- Placeholder kept for grep-greppability of the per-migration RLS
+-- audit pattern.
+
+SELECT 1;

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -128,6 +128,7 @@ model Tenant {
   inspectionPhotos        InspectionPhoto[]
   assetMaintenances       AssetMaintenance[]
   maintenancePhotos       MaintenancePhoto[]
+  emailVerifications      EmailVerification[]
 
   @@map("tenants")
 }
@@ -171,8 +172,43 @@ model User {
   maintenancesAssigned       AssetMaintenance[]    @relation("MaintenanceAssignee")
   maintenancesCompleted      AssetMaintenance[]    @relation("MaintenanceCompletedBy")
   maintenancePhotosUploaded  MaintenancePhoto[]    @relation("MaintenancePhotoUploader")
+  emailVerifications         EmailVerification[]
 
   @@map("users")
+}
+
+/// ADR-0020 §3 — one-time-use email-verification tokens minted at
+/// self-serve signup. Consumed via POST /auth/verify; flips
+/// `tenants.pendingVerification` to false in the same transaction.
+/// Per-email rate cap (3/24h, see EmailVerificationService) is
+/// enforced via Redis, not a DB-side partial unique, because the
+/// cap counts DISPATCH ATTEMPTS (including already-consumed tokens)
+/// rather than open rows.
+///
+/// All access goes through `prisma.runAsSuperAdmin` because the
+/// verify endpoint runs from a logged-out browser (no tenant
+/// context) — panorama_app does NOT receive GRANTs on this table,
+/// and there is no RLS policy because there is no need for tenant-
+/// scoped read.
+model EmailVerification {
+  id         String    @id @default(uuid()) @db.Uuid
+  userId     String    @db.Uuid
+  user       User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tenantId   String    @db.Uuid
+  tenant     Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  /// Lowercased + trimmed email from the OIDC id_token. Per ADR §3,
+  /// NEVER a user-supplied form field — the IdP-asserted email is
+  /// the only legitimate verification target (phishing-by-proxy
+  /// defense).
+  emailLower String
+  /// sha256 hex of the plaintext token. Plaintext never persisted.
+  tokenHash  String    @unique
+  expiresAt  DateTime  @db.Timestamptz(6)
+  consumedAt DateTime? @db.Timestamptz(6)
+  createdAt  DateTime  @default(now()) @db.Timestamptz(6)
+
+  @@index([tenantId])
+  @@map("email_verifications")
 }
 
 enum UserStatus {

--- a/apps/core-api/src/app.module.ts
+++ b/apps/core-api/src/app.module.ts
@@ -23,6 +23,7 @@ import { ReservationModule } from './modules/reservation/reservation.module.js';
 import { SnipeitCompatModule } from './modules/snipeit-compat/snipeit-compat.module.js';
 import { BootAuditModule } from './modules/boot-audit/boot-audit.module.js';
 import { SignupModule } from './modules/signup/signup.module.js';
+import { EmailVerificationModule } from './modules/email-verification/email-verification.module.js';
 
 /**
  * `FEATURE_SNIPEIT_COMPAT_SHIM` (ADR-0010 rollback plan) toggles
@@ -141,6 +142,7 @@ const conditionalSelfServeSignup: DynamicModule[] = selfServeSignupEnabled()
     AssetModule,
     HealthModule,
     ImportModule,
+    EmailVerificationModule,
     ...conditionalCompatShim,
     ...conditionalInspections,
     ...conditionalMaintenance,

--- a/apps/core-api/src/modules/audit/audit-actions.ts
+++ b/apps/core-api/src/modules/audit/audit-actions.ts
@@ -148,32 +148,82 @@ export const PanoramaAuditAction = {
    */
   TenantSignupInitiated: 'panorama.tenant.signup_initiated',
   /**
-   * Verification email dispatched after a successful signup
-   * (ADR-0020 §3). Per-tenant event (the tenant exists in
-   * `pending_verification` state by this point). Fired after the
-   * SMTP submit returns success — bounces are tracked separately
-   * (out of scope for this event).
+   * Verification token minted (tenant row inserted, email-row
+   * persisted, SMTP submit attempted). Per-tenant event (the tenant
+   * exists in `pending_verification` state by this point).
+   *
+   * Emit happens INSIDE the mint transaction — so the row is present
+   * even if the subsequent SMTP submit fails. A separate
+   * `TenantVerificationDispatchFailed` row signals the SMTP-side
+   * outcome; readers correlating the pair distinguish "minted +
+   * delivered" from "minted but SMTP refused" by the presence /
+   * absence of the dispatch-failed sibling within the same
+   * tokenKeyPrefix window.
    *
    * Metadata: `emailHash` (sha256 of normalized lowercase email —
    * the raw email is on `actorUser`, no need to duplicate), `ttl`
    * (token TTL in seconds, currently 86400), `tokenKeyPrefix`
-   * (first 8 chars of the token — ties this row to the consume
-   * row).
+   * (first 8 hex chars of the sha256 tokenHash — ties this row to
+   * the consume row and to any matching dispatch-failed sibling).
    */
   TenantVerificationSent: 'panorama.tenant.verification_sent',
+  /**
+   * SMTP submission for a verification email failed AFTER the token
+   * row was committed. Per-tenant event. Emitted out-of-band (own
+   * `audit.record` transaction) because the mint tx already
+   * committed by the time the dispatch attempt runs.
+   *
+   * The user-facing impact: the tenant exists in
+   * `pending_verification` state but the recipient never received
+   * the email. PR 2b's resend endpoint is the operator-driven
+   * recovery; until then, the user can re-signup (consuming a
+   * second §3 cap slot) or the maintainer can hand-flip the
+   * tenant via super-admin tooling.
+   *
+   * Metadata: `emailHash`, `tokenKeyPrefix` (ties to the
+   * `TenantVerificationSent` row whose dispatch failed), `errKind`
+   * (short string from the caught error name, e.g. `Error`,
+   * `TimeoutError`).
+   */
+  TenantVerificationDispatchFailed: 'panorama.tenant.verification_dispatch_failed',
   /**
    * Verification token consumed via POST /auth/verify (ADR-0020
    * §3). Per-tenant event. The tenant transitions from
    * `pending_verification` to `active` in the same transaction
-   * that writes this row. One-time-use is enforced by deleting the
-   * token row in the same transaction.
+   * that writes this row. One-time-use is enforced by setting the
+   * row's `consumedAt` timestamp (NOT a DELETE — preserving the
+   * row leaves a verifier-readable audit trail of the
+   * successful consume, and the row is reaped later by a cleanup
+   * sweep, not at consume time).
    *
-   * Metadata: `tokenKeyPrefix` (ties to the verification_sent
-   * row), `elapsedMs` (time between dispatch and consume — used
-   * for "verification took N hours" UX telemetry without standing
-   * up product analytics).
+   * Metadata: `tokenKeyPrefix` (first 8 hex chars of the sha256
+   * tokenHash — ties to the verification_sent row), `elapsedMs`
+   * (time between dispatch and consume — used for "verification
+   * took N hours" UX telemetry without standing up product
+   * analytics).
    */
   TenantVerified: 'panorama.tenant.verified',
+  /**
+   * POST /auth/verify refused. Cluster-wide event (`tenantId=null`)
+   * — the verify endpoint is reached from a logged-out browser
+   * before any tenant context applies. SIEM SHOULD alert on
+   * sustained non-zero rate (probable token-brute or audit-DoS).
+   * Possible reasons:
+   *   - `session_attached` — caller arrived with an authenticated
+   *     session; the verify endpoint is logged-out-only (mirrors
+   *     ADR-0020 §1a's signup-callback contract for the verify
+   *     surface).
+   *   - `rate_limit_ip` — POST /auth/verify per-IP bucket tripped
+   *     (5/IP/hour, parity with signup-initiate).
+   *   - `rate_limit_subnet` — POST /auth/verify per-subnet bucket
+   *     tripped (50/IPv4-/24 or IPv6-/64/24h, parity with
+   *     signup-initiate).
+   *
+   * Metadata: `reason` (one of the above), `keyHash` (sha256
+   * first-16 chars of the per-IP or per-subnet bucket key — only
+   * set for the rate_limit_* reasons).
+   */
+  AuthVerifyRefused: 'panorama.auth.verify_refused',
   /**
    * Self-serve signup refused because the OIDC identity (or its
    * email) already maps to an existing Panorama account (ADR-0020

--- a/apps/core-api/src/modules/email-verification/email-verification.config.ts
+++ b/apps/core-api/src/modules/email-verification/email-verification.config.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * ADR-0020 §3 — email-verification surface configuration.
+ *
+ * `EMAIL_VERIFICATION_TTL_HOURS` (default 24h) bounds how long a
+ * minted token stays consumable. Self-hosters can shorten if their
+ * threat model demands.
+ *
+ * `verifyUrlBase` is the absolute prefix the email body links to —
+ * defaults to `${APP_BASE_URL}/auth/verify`. The link itself is a
+ * GET (so email clients can render it) but the page at that URL is
+ * expected to forward the token to the backend via POST per §3
+ * (defeats Outlook Safe-Links / Slack unfurl pre-consumption of
+ * one-time tokens). The frontend implementation of that page is
+ * apps/web work; backend ships the endpoint + the email body.
+ */
+export interface EmailVerificationConfig {
+  ttlHours: number;
+  verifyUrlBase: string;
+  /**
+   * Same shape and env knob as `SignupConfigService.failureLatencyFloorMs`
+   * — reused here so the verify endpoint shares the §5 timing-padded
+   * 400 envelope without a cross-module dependency cycle
+   * (SignupModule → EmailVerificationModule and back). Default 600ms.
+   */
+  failureLatencyFloorMs: number;
+}
+
+@Injectable()
+export class EmailVerificationConfigService {
+  readonly config: EmailVerificationConfig;
+
+  constructor() {
+    const ttlRaw = process.env['EMAIL_VERIFICATION_TTL_HOURS'];
+    const ttlHours = ttlRaw ? Number(ttlRaw) : 24;
+    if (!Number.isFinite(ttlHours) || ttlHours <= 0 || ttlHours > 168) {
+      throw new Error(
+        `EMAIL_VERIFICATION_TTL_HOURS must be a positive number ≤168; got ${JSON.stringify(ttlRaw)}`,
+      );
+    }
+    const floorRaw = process.env['SIGNUP_FAILURE_LATENCY_FLOOR_MS'];
+    const failureLatencyFloorMs = floorRaw ? Number(floorRaw) : 600;
+    if (!Number.isFinite(failureLatencyFloorMs) || failureLatencyFloorMs < 0) {
+      throw new Error(
+        `SIGNUP_FAILURE_LATENCY_FLOOR_MS must be a non-negative number; got ${JSON.stringify(floorRaw)}`,
+      );
+    }
+    const baseUrl = (process.env['APP_BASE_URL'] ?? 'http://localhost:4000')
+      .replace(/\/+$/, '')
+      .toLowerCase();
+    this.config = {
+      ttlHours,
+      verifyUrlBase: `${baseUrl}/auth/verify`,
+      failureLatencyFloorMs,
+    };
+  }
+}

--- a/apps/core-api/src/modules/email-verification/email-verification.controller.ts
+++ b/apps/core-api/src/modules/email-verification/email-verification.controller.ts
@@ -1,0 +1,173 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Logger,
+  Post,
+  Req,
+  Res,
+} from '@nestjs/common';
+import { createHash } from 'node:crypto';
+import type { Request, Response } from 'express';
+import { z } from 'zod';
+import { EmailVerificationService } from './email-verification.service.js';
+import { EmailVerificationConfigService } from './email-verification.config.js';
+import { SignupRateLimits } from '../signup/signup-rate-limits.service.js';
+import { respondTimingPadded } from '../signup/signup-failure.helper.js';
+import { getRequestSession } from '../auth/session.middleware.js';
+import { AuditService } from '../audit/audit.service.js';
+import { PanoramaAuditAction } from '../audit/audit-actions.js';
+
+/**
+ * ADR-0020 §3 — POST /auth/verify.
+ *
+ * Token comes in the request body. The email link uses a URL FRAGMENT
+ * (`#token=...`) so the token never reaches the server / proxies /
+ * referers / inline scan logs; the frontend at `${verifyUrlBase}`
+ * reads `location.hash`, strips it, and POSTs the value here.
+ *
+ * Every failure path returns the same timing-padded 400 envelope as
+ * the signup endpoints (`{ error: 'signup_failed' }`, status 400 not
+ * 429) so an external attacker cannot distinguish missing /
+ * expired / already-consumed / rate-limited from each other purely
+ * by wall-clock. The shared `signup_failed` envelope is intentional:
+ * an enumerator can't tell whether `/auth/verify` even exists vs
+ * `/auth/signup/.../start` from the response shape alone.
+ *
+ * Rate-limit: shares the §4 per-IP + per-subnet buckets with the
+ * signup-initiate / signup-callback surfaces. Same threat actor
+ * (anonymous IP), same budget. Trip emits `AuthVerifyRefused` with
+ * the matching reason so SIEM can distinguish verify-flood from
+ * signup-flood. The §3 per-email cap does NOT apply here — the cap
+ * gates DISPATCH, not consume.
+ *
+ * Logged-out-only: a verify POST arriving with an authenticated
+ * session is a confused-deputy attempt (a logged-in user clicking
+ * a stray verify link from another tenant); refuse with
+ * `AuthVerifyRefused(reason='session_attached')`.
+ *
+ * Unlike SignupController, this endpoint is loaded UNCONDITIONALLY
+ * — even with `FEATURE_SELF_SERVE_SIGNUP=false`, a tenant created
+ * while the flag was on may still need the verify path. The
+ * endpoint refuses gracefully when no matching token exists.
+ */
+
+const VerifyBodySchema = z.object({
+  token: z.string().min(1).max(1024),
+});
+
+@Controller('auth')
+export class EmailVerificationController {
+  private readonly log = new Logger('EmailVerificationController');
+
+  constructor(
+    private readonly verifier: EmailVerificationService,
+    private readonly cfg: EmailVerificationConfigService,
+    private readonly limits: SignupRateLimits,
+    private readonly audit: AuditService,
+  ) {}
+
+  @Post('verify')
+  @HttpCode(200)
+  async verify(
+    @Body() body: unknown,
+    @Req() req: Request,
+    @Res({ passthrough: false }) res: Response,
+  ): Promise<void> {
+    const startedAt = Date.now();
+
+    // §3-derived rate-limits FIRST — bound any pre-validation audit-
+    // emit flood. Mirrors the SignupController contract.
+    const ipDecision = await this.limits.consumeIp(req.ip);
+    if (!ipDecision.allowed) {
+      await this.recordRefused('rate_limit_ip', req.ip ?? null);
+      return respondTimingPadded(
+        res,
+        startedAt,
+        this.cfg.config.failureLatencyFloorMs,
+      );
+    }
+    const subnetDecision = await this.limits.consumeSubnet(req.ip);
+    if (!subnetDecision.allowed) {
+      await this.recordRefused('rate_limit_subnet', req.ip ?? null);
+      return respondTimingPadded(
+        res,
+        startedAt,
+        this.cfg.config.failureLatencyFloorMs,
+      );
+    }
+
+    // §1a-parallel: verify is logged-out-only. A logged-in user
+    // POSTing a stray token from another tenant would otherwise
+    // flip that tenant's pendingVerification (the consume path
+    // doesn't check session).
+    if (getRequestSession(req)) {
+      await this.recordRefused('session_attached', null);
+      return respondTimingPadded(
+        res,
+        startedAt,
+        this.cfg.config.failureLatencyFloorMs,
+      );
+    }
+
+    const parsed = VerifyBodySchema.safeParse(body);
+    if (!parsed.success) {
+      return respondTimingPadded(
+        res,
+        startedAt,
+        this.cfg.config.failureLatencyFloorMs,
+      );
+    }
+
+    const result = await this.verifier.consume(parsed.data.token);
+
+    if (result.kind === 'ok') {
+      // Success — tenant is now verified. The browser can now sign in
+      // through the standard /auth/oidc/:provider/start flow; the
+      // session-build path will see `pendingVerification=false` and
+      // mint a session. We do NOT mint the session here because the
+      // verify endpoint is OIDC-agnostic (the user submits a token,
+      // not an OIDC token), and reusing the signup callback's stored
+      // codeVerifier would require coupling the two surfaces.
+      res.status(200).json({ ok: true });
+      return;
+    }
+
+    // All four failure shapes share the same response envelope.
+    // The specific reason is logged + (could be audited in a future
+    // PR — see security-reviewer R-item on emitting for
+    // `already_consumed` and verified-`expired`) but never surfaced
+    // to the client.
+    this.log.warn({ reason: result.kind }, 'verify_failed');
+    return respondTimingPadded(
+      res,
+      startedAt,
+      this.cfg.config.failureLatencyFloorMs,
+    );
+  }
+
+  private async recordRefused(
+    reason: 'session_attached' | 'rate_limit_ip' | 'rate_limit_subnet',
+    keyMaterial: string | null,
+  ): Promise<void> {
+    try {
+      const metadata: Record<string, unknown> = { reason };
+      if (keyMaterial !== null) {
+        metadata['keyHash'] = createHash('sha256')
+          .update(keyMaterial)
+          .digest('hex')
+          .slice(0, 16);
+      }
+      await this.audit.record({
+        action: PanoramaAuditAction.AuthVerifyRefused,
+        resourceType: 'auth_identity',
+        resourceId: null,
+        tenantId: null,
+        actorUserId: null,
+        metadata,
+      });
+    } catch (err) {
+      this.log.error({ err: String(err) }, 'verify_refused_audit_write_failed');
+    }
+  }
+}

--- a/apps/core-api/src/modules/email-verification/email-verification.module.ts
+++ b/apps/core-api/src/modules/email-verification/email-verification.module.ts
@@ -1,0 +1,37 @@
+import { Module } from '@nestjs/common';
+import { EmailModule } from '../email/email.module.js';
+import { SignupRateLimits } from '../signup/signup-rate-limits.service.js';
+import { EmailVerificationConfigService } from './email-verification.config.js';
+import { EmailVerificationController } from './email-verification.controller.js';
+import { EmailVerificationService } from './email-verification.service.js';
+
+/**
+ * ADR-0020 §3 — email-verification surface (PR 2).
+ *
+ * Loaded UNCONDITIONALLY — even with `FEATURE_SELF_SERVE_SIGNUP=false`
+ * an existing tenant (created while the flag was on) may still need
+ * to verify. Signup callback consumption (mint+dispatch) is gated
+ * separately at the caller (`SignupModule` injects the service only
+ * when the flag is on).
+ *
+ * `EmailVerificationConfigService` mirrors the
+ * `SIGNUP_FAILURE_LATENCY_FLOOR_MS` env knob from `SignupConfigService`
+ * to avoid a SignupModule ↔ EmailVerificationModule import cycle.
+ * Both configs read the same env var so the two surfaces share a
+ * single tunable in deployment.
+ */
+@Module({
+  imports: [EmailModule],
+  controllers: [EmailVerificationController],
+  providers: [
+    EmailVerificationConfigService,
+    EmailVerificationService,
+    // Reused by EmailVerificationController for the §4 per-IP +
+    // per-subnet buckets on POST /auth/verify. Same Redis key
+    // namespace as the signup endpoints so a single client IP
+    // shares one budget across both surfaces.
+    SignupRateLimits,
+  ],
+  exports: [EmailVerificationService],
+})
+export class EmailVerificationModule {}

--- a/apps/core-api/src/modules/email-verification/email-verification.service.ts
+++ b/apps/core-api/src/modules/email-verification/email-verification.service.ts
@@ -1,0 +1,296 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { createHash, randomBytes } from 'node:crypto';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { AuditService } from '../audit/audit.service.js';
+import { PanoramaAuditAction } from '../audit/audit-actions.js';
+import { EmailService } from '../email/email.service.js';
+import { RateLimiter, type RateLimitDecision } from '../redis/rate-limiter.js';
+import { EmailVerificationConfigService } from './email-verification.config.js';
+import {
+  renderVerificationEmail,
+  type VerificationEmailContext,
+} from './email-verification.templates.js';
+
+/**
+ * Email-verification domain service (ADR-0020 §3).
+ *
+ * Three responsibilities:
+ *   1. `checkEmailCap` — fail-closed per-email rate limit. ADR §3
+ *      caps DISPATCH ATTEMPTS at 3 per email per 24h (not pending
+ *      tokens — already-consumed tokens still count toward the cap
+ *      because the limit defends an INBOX from harassment, not a
+ *      tenant from over-subscription). Backed by `RateLimiter`
+ *      sliding window; trip emits `TenantVerificationThrottled` and
+ *      caller refuses the signup.
+ *   2. `mintAndDispatch` — generates a 256-bit token, persists its
+ *      sha256 in `email_verifications`, dispatches the email
+ *      synchronously via `EmailService`, and emits
+ *      `TenantVerificationSent`. SMTP failure is logged but does
+ *      NOT roll back the tenant (the caller redirects to the
+ *      "check your inbox" page regardless; PR 2b would add a
+ *      resend endpoint for stuck users).
+ *   3. `consume` — POST /auth/verify entry. Looks up tokenHash,
+ *      validates not-consumed + not-expired + matching tenant in
+ *      pendingVerification state. Same transaction flips
+ *      `Tenant.pendingVerification=false`, marks `consumedAt`, and
+ *      emits `TenantVerified`. Failures funnel back to the
+ *      controller for the timing-padded 400 envelope.
+ *
+ * All paths go through `prisma.runAsSuperAdmin`: the
+ * `email_verifications` table has no GRANT to panorama_app, and the
+ * verify endpoint is called from a logged-out browser (no tenant
+ * context).
+ */
+
+const CAP_LIMIT = 3;
+const CAP_WINDOW_MS = 24 * 60 * 60 * 1000;
+const CAP_KEY_PREFIX = 'panorama:signup:verify-email:';
+
+export type ConsumeResult =
+  | { kind: 'ok'; tenantId: string }
+  | { kind: 'missing' }
+  | { kind: 'expired' }
+  | { kind: 'already_consumed' }
+  | { kind: 'tenant_already_verified' };
+
+export interface MintAndDispatchInput {
+  userId: string;
+  tenantId: string;
+  tenantDisplayName: string;
+  /**
+   * RFC 5322-asserted recipient email (preserves the IdP's
+   * original casing — RFC 5321 §2.3.11 says the local-part is
+   * case-sensitive, so SMTP `to:` MUST use the unmodified form to
+   * avoid MX-side delivery failures).
+   */
+  email: string;
+}
+
+export interface MintAndDispatchOutput {
+  dispatched: boolean;
+  /** sha256(token) first-8 hex chars — for audit correlation. */
+  tokenKeyPrefix: string;
+  expiresAt: Date;
+}
+
+@Injectable()
+export class EmailVerificationService {
+  private readonly log = new Logger('EmailVerificationService');
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+    private readonly mail: EmailService,
+    private readonly limiter: RateLimiter,
+    private readonly cfg: EmailVerificationConfigService,
+  ) {}
+
+  /**
+   * Reserve a per-email dispatch slot. Caller must invoke BEFORE
+   * `mintAndDispatch`; if `allowed === false`, caller emits
+   * `TenantVerificationThrottled` and refuses the signup with the
+   * standard timing-padded 400 envelope.
+   *
+   * Bucket key: sha256(emailLower) so the raw email never enters
+   * Redis logs.
+   */
+  async checkEmailCap(email: string): Promise<RateLimitDecision> {
+    return this.limiter.consume(
+      CAP_KEY_PREFIX + hashEmail(normalizeEmail(email)),
+      CAP_LIMIT,
+      CAP_WINDOW_MS,
+    );
+  }
+
+  async mintAndDispatch(input: MintAndDispatchInput): Promise<MintAndDispatchOutput> {
+    const { plaintext, tokenHash } = this.generateToken();
+    const expiresAt = new Date(Date.now() + this.cfg.config.ttlHours * 60 * 60 * 1000);
+    // Defensive normalization at the service boundary — every caller
+    // currently does this too, but pinning the contract here means a
+    // future caller can't accidentally key the cap on a non-canonical
+    // value or write a non-canonical row.
+    const emailLower = normalizeEmail(input.email);
+    const tokenKeyPrefix = tokenHash.slice(0, 8);
+
+    await this.prisma.runAsSuperAdmin(
+      async (tx) => {
+        await tx.emailVerification.create({
+          data: {
+            userId: input.userId,
+            tenantId: input.tenantId,
+            emailLower,
+            tokenHash,
+            expiresAt,
+          },
+        });
+        await this.audit.recordWithin(tx, {
+          action: PanoramaAuditAction.TenantVerificationSent,
+          resourceType: 'tenant',
+          resourceId: input.tenantId,
+          tenantId: input.tenantId,
+          actorUserId: input.userId,
+          metadata: {
+            emailHash: hashEmail(emailLower),
+            ttl: this.cfg.config.ttlHours * 60 * 60,
+            tokenKeyPrefix,
+          },
+        });
+      },
+      { reason: `email-verification:mint:${input.tenantId}` },
+    );
+
+    let dispatched = true;
+    try {
+      const emailCtx: VerificationEmailContext = {
+        recipientEmail: input.email,
+        tenantDisplayName: input.tenantDisplayName,
+        token: plaintext,
+        verifyUrlBase: this.cfg.config.verifyUrlBase,
+        expiresAt,
+      };
+      const rendered = renderVerificationEmail(emailCtx);
+      // SMTP `to:` uses the IdP-asserted casing per RFC 5321 §2.3.11
+      // (local-part is case-sensitive). Cap / DB / audit use the
+      // lowercased form for cross-attempt correlation.
+      await this.mail.send({
+        to: input.email,
+        subject: rendered.subject,
+        text: rendered.text,
+        html: rendered.html,
+      });
+    } catch (err) {
+      dispatched = false;
+      this.log.error({ err: String(err) }, 'verification_email_dispatch_failed');
+      // The mint tx already committed (the row exists, the audit
+      // says "Sent"). Emit a sibling `TenantVerificationDispatchFailed`
+      // row so the audit trail is honest about which dispatches
+      // actually reached the wire. Best-effort — failure to write
+      // this audit row is logged but doesn't escalate.
+      try {
+        await this.audit.record({
+          action: PanoramaAuditAction.TenantVerificationDispatchFailed,
+          resourceType: 'tenant',
+          resourceId: input.tenantId,
+          tenantId: input.tenantId,
+          actorUserId: input.userId,
+          metadata: {
+            emailHash: hashEmail(emailLower),
+            tokenKeyPrefix,
+            errKind: err instanceof Error ? err.name : 'Unknown',
+          },
+        });
+      } catch (auditErr) {
+        this.log.error(
+          { err: String(auditErr) },
+          'verification_dispatch_failed_audit_write_failed',
+        );
+      }
+    }
+    return { dispatched, tokenKeyPrefix, expiresAt };
+  }
+
+  /**
+   * POST /auth/verify consume path. Atomic flip of:
+   *   - `Tenant.pendingVerification = false`
+   *   - `EmailVerification.consumedAt = now()`
+   *
+   * Returns a tagged union so the controller can emit the right
+   * timing-padded 400 envelope without leaking the specific reason
+   * to the client (audit row carries the SIEM-side detail).
+   */
+  async consume(token: string): Promise<ConsumeResult> {
+    if (!token || typeof token !== 'string' || token.length === 0) {
+      return { kind: 'missing' };
+    }
+    const tokenHash = hashToken(token);
+    return this.prisma.runAsSuperAdmin(
+      async (tx) => {
+        const row = await tx.emailVerification.findUnique({
+          where: { tokenHash },
+        });
+        if (!row) return { kind: 'missing' } as const;
+        if (row.consumedAt !== null) return { kind: 'already_consumed' } as const;
+        if (row.expiresAt.getTime() <= Date.now()) return { kind: 'expired' } as const;
+
+        const tenant = await tx.tenant.findUnique({
+          where: { id: row.tenantId },
+          select: { id: true, pendingVerification: true },
+        });
+        if (!tenant) return { kind: 'missing' } as const;
+        if (!tenant.pendingVerification) {
+          // The tenant was already flipped (via a sibling token or
+          // an operator override). Treat the second consume as a
+          // no-op: the user-facing outcome is the same.
+          return { kind: 'tenant_already_verified' } as const;
+        }
+
+        await tx.emailVerification.update({
+          where: { id: row.id },
+          data: { consumedAt: new Date() },
+        });
+        await tx.tenant.update({
+          where: { id: row.tenantId },
+          data: { pendingVerification: false },
+        });
+
+        const elapsedMs = Date.now() - row.createdAt.getTime();
+        await this.audit.recordWithin(tx, {
+          action: PanoramaAuditAction.TenantVerified,
+          resourceType: 'tenant',
+          resourceId: row.tenantId,
+          tenantId: row.tenantId,
+          actorUserId: row.userId,
+          metadata: {
+            tokenKeyPrefix: row.tokenHash.slice(0, 8),
+            elapsedMs,
+          },
+        });
+
+        return { kind: 'ok' as const, tenantId: row.tenantId };
+      },
+      { reason: `email-verification:consume` },
+    );
+  }
+
+  /**
+   * Best-effort observability: write `TenantVerificationThrottled` when
+   * the §3 cap trips. Cluster-wide event (the tenant might not exist
+   * yet, e.g. the 4th signup attempt for a new email).
+   */
+  async recordThrottled(email: string): Promise<void> {
+    try {
+      await this.audit.record({
+        action: PanoramaAuditAction.TenantVerificationThrottled,
+        resourceType: 'tenant',
+        resourceId: null,
+        tenantId: null,
+        actorUserId: null,
+        metadata: {
+          emailHash: hashEmail(normalizeEmail(email)),
+        },
+      });
+    } catch (err) {
+      this.log.error(
+        { err: String(err) },
+        'verification_throttled_audit_write_failed',
+      );
+    }
+  }
+
+  private generateToken(): { plaintext: string; tokenHash: string } {
+    const plaintext = randomBytes(32).toString('base64url');
+    return { plaintext, tokenHash: hashToken(plaintext) };
+  }
+}
+
+function hashToken(plaintext: string): string {
+  return createHash('sha256').update(plaintext).digest('hex');
+}
+
+function hashEmail(emailLower: string): string {
+  return createHash('sha256').update(emailLower).digest('hex');
+}
+
+function normalizeEmail(email: string): string {
+  return email.toLowerCase().trim();
+}

--- a/apps/core-api/src/modules/email-verification/email-verification.templates.ts
+++ b/apps/core-api/src/modules/email-verification/email-verification.templates.ts
@@ -1,0 +1,105 @@
+/**
+ * ADR-0020 §3 — verification email body.
+ *
+ * Kept English-only for PR 2; the trilingual sibling lives at
+ * `invitation-email.templates.ts` and the same pattern can be
+ * lifted here when the public-preview launch needs PT-BR + ES.
+ *
+ * Link shape — token rides in the URL FRAGMENT (`#token=...`) NOT
+ * the query string. URL fragments never reach the server, so
+ * link-preview bots (Outlook Safe-Links, Slack unfurl, Mimecast URL
+ * Defense, Gmail content-inspection) that GET the URL cannot
+ * exfiltrate or pre-consume the token. The frontend at
+ * `${verifyUrlBase}` reads `location.hash`, strips it, and forwards
+ * the value via POST to the same endpoint — matching the §3
+ * "POST not GET" contract for the actual consume call.
+ *
+ * The paste-fallback (raw token below the button) is text-only, so
+ * no inline scanner fetches it; the token is exposed inside the
+ * email body itself, which the recipient's inbox already trusts.
+ */
+
+export interface VerificationEmailContext {
+  recipientEmail: string;
+  tenantDisplayName: string;
+  /** Plaintext token surfaced once; never persisted. */
+  token: string;
+  /** Absolute URL the email body links to, e.g. `${baseUrl}/auth/verify`. */
+  verifyUrlBase: string;
+  expiresAt: Date;
+}
+
+export interface RenderedEmail {
+  subject: string;
+  text: string;
+  html: string;
+}
+
+export function renderVerificationEmail(ctx: VerificationEmailContext): RenderedEmail {
+  const subject = `Verify your Panorama tenant "${ctx.tenantDisplayName}"`;
+  const expiresIso = ctx.expiresAt.toISOString();
+  // §3 — fragment, NOT query. The frontend at verifyUrlBase reads
+  // `location.hash`, strips it, and POSTs the token to /auth/verify.
+  // Link-preview bots that fetch the URL never see the token.
+  const verifyUrl = `${ctx.verifyUrlBase}#token=${encodeURIComponent(ctx.token)}`;
+
+  const text = [
+    `Hello ${ctx.recipientEmail},`,
+    '',
+    `You just signed up for a Panorama tenant: ${ctx.tenantDisplayName}.`,
+    `To finish setup, confirm your email by clicking the link below:`,
+    '',
+    verifyUrl,
+    '',
+    `This link expires at ${expiresIso}.`,
+    '',
+    `If the link does not work, paste this token into the verification page:`,
+    `  ${ctx.token}`,
+    '',
+    `If you did not sign up for Panorama, ignore this email — your tenant will be cleaned up automatically.`,
+    '',
+    `— Panorama`,
+  ].join('\n');
+
+  const html = /* html */ `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>${escapeHtml(subject)}</title></head>
+<body style="font-family:-apple-system,Segoe UI,Roboto,sans-serif;background:#0f172a;color:#e2e8f0;padding:32px 0;margin:0;">
+<table role="presentation" align="center" width="540" cellpadding="0" cellspacing="0"
+       style="background:#1e293b;border-radius:12px;overflow:hidden;">
+<tr><td style="padding:32px;">
+<h1 style="margin:0 0 16px 0;font-size:22px;color:#f8fafc;">Verify your tenant</h1>
+<p style="margin:0 0 16px 0;line-height:1.5;">You just signed up for the Panorama tenant
+<strong>${escapeHtml(ctx.tenantDisplayName)}</strong>. Confirm your email to finish setup.</p>
+<p style="margin:24px 0;">
+  <a href="${escapeHtml(verifyUrl)}"
+     style="display:inline-block;background:#38bdf8;color:#0f172a;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+     Verify email
+  </a>
+</p>
+<p style="margin:16px 0;color:#94a3b8;font-size:13px;">
+  This link expires at <code style="color:#e2e8f0;">${escapeHtml(expiresIso)}</code>.
+</p>
+<p style="margin:24px 0 0 0;color:#94a3b8;font-size:13px;">
+  If the button does not work, paste this token into the verification page:
+  <br/><code style="display:inline-block;background:#0f172a;padding:6px 12px;border-radius:4px;margin-top:8px;color:#e2e8f0;">${escapeHtml(ctx.token)}</code>
+</p>
+<p style="margin:24px 0 0 0;color:#64748b;font-size:12px;">
+  If you did not sign up for Panorama, ignore this email — your tenant will be cleaned up automatically.
+</p>
+</td></tr>
+</table>
+</body>
+</html>`;
+
+  return { subject, text, html };
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/apps/core-api/src/modules/signup/signup.controller.ts
+++ b/apps/core-api/src/modules/signup/signup.controller.ts
@@ -18,6 +18,7 @@ import { getRequestSession } from '../auth/session.middleware.js';
 import { AuditService } from '../audit/audit.service.js';
 import { PanoramaAuditAction } from '../audit/audit-actions.js';
 import { TenantAdminService } from '../tenant/tenant-admin.service.js';
+import { EmailVerificationService } from '../email-verification/email-verification.service.js';
 import { SignupConfigService } from './signup.config.js';
 import {
   SignupStateStore,
@@ -95,6 +96,7 @@ export class SignupController {
     private readonly stateStore: SignupStateStore,
     private readonly turnstile: TurnstileVerifier,
     private readonly limits: SignupRateLimits,
+    private readonly verification: EmailVerificationService,
     private readonly audit: AuditService,
   ) {}
 
@@ -323,6 +325,18 @@ export class SignupController {
       return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
     }
 
+    // §3 per-email cap — fail-closed BEFORE creating the tenant so
+    // a throttled email doesn't leave behind an orphan pending
+    // tenant. Bucket: 3 verification dispatches per email per 24h.
+    // Trip emits TenantVerificationThrottled. `checkEmailCap`
+    // normalizes the email internally so we pass the IdP-asserted
+    // form here.
+    const capDecision = await this.verification.checkEmailCap(userInfo.email);
+    if (!capDecision.allowed) {
+      await this.verification.recordThrottled(userInfo.email);
+      return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+
     // §2 + §2a + §3 — one tenant per successful signup. Tenant.id +
     // Tenant.slug = freshly-minted UUID (opaque). Tenant ships with
     // `pendingVerification=true`; PR 2's verify endpoint flips it.
@@ -347,6 +361,23 @@ export class SignupController {
     } catch (err) {
       this.log.error({ err: String(err) }, 'signup_tenant_create_failed');
       return respondTimingPadded(res, startedAt, this.cfg.config.failureLatencyFloorMs);
+    }
+
+    // §3 mint verification token + dispatch email. SMTP failure logs
+    // loud but does NOT roll back the tenant — the operator-driven
+    // resend (PR 2b) is the fallback for stuck users; everyone else
+    // sees the email. The cap check above already reserved one
+    // dispatch slot for this email; that slot stays consumed
+    // regardless of SMTP outcome.
+    try {
+      await this.verification.mintAndDispatch({
+        userId: resolved.userId,
+        tenantId,
+        tenantDisplayName: displayName,
+        email: userInfo.email,
+      });
+    } catch (err) {
+      this.log.error({ err: String(err), tenantId }, 'signup_mint_dispatch_failed');
     }
 
     // §3 — DO NOT establish a session here. The tenant carries
@@ -534,13 +565,28 @@ function hashUserAgent(userAgent: string | null): string | null {
   return createHash('sha256').update(userAgent).digest('hex');
 }
 
+/** Cap the OIDC `name` claim at a sensible length + strip control
+ * characters before persisting it as `Tenant.displayName`. Without
+ * this, a malicious IdP could ship a 10kB name with embedded ANSI /
+ * NUL bytes; the value would round-trip through Tenant rows,
+ * audit-event metadata (becoming part of the chain digest pre-image),
+ * and email subject lines (exceeding RFC 5322 line-length limits).
+ * 200 chars matches typical UI render budgets; control chars are
+ * stripped via a class match on the C0 + C1 control ranges + DEL.
+ */
+function sanitizeDisplayName(raw: string): string {
+  // eslint-disable-next-line no-control-regex
+  return raw.replace(/[\x00-\x1f\x7f-\x9f]/g, '').trim().slice(0, 200);
+}
+
 function friendlyDisplayName(resolvedName: string, email: string): string {
   // OIDC `name` claim is usually the user's full name and works as
   // both Tenant.name and Tenant.displayName for a one-person org. If
   // the IdP didn't send a name (rare), fall back to the local-part
   // of the email so the tenant has SOMETHING readable in the UI.
-  const trimmed = resolvedName.trim();
-  if (trimmed.length > 0 && !trimmed.includes('@')) return trimmed;
+  const safe = sanitizeDisplayName(resolvedName);
+  if (safe.length > 0 && !safe.includes('@')) return safe;
   const at = email.indexOf('@');
-  return at > 0 ? email.slice(0, at) : email;
+  const fallback = at > 0 ? email.slice(0, at) : email;
+  return sanitizeDisplayName(fallback);
 }

--- a/apps/core-api/src/modules/signup/signup.module.ts
+++ b/apps/core-api/src/modules/signup/signup.module.ts
@@ -1,6 +1,7 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module.js';
 import { TenantModule } from '../tenant/tenant.module.js';
+import { EmailVerificationModule } from '../email-verification/email-verification.module.js';
 import { SignupConfigService } from './signup.config.js';
 import { SignupController } from './signup.controller.js';
 import { SignupStateStore } from './signup-state.store.js';
@@ -25,7 +26,7 @@ import { TurnstileVerifier } from './turnstile-verifier.service.js';
  *     automatically.
  */
 @Module({
-  imports: [forwardRef(() => AuthModule), TenantModule],
+  imports: [forwardRef(() => AuthModule), TenantModule, EmailVerificationModule],
   controllers: [SignupController],
   providers: [SignupConfigService, SignupStateStore, SignupRateLimits, TurnstileVerifier],
 })

--- a/apps/core-api/test/email-verification.e2e.test.ts
+++ b/apps/core-api/test/email-verification.e2e.test.ts
@@ -1,0 +1,382 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Test } from '@nestjs/testing';
+import { ValidationPipe } from '@nestjs/common';
+import type { INestApplication } from '@nestjs/common';
+import type { NestExpressApplication } from '@nestjs/platform-express';
+import { PrismaClient } from '@prisma/client';
+import { Redis } from 'ioredis';
+import { AppModule } from '../src/app.module.js';
+import { OidcService, type OidcUserInfo } from '../src/modules/auth/oidc.service.js';
+import { TurnstileVerifier } from '../src/modules/signup/turnstile-verifier.service.js';
+import { EmailService } from '../src/modules/email/email.service.js';
+import { resetTestDb } from './_reset-db.js';
+
+/**
+ * E2e coverage for ADR-0020 §3 (PR 2 email verification surface).
+ *
+ * Walks the full self-serve signup → verify flow end-to-end:
+ *
+ *   1. Happy path: POST signup-start → GET signup-callback (mocked
+ *      OidcService) → captured email → POST /auth/verify with the
+ *      mock-captured token → tenant.pendingVerification flips to
+ *      false.
+ *   2. Replay: a second POST with the same token gets the same
+ *      timing-padded 400 envelope (one-time-use enforcement).
+ *   3. Expired: manually move the row's expiresAt into the past +
+ *      assert POST returns 400.
+ *   4. Per-email cap: 4 signups with the same email — the 4th hits
+ *      the §3 per-email Redis bucket BEFORE the tenant is created
+ *      and refuses with 400; `TenantVerificationThrottled` audit row
+ *      is emitted; only 3 tenants exist for that email.
+ *
+ * The `EmailService.send` mock captures the LAST dispatched email per
+ * recipient so the verify-token can be extracted from the rendered
+ * text body without round-tripping through SMTP.
+ */
+
+const HOST = process.env['PG_HOST'] ?? 'localhost';
+const PORT = process.env['PG_PORT'] ?? '5432';
+const DB = process.env['PG_DB'] ?? 'panorama';
+const ADMIN_URL = `postgres://panorama_super_admin:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+const APP_URL = `postgres://panorama_app:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+const REDIS_URL = process.env['REDIS_URL'] ?? 'redis://localhost:6379/0';
+
+const SYNTHETIC_GOOGLE_ISSUER = 'https://accounts.google.invalid';
+
+interface SentEmail {
+  to: string;
+  subject: string;
+  text: string;
+}
+
+describe('email verification (ADR-0020 §3, PR 2)', () => {
+  let app: INestApplication;
+  let url: string;
+  let admin: PrismaClient;
+  let redis: Redis;
+  let sentEmails: SentEmail[];
+  let oidcCallback: ReturnType<typeof makeOidcCallbackMock>;
+
+  beforeAll(async () => {
+    process.env['SESSION_SECRET'] = process.env['SESSION_SECRET'] ?? 'a'.repeat(32);
+    process.env['DATABASE_URL'] = APP_URL;
+    process.env['FEATURE_SELF_SERVE_SIGNUP'] = 'true';
+    process.env['TURNSTILE_SECRET'] = 'test-secret';
+    process.env['SIGNUP_FAILURE_LATENCY_FLOOR_MS'] = '20';
+    process.env['OIDC_GOOGLE_CLIENT_ID'] = 'test-google-client';
+    process.env['OIDC_GOOGLE_CLIENT_SECRET'] = 'test-google-secret';
+    process.env['APP_BASE_URL'] = process.env['APP_BASE_URL'] ?? 'http://localhost:4000';
+
+    admin = new PrismaClient({ datasources: { db: { url: ADMIN_URL } } });
+    await resetTestDb(admin);
+
+    redis = new Redis(REDIS_URL);
+    await flushSignupKeys(redis);
+
+    sentEmails = [];
+    oidcCallback = makeOidcCallbackMock();
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(OidcService)
+      .useValue({
+        start: async (params: { provider: string; state?: string }) => ({
+          url: `http://example.invalid/idp/auth?state=${params.state ?? 'unknown'}`,
+          state: params.state ?? 'unknown',
+          codeVerifier: 'test-code-verifier',
+          nonce: 'test-nonce',
+        }),
+        callback: oidcCallback.fn,
+      })
+      .overrideProvider(TurnstileVerifier)
+      .useValue({
+        verify: async () => ({ ok: true }),
+      })
+      .overrideProvider(EmailService)
+      .useValue({
+        send: async (input: { to: string; subject: string; text: string }) => {
+          sentEmails.push({ to: input.to, subject: input.subject, text: input.text });
+          return { messageId: `mock-${sentEmails.length}` };
+        },
+        onModuleDestroy: async () => {},
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication<NestExpressApplication>({
+      logger: ['error', 'warn'],
+    });
+    (app as NestExpressApplication).set('trust proxy', 1);
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+    await app.listen(0);
+    url = await app.getUrl();
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.close();
+    await admin?.$disconnect();
+    await redis?.quit();
+    delete process.env['FEATURE_SELF_SERVE_SIGNUP'];
+  });
+
+  beforeEach(async () => {
+    await flushSignupKeys(redis);
+    // Use the shared resetTestDb helper — it wraps the deletes in the
+    // `panorama.bypass_owner_check` GUC scope so the
+    // TENANT_MUST_HAVE_AT_LEAST_ONE_OWNER trigger (migration 0005)
+    // doesn't fire while we tear down per-test fixtures.
+    await resetTestDb(admin);
+    sentEmails.length = 0;
+    oidcCallback.reset();
+  });
+
+  it('happy path: signup mints a verification email; POST /auth/verify flips pendingVerification', async () => {
+    oidcCallback.setUserInfo({
+      subject: 'sub-happy-001',
+      email: 'happy@example.invalid',
+      firstName: 'Happy',
+      lastName: 'User',
+      displayName: 'Happy User',
+      emailVerified: true,
+      hd: null,
+      iss: SYNTHETIC_GOOGLE_ISSUER,
+    });
+
+    // Drive the signup flow.
+    const startResp = await postStart(url, '14.0.0.1');
+    expect(startResp.status).toBe(302);
+    const stateKey = readStateFromLocation(startResp.headers.get('location') ?? '');
+    const cbResp = await fetch(
+      `${url}/auth/signup/google/callback?code=fake&state=${stateKey}`,
+      { redirect: 'manual', headers: { 'X-Forwarded-For': '14.0.0.1' } },
+    );
+    expect(cbResp.status).toBe(302);
+    expect(cbResp.headers.get('location')).toBe('/?signup=verify');
+
+    // The mock captured one email — extract the plaintext token from
+    // the rendered text body (matches the template's
+    // "?token=<plaintext>" link AND the "paste this token" stanza).
+    expect(sentEmails).toHaveLength(1);
+    expect(sentEmails[0]!.to).toBe('happy@example.invalid');
+    const token = extractTokenFromEmail(sentEmails[0]!.text);
+    expect(token).not.toBe('');
+
+    // Pre-verify: tenant exists, pendingVerification=true.
+    const pendingBefore = await admin.tenant.findFirst({
+      where: { pendingVerification: true },
+    });
+    expect(pendingBefore).not.toBeNull();
+
+    // POST /auth/verify.
+    const verifyResp = await fetch(`${url}/auth/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+    expect(verifyResp.status).toBe(200);
+
+    // Post-verify: tenant.pendingVerification=false.
+    const verified = await admin.tenant.findUnique({
+      where: { id: pendingBefore!.id },
+    });
+    expect(verified?.pendingVerification).toBe(false);
+
+    // EmailVerification row is consumed.
+    const consumedRow = await admin.emailVerification.findFirst({
+      where: { tenantId: pendingBefore!.id },
+    });
+    expect(consumedRow?.consumedAt).not.toBeNull();
+  });
+
+  it('replay: a second POST with the same token is rejected', async () => {
+    oidcCallback.setUserInfo({
+      subject: 'sub-replay-001',
+      email: 'replay@example.invalid',
+      firstName: 'Replay',
+      lastName: 'User',
+      displayName: 'Replay',
+      emailVerified: true,
+      hd: null,
+      iss: SYNTHETIC_GOOGLE_ISSUER,
+    });
+    const startResp = await postStart(url, '14.0.0.2');
+    const stateKey = readStateFromLocation(startResp.headers.get('location') ?? '');
+    await fetch(`${url}/auth/signup/google/callback?code=fake&state=${stateKey}`, {
+      redirect: 'manual',
+      headers: { 'X-Forwarded-For': '14.0.0.2' },
+    });
+    const token = extractTokenFromEmail(sentEmails[0]!.text);
+
+    const first = await fetch(`${url}/auth/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+    expect(first.status).toBe(200);
+
+    const second = await fetch(`${url}/auth/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+    expect(second.status).toBe(400);
+  });
+
+  it('expired: a token past its expiresAt is rejected', async () => {
+    oidcCallback.setUserInfo({
+      subject: 'sub-expired-001',
+      email: 'expired@example.invalid',
+      firstName: 'Expired',
+      lastName: 'User',
+      displayName: 'Expired',
+      emailVerified: true,
+      hd: null,
+      iss: SYNTHETIC_GOOGLE_ISSUER,
+    });
+    const startResp = await postStart(url, '14.0.0.3');
+    const stateKey = readStateFromLocation(startResp.headers.get('location') ?? '');
+    await fetch(`${url}/auth/signup/google/callback?code=fake&state=${stateKey}`, {
+      redirect: 'manual',
+      headers: { 'X-Forwarded-For': '14.0.0.3' },
+    });
+    const token = extractTokenFromEmail(sentEmails[0]!.text);
+
+    // Move the row's expiresAt into the past — we still own
+    // panorama_super_admin (admin client) so the UPDATE goes through.
+    await admin.emailVerification.updateMany({
+      where: { emailLower: 'expired@example.invalid' },
+      data: { expiresAt: new Date(Date.now() - 60 * 60 * 1000) },
+    });
+
+    const resp = await fetch(`${url}/auth/verify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+    expect(resp.status).toBe(400);
+  });
+
+  it('rate-limit: POST /auth/verify trips on the 6th attempt from one IP', async () => {
+    // The verify endpoint shares the §4 per-IP + per-subnet buckets
+    // with the signup endpoints. Six POSTs from one IP exhaust the
+    // 5/hour budget; the 6th returns the timing-padded 400 envelope
+    // even with an entirely well-formed body (the rate-limit fires
+    // BEFORE the consume call, by design).
+    const xff = '16.0.0.1';
+    const statuses: number[] = [];
+    for (let i = 0; i < 6; i++) {
+      const resp = await fetch(`${url}/auth/verify`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Forwarded-For': xff,
+        },
+        body: JSON.stringify({ token: `dummy-${i}` }),
+      });
+      statuses.push(resp.status);
+    }
+    // First 5 attempts: consume call returns `missing` → 400 padded.
+    // 6th attempt: ip bucket trips first → 400 padded with
+    // AuthVerifyRefused audit row.
+    expect(statuses.every((s) => s === 400)).toBe(true);
+    const ipTrips = await admin.auditEvent.count({
+      where: {
+        action: 'panorama.auth.verify_refused',
+      },
+    });
+    expect(ipTrips).toBeGreaterThanOrEqual(1);
+  });
+
+  // The §3 per-email cap (3/24h) is intentionally LAST-LINE: in the
+  // callback's normal flow, the §2 enforcement
+  // (TenantSignupRefusedExistingAccount) refuses the 2nd+ signup
+  // attempt with the same email BEFORE the cap is consumed. The cap
+  // only matters as a defense-in-depth: if §2 ever regresses (e.g.,
+  // a refactor narrows the `pathTaken !== 'new_user'` check), the
+  // cap still bounds inbox harassment.
+  //
+  // We don't e2e-test the cap-trip path because it cannot reach
+  // mintAndDispatch under current callback ordering. The cap
+  // implementation itself is a thin wrapper over `RateLimiter` (which
+  // has dedicated unit tests in `rate-limiter.test.ts`) — its
+  // correctness rests on RateLimiter's sliding-window behaviour, not
+  // on a controller-flow integration.
+});
+
+// -----------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------
+
+function makeOidcCallbackMock(): {
+  fn: (params: unknown) => Promise<OidcUserInfo>;
+  setUserInfo: (u: OidcUserInfo) => void;
+  reset: () => void;
+} {
+  let current: OidcUserInfo | null = null;
+  return {
+    fn: async () => {
+      if (!current) {
+        throw new Error('OidcService.callback called without setUserInfo()');
+      }
+      return current;
+    },
+    setUserInfo: (u: OidcUserInfo) => {
+      current = u;
+    },
+    reset: () => {
+      current = null;
+    },
+  };
+}
+
+function postStart(baseUrl: string, xff: string): Promise<Response> {
+  return fetch(`${baseUrl}/auth/signup/google/start`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Forwarded-For': xff,
+    },
+    body: JSON.stringify({
+      captchaToken: `tt-${Math.random().toString(36).slice(2, 12)}`,
+      ctaSource: 'hosted_button',
+      ageGateAccepted: true,
+    }),
+    redirect: 'manual',
+  });
+}
+
+function readStateFromLocation(location: string): string {
+  const idx = location.indexOf('state=');
+  if (idx === -1) return '';
+  const tail = location.slice(idx + 'state='.length);
+  const amp = tail.indexOf('&');
+  return amp === -1 ? tail : tail.slice(0, amp);
+}
+
+function extractTokenFromEmail(text: string): string {
+  // Template renders the link `#token=<plaintext>` (URL fragment, not
+  // query) AND a separate plain-text "paste this token: <plaintext>"
+  // line. The fragment never reaches the server when fetched but the
+  // body still contains the token verbatim. We grep the fragment
+  // shape — base64url chars (alphanumeric, `-`, `_`).
+  const match = text.match(/#token=([A-Za-z0-9_-]+)/);
+  return match ? match[1]! : '';
+}
+
+async function flushSignupKeys(redis: Redis): Promise<void> {
+  const stream = redis.scanStream({ match: 'panorama:signup:*', count: 200 });
+  for await (const batch of stream) {
+    const keys = batch as string[];
+    if (keys.length > 0) {
+      await redis.del(...keys);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements ADR-0020 §3 — the mint+dispatch+consume surface for self-serve OIDC signup. Builds on [PR #212](https://github.com/VitorMRodovalho/panorama/pull/212) (PR 1 signup endpoints).

- Migration 0023 — `email_verifications` table. NOT granted to panorama_app (super-admin only via `runAsSuperAdmin`).
- `modules/email-verification/` — new module: config + templates + service + POST /auth/verify controller + module.
- SignupController callback hook: per-email cap check + mint+dispatch after createTenant.
- Audit registry: new `AuthVerifyRefused` + `TenantVerificationDispatchFailed`; JSDoc fixes on `TenantVerified` and `TenantVerificationSent` for the consumedAt-not-deletion + dispatch-attempted semantics.

## Major surfaces

- **POST /auth/verify** — body `{ token }`. Rate-limited via §4 ip/subnet buckets (shared with signup endpoints; same client budget covers both). Refuses session-attached. Timing-padded 400 envelope. Audit emits `AuthVerifyRefused(reason)`.
- **`EmailVerificationService.mintAndDispatch`** — atomic tx (insert row + emit `TenantVerificationSent`), then best-effort SMTP send. SMTP failure emits sibling `TenantVerificationDispatchFailed` audit row so the trail is honest.
- **`EmailVerificationService.consume`** — atomic tx flips `Tenant.pendingVerification=false` + sets `consumedAt` + emits `TenantVerified`. Row is kept (not deleted) so the verifier reads the consumed state.
- **Email template** — URL FRAGMENT (`#token=...`) not query. Link-preview bots can't pre-consume via GET (ADR §3 contract honored). Paste-fallback in body text for users where the link doesn't work.
- **SignupController hook** — `checkEmailCap(userInfo.email)` BEFORE createTenant (refuses orphan pending tenants on cap trip). `friendlyDisplayName` now sanitizes the OIDC name claim (200 char cap + strip C0/C1 control chars) before persisting.

## Adversarial review log

- **tech-lead 1st pass**: 1 blocker (audit registry tokenKeyPrefix length drift) + 5 concerns. ALL addressed.
- **security-reviewer 1st pass**: 1 blocker (ADR §3 GET-link-with-token-in-query contract violation) + 3 conditioned (/auth/verify rate-limit; displayName cap; session-attached refuse) + 5 R-items deferred. BLOCKER + CONDITIONED addressed.
- **Deferred to follow-ups** (logged for next-PR work):
    - PR 2b: resend endpoint for SMTP-failed dispatches.
    - Audit emission for verify failures (`already_consumed` + valid-but-expired) per security-reviewer R-compromise.
    - `buildSessionForUser` per-request pendingVerification re-check (operator un-verifies vs live sessions).
    - Audit-row retention sweep for consumed/expired email_verification rows.

## Test plan

- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean.
- [x] `pnpm rls:allowlist-check` — clean (32 calls across 13 files; budget 2 added for email-verification.service.ts).
- [x] Migration 0023 applied to dev DB + Supabase staging.
- [x] Suite: 49 test files / 464 tests passing locally.
- [x] `test/email-verification.e2e.test.ts` (4 tests):
    - happy path (signup → mint → POST /auth/verify → tenant.pendingVerification=false)
    - replay (2nd POST same token → 400)
    - expired (manually advance expiresAt → 400)
    - rate-limit (6 POSTs from one IP → 6th 400 + `AuthVerifyRefused` audit)
- [ ] NOT covered (deferred): real SMTP against MailHog / SES; real Google/Microsoft OIDC end-to-end through the verify path; frontend hash-strip-and-POST flow at `${verifyUrlBase}` (apps/web stub).

## Operational notes

- `FEATURE_SELF_SERVE_SIGNUP` stays default off. PR 1 + PR 2 are flag-safe pair: verify endpoint loads unconditionally, so existing pending tenants can still verify after a flag-flip-off.
- `TURNSTILE_SECRET` required when flag on (boot guard from PR 1).
- `TRUST_PROXY_HOPS` becomes security-critical when flag on (PR 1's contract).
- New env knob: `EMAIL_VERIFICATION_TTL_HOURS` (default 24h, range 1-168). Tunable by self-hoster if threat model demands.
- `SIGNUP_FAILURE_LATENCY_FLOOR_MS` is now read by BOTH SignupConfigService and EmailVerificationConfigService — same env knob, identical validation.

## Files of record

- `apps/core-api/prisma/migrations/20260517010000_0023_email_verification/{migration.sql,rls.sql,ROLLBACK.md}`
- `apps/core-api/prisma/schema.prisma` (EmailVerification model + User/Tenant back-relations)
- `apps/core-api/src/modules/email-verification/*` (5 new files)
- `apps/core-api/src/modules/signup/signup.controller.ts` (callback hook)
- `apps/core-api/src/modules/signup/signup.module.ts` (imports EmailVerificationModule)
- `apps/core-api/src/modules/audit/audit-actions.ts` (registry additions + JSDoc fixes)
- `apps/core-api/src/app.module.ts` (registers EmailVerificationModule unconditionally)
- `apps/core-api/test/email-verification.e2e.test.ts`
- `.runAsSuperAdmin.allowlist.json`
- `docs/adr/0020-self-serve-oidc-signup.md` — unchanged in PR 2; §3 contract was already amended in PR 1 ADR pass.