### PR TITLE
feat(tenant-deletion): Round 3 main 3 — 7-day cool-off + multi-Owner email + peer veto + cron purge (ADR-0020 §7)

### DIFF
--- a/.runAsSuperAdmin.allowlist.json
+++ b/.runAsSuperAdmin.allowlist.json
@@ -1,7 +1,7 @@
 {
   "_doc": "Allowlist gate for prisma.runAsSuperAdmin call sites. Closes #58 (RLS-CI). Each entry is a file path + the count of CURRENTLY-JUSTIFIED runAsSuperAdmin calls in it + a one-line rationale. The CI script `scripts/check-runAsSuperAdmin-allowlist.ts` compares the actual count against the budget and fails if a file exceeds its budget. Lower the budget when a site migrates to runInTenant; raise only with reviewer sign-off documenting why a tenant-scoped op needs the privileged path.",
   "_review_policy": "Any PR that raises a budget MUST be reviewed by security-reviewer. Lowering a budget is encouraged.",
-  "_last_audit": "2026-05-17 — email-verification.service.ts added budget 2 for ADR-0020 §3 mint/consume; auth.service.ts at 7 from ADR-0020 §1 resolveOidcUserForSignup.",
+  "_last_audit": "2026-05-17 — tenant-deletion.service.ts added budget 6 for ADR-0020 §7 request/confirm/cancel/veto/listDue/purgeOne (tenant_deletion_tokens table has no GRANT to panorama_app, and the purge flow crosses the tenant boundary by construction).",
   "files": {
     "apps/core-api/src/modules/audit/audit.service.ts": {
       "budget": 1,
@@ -46,6 +46,10 @@
     "apps/core-api/src/modules/reservation/reservation-sweep.service.ts": {
       "budget": 2,
       "rationale": "#77 PILOT-04 hourly sweeps. Two cluster-wide tenant-list reads (one per sweep — overdue + no-show) so each sweep can iterate `panorama_app`-invisible tenants. Per-tenant scans + transitions run under runInTenant. Both audit emissions go through audit.record (separate budget, audit.service.ts file)."
+    },
+    "apps/core-api/src/modules/tenant-deletion/tenant-deletion.service.ts": {
+      "budget": 6,
+      "rationale": "ADR-0020 §7 request/confirm/cancel/veto + the purge cron's list+per-tenant paths. All six sites operate on tenant_deletion_tokens which has NO grant to panorama_app, so RLS-scoped access is unavailable by construction. The purge cron's per-tenant tx ALSO crosses the tenant boundary at delete time (NULL systemActorUserId + delete user + delete tenant)."
     },
     "apps/core-api/src/modules/notification/notification.dispatcher.ts": {
       "budget": 5,

--- a/apps/core-api/prisma/migrations/20260517020000_0024_tenant_deletion/ROLLBACK.md
+++ b/apps/core-api/prisma/migrations/20260517020000_0024_tenant_deletion/ROLLBACK.md
@@ -1,0 +1,95 @@
+# Rollback — 0024 tenant deletion cool-off
+
+## Pre-flight (operator MUST verify BEFORE running)
+
+Three coordinated changes (see `migration.sql` header):
+
+1. New columns on `tenants` (`deletionScheduledAt`,
+   `deletionRequestedByUserId`).
+2. `tenants.systemActorUserId` made nullable.
+3. New table `tenant_deletion_tokens`.
+
+Only roll back if PR 3's tenant-deletion endpoints + the purge cron
+are also reverted — the runtime code reads `deletionScheduledAt`
+unconditionally and would crash on a missing column otherwise.
+
+## SQL revert (privileged role)
+
+Run from a psql session against `$DATABASE_PRIVILEGED_URL`.
+
+```sql
+-- 3. Drop the tokens table first (cascade-safe).
+DROP TABLE "tenant_deletion_tokens";
+
+-- 2. Restore NOT NULL on systemActorUserId. SAFE because every live
+--    tenant has this set (the purge cron is the only path that
+--    nulls it, and rolling back ALSO rolls back the cron + the
+--    endpoints, so no path can produce a NULL row).
+ALTER TABLE "tenants"
+    ALTER COLUMN "systemActorUserId" SET NOT NULL;
+
+-- 1. Drop the new columns + their index + FK.
+ALTER TABLE "tenants" DROP CONSTRAINT "tenants_deletionRequestedByUserId_fkey";
+DROP INDEX "tenants_deletionScheduledAt_idx";
+ALTER TABLE "tenants" DROP COLUMN "deletionRequestedByUserId";
+ALTER TABLE "tenants" DROP COLUMN "deletionScheduledAt";
+```
+
+## Data-loss warnings
+
+- **Active deletion-cool-off state is lost.** Any tenant currently in
+  the 7-day window (`deletionScheduledAt IS NOT NULL`) reverts to the
+  pre-PR-3 state where the operator must drop the tenant manually if
+  they still want it deleted. The Owners who confirmed the deletion
+  have no in-app surface to recover from the lost state until PR 3
+  re-applies.
+- **Unconsumed confirmation tokens are dropped** when the table goes.
+  A user mid-flow (after delete-request, before delete-confirm) loses
+  their token; they must restart the request flow once PR 3 is
+  re-applied.
+- **systemActorUserId rollback to NOT NULL is safe** under the
+  pre-flight rule above — but only if no path produced a NULL row
+  during the PR-3 window. If the purge cron RAN during PR 3 and was
+  interrupted mid-sequence, a tenant could have NULL systemActorUserId
+  + still-present rows. Verify with
+  `SELECT id FROM tenants WHERE systemActorUserId IS NULL;` before
+  the SET NOT NULL — fix any orphans manually.
+
+## When you would actually revert
+
+- PR 3 (tenant-deletion endpoints + cron) is being rolled back as
+  part of a broader Wave 0.5 revert.
+- A bug in the cron purges tenants prematurely or fails to purge —
+  in either case, fix-forward on the cron is preferred to
+  schema rollback.
+
+## Re-apply pattern
+
+Forward-only by design. Re-applying after a rollback is a clean
+additive operation. Tenants with NULL systemActorUserId (if any
+slipped through the manual cleanup above) need a new system user
+seeded before the column is set NOT NULL again — but PR 3's schema
+DOESN'T re-add NOT NULL on re-apply, so this is moot in practice.
+
+## Schema implications
+
+`schema.prisma` updated to mirror:
+- `Tenant.systemActorUserId` → nullable (`String? @db.Uuid`).
+- `Tenant.deletionScheduledAt`, `Tenant.deletionRequestedByUserId`
+  added.
+- `TenantDeletionToken` model added with back-relations on User +
+  Tenant.
+
+A revert of THIS migration must also revert those edits or
+`prisma migrate status` will diff against the rolled-back DB.
+
+## Production migration timing
+
+- `ALTER TABLE ADD COLUMN` (nullable, no default) is metadata-only;
+  takes ACCESS EXCLUSIVE on `tenants` for sub-millisecond.
+- `ALTER TABLE ALTER COLUMN DROP NOT NULL` is also metadata-only; no
+  row rewrite. Safe under load.
+- `CREATE TABLE` is fast on an empty table.
+- The new partial index `tenants_deletionScheduledAt_idx WHERE
+  deletionScheduledAt IS NOT NULL` builds against zero rows at apply
+  time (the column is fresh-NULL); also instantaneous.

--- a/apps/core-api/prisma/migrations/20260517020000_0024_tenant_deletion/migration.sql
+++ b/apps/core-api/prisma/migrations/20260517020000_0024_tenant_deletion/migration.sql
@@ -1,0 +1,105 @@
+-- Migration 0024 — Tenant deletion 7-day cool-off (ADR-0020 §7).
+--
+-- Three coordinated changes:
+--
+--   1. `tenants.deletionScheduledAt` + `tenants.deletionRequestedByUserId`:
+--      the cool-off window state lives on the Tenant row so every
+--      authenticated read (banner, dashboard, RLS-scoped query) can
+--      see it without joining a separate "pending deletions" table.
+--      `deletionScheduledAt IS NULL` = not scheduled; non-NULL = T+7d
+--      from the confirm.
+--
+--   2. `tenants.systemActorUserId` becomes NULLABLE. Per ADR-0020 §7
+--      amendment ("NULL Tenant.systemActorUserId first per ON DELETE
+--      RESTRICT cascade ordering"), the purge cron MUST null this
+--      reference before deleting the system user + then the tenant.
+--      The previous NOT NULL constraint (migration 0014) would block
+--      that sequence — every tenant tx after creation always sets the
+--      column, and runtime code that reads it falls back to null-safe
+--      lookups (PR 3 makes the schema match the runtime contract).
+--      The FK target's ON DELETE behaviour stays RESTRICT because we
+--      WANT writes-after-purge to fail loudly if a forgotten path
+--      tries to write through a tenant in the middle of being purged.
+--
+--   3. `tenant_deletion_tokens` — one-time-use confirmation tokens
+--      minted by `POST /tenants/:id/delete-request`. Same shape as
+--      `email_verifications` (PR 2 migration 0023): tokenHash UNIQUE,
+--      expiresAt (24h), consumedAt (nullable timestamp), createdAt.
+--      panorama_app gets NO grants on this table; service operates
+--      under runAsSuperAdmin.
+--
+-- Cascade-related notes:
+--   - email_verifications.tenantId is ON DELETE CASCADE (migration
+--     0023). When the purge cron DELETEs the tenant, the verification
+--     rows it once owned cascade away. Acceptable: by the time the
+--     cron runs, any unconsumed verification token for the deleted
+--     tenant is moot.
+--   - tenant_deletion_tokens.tenantId is also ON DELETE CASCADE so
+--     a cancel-then-delete-later cleanup is automatic.
+--   - All other tenant-scoped FKs to `tenants(id)` already CASCADE
+--     per migrations 0001-0023. The purge cron itself doesn't need
+--     to issue explicit per-table DELETEs.
+
+-- ---------------------------------------------------------------------
+-- 1. Cool-off state on tenants.
+-- ---------------------------------------------------------------------
+ALTER TABLE "tenants"
+    ADD COLUMN "deletionScheduledAt"       TIMESTAMPTZ,
+    ADD COLUMN "deletionRequestedByUserId" UUID;
+
+ALTER TABLE "tenants"
+    ADD CONSTRAINT "tenants_deletionRequestedByUserId_fkey"
+        FOREIGN KEY ("deletionRequestedByUserId")
+        REFERENCES "users"("id")
+        ON DELETE SET NULL
+        ON UPDATE CASCADE;
+
+CREATE INDEX "tenants_deletionScheduledAt_idx"
+    ON "tenants"("deletionScheduledAt")
+    WHERE "deletionScheduledAt" IS NOT NULL;
+
+COMMENT ON COLUMN "tenants"."deletionScheduledAt" IS
+'ADR-0020 §7 — T+7d the purge cron will execute the delete. NULL = '
+'not scheduled. Set by POST /tenants/:id/delete-confirm; cleared by '
+'POST /tenants/:id/delete-cancel and POST /tenants/:id/delete-veto.';
+
+COMMENT ON COLUMN "tenants"."deletionRequestedByUserId" IS
+'ADR-0020 §7 — the Tenant Owner that initiated POST /tenants/:id/'
+'delete-request. ON DELETE SET NULL so a user account deletion '
+'does not block the tenant cool-off bookkeeping.';
+
+-- ---------------------------------------------------------------------
+-- 2. systemActorUserId — drop NOT NULL.
+-- ---------------------------------------------------------------------
+ALTER TABLE "tenants"
+    ALTER COLUMN "systemActorUserId" DROP NOT NULL;
+
+COMMENT ON COLUMN "tenants"."systemActorUserId" IS
+'ADR-0016 §1 system user for auto-suggested maintenance tickets. '
+'Nullable as of ADR-0020 §7 amendment: the purge cron NULLs this '
+'before deleting the system user + the tenant, so the ON DELETE '
+'RESTRICT FK does not block the cascade. Live tenants always have '
+'this column set; null only during the brief purge sequence.';
+
+-- ---------------------------------------------------------------------
+-- 3. Deletion confirmation tokens.
+-- ---------------------------------------------------------------------
+CREATE TABLE "tenant_deletion_tokens" (
+    "id"                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    "tenantId"            UUID NOT NULL REFERENCES "tenants"("id") ON DELETE CASCADE,
+    "requestedByUserId"   UUID NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "tokenHash"           TEXT NOT NULL UNIQUE,
+    "expiresAt"           TIMESTAMPTZ NOT NULL,
+    "consumedAt"          TIMESTAMPTZ,
+    "createdAt"           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX "tenant_deletion_tokens_tenantId_idx"
+    ON "tenant_deletion_tokens"("tenantId");
+
+COMMENT ON TABLE "tenant_deletion_tokens" IS
+'ADR-0020 §7 — one-time-use confirmation tokens minted by POST '
+'/tenants/:id/delete-request. Consumed by POST /tenants/:id/'
+'delete-confirm. panorama_app has NO grants on this table — all '
+'access via prisma.runAsSuperAdmin (the request + confirm paths '
+'route through the service layer which runs super-admin txs).';

--- a/apps/core-api/prisma/migrations/20260517020000_0024_tenant_deletion/rls.sql
+++ b/apps/core-api/prisma/migrations/20260517020000_0024_tenant_deletion/rls.sql
@@ -1,0 +1,15 @@
+-- Migration 0024 — no RLS surface change.
+--
+-- `tenant_deletion_tokens` is intentionally NOT granted to panorama_app.
+-- All access via `prisma.runAsSuperAdmin`. Adding an RLS policy for
+-- an audience that has no underlying GRANT would be dead config.
+--
+-- The two new columns on `tenants` (`deletionScheduledAt`,
+-- `deletionRequestedByUserId`) inherit the existing `tenants_*`
+-- policies. Tenant Owners + admins see them via the same tenant-
+-- scoped filter that already gates every other tenant column.
+--
+-- Placeholder kept for grep-greppability of the per-migration RLS
+-- audit pattern.
+
+SELECT 1;

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -80,8 +80,13 @@ model Tenant {
   /// Seeded at tenant creation. Migration 0014 backfills existing
   /// tenants then SETs NOT NULL. Migration 0015 adds the FK
   /// constraint enforcing referential integrity (DATA-04 / #42).
-  systemActorUserId                    String    @db.Uuid
-  systemActor                          User      @relation("TenantSystemActor", fields: [systemActorUserId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  ///
+  /// NULLABLE as of ADR-0020 §7 (migration 0024): the purge cron
+  /// NULLs this column before deleting the system user and then the
+  /// tenant. Live tenants always have it set; null only during the
+  /// brief purge sequence.
+  systemActorUserId                    String?   @db.Uuid
+  systemActor                          User?     @relation("TenantSystemActor", fields: [systemActorUserId], references: [id], onDelete: Restrict, onUpdate: Cascade)
   /// ADR-0016 §5 toggle: when true, FAIL/NEEDS_MAINTENANCE
   /// inspection outcomes AND damageFlag check-in events auto-open
   /// a draft maintenance ticket. Defaults FALSE per security +
@@ -110,6 +115,16 @@ model Tenant {
   /// existed before signup continue to write the default). PR 2 adds
   /// the route guard reading this column and the flip endpoint.
   pendingVerification                  Boolean   @default(false)
+  /// ADR-0020 §7 — T+7d the purge cron will execute the delete. NULL
+  /// = not scheduled. Set by POST /tenants/:id/delete-confirm;
+  /// cleared by POST /tenants/:id/delete-cancel and POST
+  /// /tenants/:id/delete-veto.
+  deletionScheduledAt                  DateTime? @db.Timestamptz(6)
+  /// ADR-0020 §7 — the Owner that initiated the delete-request. ON
+  /// DELETE SET NULL so a user account deletion does not block the
+  /// tenant cool-off bookkeeping.
+  deletionRequestedByUserId            String?   @db.Uuid
+  deletionRequestedBy                  User?     @relation("TenantDeletionRequester", fields: [deletionRequestedByUserId], references: [id], onDelete: SetNull, onUpdate: Cascade)
   createdAt                            DateTime  @default(now())
   updatedAt                            DateTime  @updatedAt
   deletedAt                            DateTime?
@@ -129,6 +144,7 @@ model Tenant {
   assetMaintenances       AssetMaintenance[]
   maintenancePhotos       MaintenancePhoto[]
   emailVerifications      EmailVerification[]
+  deletionTokens          TenantDeletionToken[]
 
   @@map("tenants")
 }
@@ -173,8 +189,43 @@ model User {
   maintenancesCompleted      AssetMaintenance[]    @relation("MaintenanceCompletedBy")
   maintenancePhotosUploaded  MaintenancePhoto[]    @relation("MaintenancePhotoUploader")
   emailVerifications         EmailVerification[]
+  tenantsAsDeletionRequester Tenant[]              @relation("TenantDeletionRequester")
+  tenantDeletionTokens       TenantDeletionToken[]
 
   @@map("users")
+}
+
+/// ADR-0020 §7 — one-time-use deletion-confirmation tokens minted by
+/// POST /tenants/:id/delete-request, fanned out by email to ALL
+/// active Owners of the tenant. Consumed by POST /tenants/:id/
+/// delete-confirm (any Owner may consume; one token per request,
+/// regardless of Owner count). 24h TTL — if no Owner confirms within
+/// the window, the request is moot and the user can re-request.
+///
+/// Lifecycle:
+///   - request: insert row, fan out email, emit
+///     panorama.tenant.delete_requested
+///   - confirm: mark consumedAt, set Tenant.deletionScheduledAt to
+///     T+7d, emit panorama.tenant.delete_confirmed
+///   - cancel: clear Tenant.deletionScheduledAt; the unconsumed token
+///     stays in place (will fail to consume because the tenant has no
+///     scheduled deletion; the second consume returns no-op)
+///
+/// All access via runAsSuperAdmin — panorama_app has no GRANT.
+model TenantDeletionToken {
+  id                String    @id @default(uuid()) @db.Uuid
+  tenantId          String    @db.Uuid
+  tenant            Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  requestedByUserId String    @db.Uuid
+  requestedBy       User      @relation(fields: [requestedByUserId], references: [id], onDelete: Cascade)
+  /// sha256 hex of the plaintext token. Plaintext never persisted.
+  tokenHash         String    @unique
+  expiresAt         DateTime  @db.Timestamptz(6)
+  consumedAt        DateTime? @db.Timestamptz(6)
+  createdAt         DateTime  @default(now()) @db.Timestamptz(6)
+
+  @@index([tenantId])
+  @@map("tenant_deletion_tokens")
 }
 
 /// ADR-0020 §3 — one-time-use email-verification tokens minted at

--- a/apps/core-api/src/app.module.ts
+++ b/apps/core-api/src/app.module.ts
@@ -24,6 +24,7 @@ import { SnipeitCompatModule } from './modules/snipeit-compat/snipeit-compat.mod
 import { BootAuditModule } from './modules/boot-audit/boot-audit.module.js';
 import { SignupModule } from './modules/signup/signup.module.js';
 import { EmailVerificationModule } from './modules/email-verification/email-verification.module.js';
+import { TenantDeletionModule } from './modules/tenant-deletion/tenant-deletion.module.js';
 
 /**
  * `FEATURE_SNIPEIT_COMPAT_SHIM` (ADR-0010 rollback plan) toggles
@@ -143,6 +144,7 @@ const conditionalSelfServeSignup: DynamicModule[] = selfServeSignupEnabled()
     HealthModule,
     ImportModule,
     EmailVerificationModule,
+    TenantDeletionModule,
     ...conditionalCompatShim,
     ...conditionalInspections,
     ...conditionalMaintenance,

--- a/apps/core-api/src/modules/audit/audit-actions.ts
+++ b/apps/core-api/src/modules/audit/audit-actions.ts
@@ -298,6 +298,23 @@ export const PanoramaAuditAction = {
    * `platform_maintainer`), `previouslyScheduledAt`.
    */
   TenantDeleteVeto: 'panorama.tenant.delete_veto',
+  /**
+   * Tenant data purged by the ADR-0020 §7 cron after the 7-day
+   * cool-off elapsed without cancel / veto. Per-tenant event,
+   * emitted INSIDE the purge tx BEFORE the cascade DELETE so the
+   * row carries `tenantId = <the tenant being purged>` for the
+   * per-tenant audit strand. The audit_events table has no FK to
+   * tenants(id), so the row survives the cascade and the strand's
+   * tail is the deletion event itself.
+   *
+   * Metadata: `slug`, `displayName` (snapshot pre-purge),
+   * `scheduledAt` (the deletionScheduledAt the cron honoured),
+   * `requestedByUserId` (the Owner that confirmed the deletion;
+   * may be NULL if the User account was deleted between confirm
+   * and purge — `tenants.deletionRequestedByUserId` is ON DELETE
+   * SET NULL).
+   */
+  TenantDeleted: 'panorama.tenant.deleted',
 } as const;
 
 export type PanoramaAuditAction =

--- a/apps/core-api/src/modules/maintenance/maintenance-ticket.subscriber.ts
+++ b/apps/core-api/src/modules/maintenance/maintenance-ticket.subscriber.ts
@@ -131,6 +131,18 @@ export class MaintenanceTicketSubscriber implements ChannelHandler {
           return;
         }
 
+        if (!tenant.systemActorUserId) {
+          // Tenant is mid-deletion (ADR-0020 §7 purge cron nulls this
+          // column just before dropping the system user + the tenant
+          // row). Auto-suggest can't author tickets without a system
+          // actor; skip cleanly so the dispatcher marks the event
+          // dispatched and the in-flight purge proceeds.
+          this.log.warn(
+            { eventId: event.id, eventType: event.eventType, tenantId },
+            'auto_suggest_skipped_tenant_purging',
+          );
+          return;
+        }
         const params = await this.buildParams(tx, event, tenant.systemActorUserId);
         if (!params) {
           // PASS outcome on inspection.completed → no ticket. The event

--- a/apps/core-api/src/modules/tenant-deletion/tenant-deletion-sweep.service.ts
+++ b/apps/core-api/src/modules/tenant-deletion/tenant-deletion-sweep.service.ts
@@ -1,0 +1,99 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { Queue, Worker } from 'bullmq';
+import { Redis } from 'ioredis';
+import { TenantDeletionService } from './tenant-deletion.service.js';
+
+/**
+ * ADR-0020 §7 — purge cron.
+ *
+ * Daily BullMQ repeatable job that asks `TenantDeletionService` to
+ * process every tenant whose `deletionScheduledAt` is in the past.
+ * Mirrors the `MaintenanceSweepService` shape (#74 / ADR-0016 §9):
+ * Queue + Worker on the same process, idle-in-tests, single
+ * repeatable-key so a redeploy doesn't accumulate duplicate jobs.
+ *
+ * The actual cascade work lives in the service; this file is the
+ * scheduling shell.
+ */
+
+const PURGE_QUEUE = 'tenant-deletion-purge';
+const PURGE_JOB_NAME = 'sweep';
+const PURGE_REPEATABLE_KEY = 'tenant-deletion-daily';
+const PURGE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+@Injectable()
+export class TenantDeletionSweepService implements OnModuleInit, OnModuleDestroy {
+  private readonly log = new Logger('TenantDeletionSweepService');
+  private queue: Queue | null = null;
+  private worker: Worker | null = null;
+  private redisConnections: Redis[] = [];
+
+  constructor(private readonly deletion: TenantDeletionService) {}
+
+  async onModuleInit(): Promise<void> {
+    if (process.env['NODE_ENV'] === 'test') {
+      this.log.log('tenant_deletion_sweep_idle_in_tests');
+      return;
+    }
+    await this.start();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.stop();
+  }
+
+  async start(): Promise<void> {
+    if (this.queue) return;
+    const redisUrl = process.env['REDIS_URL'] ?? 'redis://localhost:6379/0';
+
+    const queueConn = new Redis(redisUrl, { maxRetriesPerRequest: null });
+    const workerConn = new Redis(redisUrl, { maxRetriesPerRequest: null });
+    this.redisConnections = [queueConn, workerConn];
+
+    this.queue = new Queue(PURGE_QUEUE, { connection: queueConn });
+    this.worker = new Worker(
+      PURGE_QUEUE,
+      async () => {
+        const result = await this.deletion.runPurgeBatch();
+        this.log.log({ purged: result.purged }, 'tenant_deletion_purge_batch_done');
+        return result;
+      },
+      { connection: workerConn, concurrency: 1 },
+    );
+
+    // One repeatable per process — re-creating with the same key is
+    // idempotent in BullMQ 5.x; the old upcoming job is replaced.
+    await this.queue.add(
+      PURGE_JOB_NAME,
+      {},
+      {
+        repeat: { every: PURGE_INTERVAL_MS },
+        jobId: PURGE_REPEATABLE_KEY,
+        removeOnComplete: true,
+        removeOnFail: 10,
+      },
+    );
+
+    this.log.log({ intervalMs: PURGE_INTERVAL_MS }, 'tenant_deletion_sweep_started');
+  }
+
+  async stop(): Promise<void> {
+    if (this.worker) {
+      await this.worker.close();
+      this.worker = null;
+    }
+    if (this.queue) {
+      await this.queue.close();
+      this.queue = null;
+    }
+    for (const conn of this.redisConnections) {
+      await conn.quit().catch(() => {});
+    }
+    this.redisConnections = [];
+  }
+}

--- a/apps/core-api/src/modules/tenant-deletion/tenant-deletion.config.ts
+++ b/apps/core-api/src/modules/tenant-deletion/tenant-deletion.config.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * ADR-0020 §7 — tenant deletion cool-off configuration.
+ *
+ * `coolOffDays` (default 7) bounds the wait between
+ * `delete-confirm` and the cron purge. Self-hosters can shorten
+ * for staging convenience or lengthen for compliance.
+ *
+ * `tokenTtlHours` (default 24h) bounds how long a delete-request
+ * confirmation token stays consumable. The window is the time an
+ * Owner has to react to the request-email; missing the window
+ * cleanly invalidates the request without escalating.
+ *
+ * `manageUrlBase` is the absolute prefix the email body links to
+ * for the confirm / cancel pages —
+ * `${APP_BASE_URL}/tenants/:tenantId/deletion`. The token rides in
+ * the URL fragment (#token=...) so link-preview bots cannot
+ * pre-consume; the frontend forwards via POST.
+ *
+ * `failureLatencyFloorMs` mirrors the `SIGNUP_FAILURE_LATENCY_FLOOR_MS`
+ * env knob from SignupConfigService / EmailVerificationConfigService —
+ * same shape, same env knob, kept in-module to avoid a circular
+ * import.
+ */
+export interface TenantDeletionConfig {
+  coolOffDays: number;
+  tokenTtlHours: number;
+  manageUrlBase: string;
+  failureLatencyFloorMs: number;
+}
+
+@Injectable()
+export class TenantDeletionConfigService {
+  readonly config: TenantDeletionConfig;
+
+  constructor() {
+    const coolOffRaw = process.env['TENANT_DELETE_COOL_OFF_DAYS'];
+    const coolOffDays = coolOffRaw ? Number(coolOffRaw) : 7;
+    if (!Number.isFinite(coolOffDays) || coolOffDays <= 0 || coolOffDays > 30) {
+      throw new Error(
+        `TENANT_DELETE_COOL_OFF_DAYS must be a positive number ≤30; got ${JSON.stringify(coolOffRaw)}`,
+      );
+    }
+    const ttlRaw = process.env['TENANT_DELETE_TOKEN_TTL_HOURS'];
+    const tokenTtlHours = ttlRaw ? Number(ttlRaw) : 24;
+    if (!Number.isFinite(tokenTtlHours) || tokenTtlHours <= 0 || tokenTtlHours > 168) {
+      throw new Error(
+        `TENANT_DELETE_TOKEN_TTL_HOURS must be a positive number ≤168; got ${JSON.stringify(ttlRaw)}`,
+      );
+    }
+    const floorRaw = process.env['SIGNUP_FAILURE_LATENCY_FLOOR_MS'];
+    const failureLatencyFloorMs = floorRaw ? Number(floorRaw) : 600;
+    if (!Number.isFinite(failureLatencyFloorMs) || failureLatencyFloorMs < 0) {
+      throw new Error(
+        `SIGNUP_FAILURE_LATENCY_FLOOR_MS must be a non-negative number; got ${JSON.stringify(floorRaw)}`,
+      );
+    }
+    const baseUrl = (process.env['APP_BASE_URL'] ?? 'http://localhost:4000')
+      .replace(/\/+$/, '')
+      .toLowerCase();
+    this.config = {
+      coolOffDays,
+      tokenTtlHours,
+      manageUrlBase: baseUrl,
+      failureLatencyFloorMs,
+    };
+  }
+}

--- a/apps/core-api/src/modules/tenant-deletion/tenant-deletion.controller.ts
+++ b/apps/core-api/src/modules/tenant-deletion/tenant-deletion.controller.ts
@@ -1,0 +1,177 @@
+import {
+  BadRequestException,
+  Body,
+  ConflictException,
+  Controller,
+  ForbiddenException,
+  HttpCode,
+  Logger,
+  NotFoundException,
+  Param,
+  Post,
+  Req,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { z } from 'zod';
+import { getRequestSession } from '../auth/session.middleware.js';
+import type { PanoramaSession } from '../auth/session.types.js';
+import { TenantDeletionService } from './tenant-deletion.service.js';
+
+/**
+ * ADR-0020 §7 — tenant-deletion endpoints. Four routes under
+ * `/tenants/:tenantId/...`, all Owner-only:
+ *
+ *   - POST /delete-request — Owner initiates; email fans out to ALL
+ *     active Owners with a one-time confirmation token.
+ *   - POST /delete-confirm — any Owner of the same tenant consumes
+ *     the token; sets `Tenant.deletionScheduledAt = T+coolOffDays`.
+ *   - POST /delete-cancel — any Owner cancels during the cool-off.
+ *     Idempotent.
+ *   - POST /delete-veto — peer Owner cancels with the distinct
+ *     audit signal `TenantDeleteVeto(vetoSource=peer_owner)`. The
+ *     vetoing Owner MUST NOT be the original requester
+ *     (self-veto is just a cancel; routing through veto would
+ *     pollute the SIEM signal).
+ *
+ * Auth contract:
+ *   - Caller session present (logged-in).
+ *   - `session.currentTenantId === :tenantId` (URL prevents
+ *     cross-tenant by construction; we re-check here so a
+ *     misrouted client still fails-closed).
+ *   - `session.currentRole === 'owner'`.
+ *
+ * NOT covered in PR 3: platform-maintainer veto (admin console
+ * surface). The hosted instance's maintainer can today only
+ * cancel a tenant-deletion via direct DB UPDATE; future-PR work
+ * adds an authenticated admin path with `vetoSource=platform_maintainer`.
+ */
+
+const ConfirmBodySchema = z.object({
+  token: z.string().min(1).max(1024),
+});
+
+@Controller('tenants/:tenantId')
+export class TenantDeletionController {
+  private readonly log = new Logger('TenantDeletionController');
+
+  constructor(private readonly deletion: TenantDeletionService) {}
+
+  @Post('delete-request')
+  @HttpCode(200)
+  async request(
+    @Param('tenantId') tenantId: string,
+    @Req() req: Request,
+  ): Promise<unknown> {
+    const session = this.requireOwner(req, tenantId);
+    const result = await this.deletion.request({
+      tenantId,
+      requestedByUserId: session.userId,
+    });
+    if (result.kind === 'already_scheduled') {
+      throw new ConflictException('deletion_already_scheduled');
+    }
+    if (result.kind === 'duplicate_request') {
+      // Either the tenant is gone or an unconsumed token already
+      // exists. From the caller's POV the operationally-correct
+      // surface is the same — there is already a request in flight.
+      throw new ConflictException('deletion_request_already_pending');
+    }
+    return {
+      ok: true,
+      tokenKeyPrefix: result.tokenKeyPrefix,
+      ownerCount: result.ownerCount,
+    };
+  }
+
+  @Post('delete-confirm')
+  @HttpCode(200)
+  async confirm(
+    @Param('tenantId') tenantId: string,
+    @Body() body: unknown,
+    @Req() req: Request,
+  ): Promise<unknown> {
+    const session = this.requireOwner(req, tenantId);
+    const parsed = ConfirmBodySchema.safeParse(body);
+    if (!parsed.success) throw new BadRequestException('invalid_body');
+
+    const result = await this.deletion.confirm({
+      tenantId,
+      actorUserId: session.userId,
+      token: parsed.data.token,
+    });
+    switch (result.kind) {
+      case 'ok':
+        return { ok: true, scheduledAt: result.scheduledAt.toISOString() };
+      case 'missing':
+      case 'expired':
+      case 'already_consumed':
+      case 'tenant_mismatch':
+        // All four surface as the same client-facing error so an
+        // attacker cannot enumerate token state. Operator triage
+        // uses the per-result log line + (future) audit signal.
+        this.log.warn({ tenantId, reason: result.kind }, 'delete_confirm_failed');
+        throw new NotFoundException('verification_failed');
+      case 'tenant_already_scheduled':
+        // Race A — the cancel side already won (or another confirm
+        // path beat us). Idempotent surface: return the current
+        // state so the caller can re-read.
+        throw new ConflictException('deletion_already_scheduled');
+    }
+  }
+
+  @Post('delete-cancel')
+  @HttpCode(200)
+  async cancel(
+    @Param('tenantId') tenantId: string,
+    @Req() req: Request,
+  ): Promise<unknown> {
+    const session = this.requireOwner(req, tenantId);
+    const result = await this.deletion.cancel({
+      tenantId,
+      actorUserId: session.userId,
+    });
+    return {
+      ok: true,
+      previouslyScheduledAt:
+        result.kind === 'ok'
+          ? result.previouslyScheduledAt.toISOString()
+          : null,
+    };
+  }
+
+  @Post('delete-veto')
+  @HttpCode(200)
+  async veto(
+    @Param('tenantId') tenantId: string,
+    @Req() req: Request,
+  ): Promise<unknown> {
+    const session = this.requireOwner(req, tenantId);
+    const result = await this.deletion.veto({
+      tenantId,
+      actorUserId: session.userId,
+    });
+    if (result.kind === 'requester_self_veto_refused') {
+      throw new ForbiddenException('requester_must_cancel_not_veto');
+    }
+    return {
+      ok: true,
+      previouslyScheduledAt:
+        result.kind === 'ok'
+          ? result.previouslyScheduledAt.toISOString()
+          : null,
+    };
+  }
+
+  private requireOwner(req: Request, tenantId: string): PanoramaSession {
+    const session = getRequestSession(req);
+    if (!session) throw new UnauthorizedException('authentication_required');
+    if (session.currentTenantId !== tenantId) {
+      throw new UnauthorizedException('tenant_mismatch');
+    }
+    if (session.currentRole !== 'owner') {
+      throw new ForbiddenException('owner_role_required');
+    }
+    return session;
+  }
+}

--- a/apps/core-api/src/modules/tenant-deletion/tenant-deletion.module.ts
+++ b/apps/core-api/src/modules/tenant-deletion/tenant-deletion.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { EmailModule } from '../email/email.module.js';
+import { TenantDeletionConfigService } from './tenant-deletion.config.js';
+import { TenantDeletionController } from './tenant-deletion.controller.js';
+import { TenantDeletionService } from './tenant-deletion.service.js';
+import { TenantDeletionSweepService } from './tenant-deletion-sweep.service.js';
+
+/**
+ * ADR-0020 §7 — tenant deletion cool-off surface.
+ *
+ * Loaded UNCONDITIONALLY. The endpoints are Owner-only and the
+ * cron sweep is idle-in-tests; both behave as no-ops on a self-host
+ * that never has any tenant request deletion. The benefit of
+ * always-on: any tenant created (whether self-hosted, seeded, or
+ * via the self-serve signup) has the deletion path available
+ * without needing a separate feature flag.
+ */
+@Module({
+  imports: [EmailModule],
+  controllers: [TenantDeletionController],
+  providers: [
+    TenantDeletionConfigService,
+    TenantDeletionService,
+    TenantDeletionSweepService,
+  ],
+  exports: [TenantDeletionService],
+})
+export class TenantDeletionModule {}

--- a/apps/core-api/src/modules/tenant-deletion/tenant-deletion.service.ts
+++ b/apps/core-api/src/modules/tenant-deletion/tenant-deletion.service.ts
@@ -1,0 +1,599 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { createHash, randomBytes } from 'node:crypto';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { AuditService } from '../audit/audit.service.js';
+import { PanoramaAuditAction } from '../audit/audit-actions.js';
+import { EmailService } from '../email/email.service.js';
+import { TenantDeletionConfigService } from './tenant-deletion.config.js';
+import {
+  renderDeletionRequestEmail,
+  type DeletionRequestEmailContext,
+} from './tenant-deletion.templates.js';
+
+/**
+ * Tenant deletion domain service (ADR-0020 §7).
+ *
+ * Four state transitions on a `Tenant` row's
+ * `deletionScheduledAt` column:
+ *
+ *   - request: mint a one-time confirmation token, fan email out to
+ *     every active Owner of the tenant, audit-emit
+ *     `TenantDeleteRequested`. The Tenant.deletionScheduledAt stays
+ *     NULL — the cool-off only starts on confirm.
+ *   - confirm: consume the token, set Tenant.deletionScheduledAt to
+ *     T+coolOffDays, capture deletionRequestedByUserId, audit-emit
+ *     `TenantDeleteConfirmed`.
+ *   - cancel: clear Tenant.deletionScheduledAt + the requester
+ *     reference; idempotent — second cancel against an already-
+ *     cancelled tenant is a no-op. Audit-emit `TenantDeleteCancelled`
+ *     exactly once (the precondition check prevents double-emit per
+ *     ADR §7 race C).
+ *   - veto: identical post-condition to cancel BUT requires the
+ *     vetoing Owner to NOT be the original requester (peer-Owner
+ *     safety net per §7 race B). Audit-emit `TenantDeleteVeto` with
+ *     `vetoSource: 'peer_owner'`. Platform-maintainer veto path
+ *     (admin console) is out of scope for PR 3.
+ *
+ * Cron purge (`runPurgeBatch`):
+ *   - find tenants where deletionScheduledAt <= NOW()
+ *   - per-tenant, runAsSuperAdmin tx:
+ *       1. emit `TenantDeleted` audit row (BEFORE the cascade so the
+ *          row's tenantId carries the per-tenant strand head)
+ *       2. capture systemActorUserId
+ *       3. UPDATE tenant SET systemActorUserId = NULL (migration
+ *          0024 made the column nullable; this clears the FK so the
+ *          system user can be dropped without triggering the
+ *          ON DELETE RESTRICT)
+ *       4. DELETE the system user (FKs in tenant_membership /
+ *          inspection / maintenance / etc. CASCADE; tenant
+ *          membership row tied to the system user goes away here)
+ *       5. DELETE the tenant (CASCADE drops every remaining
+ *          tenant-scoped row including any unconsumed deletion
+ *          tokens and email_verifications)
+ *   - the audit_events table has no FK to tenants, so the
+ *     TenantDeleted row at step 1 survives the cascade and the
+ *     strand's tail is the deletion marker itself.
+ *
+ * All paths route through runAsSuperAdmin because the deletion flow
+ * crosses the tenant boundary — most directly at purge time when
+ * the tenant row is going away, but also at request time because
+ * the cron + the request paths share a service layer that lives
+ * outside any single tenant's RLS scope.
+ */
+
+export type RequestResult =
+  | { kind: 'ok'; tokenKeyPrefix: string; ownerCount: number }
+  | { kind: 'already_scheduled' }
+  | { kind: 'duplicate_request' };
+
+export type ConfirmResult =
+  | { kind: 'ok'; scheduledAt: Date }
+  | { kind: 'missing' }
+  | { kind: 'expired' }
+  | { kind: 'already_consumed' }
+  | { kind: 'tenant_already_scheduled' }
+  | { kind: 'tenant_mismatch' };
+
+export type CancelResult =
+  | { kind: 'ok'; previouslyScheduledAt: Date }
+  | { kind: 'noop' };
+
+export type VetoResult =
+  | { kind: 'ok'; previouslyScheduledAt: Date }
+  | { kind: 'noop' }
+  | { kind: 'requester_self_veto_refused' };
+
+@Injectable()
+export class TenantDeletionService {
+  private readonly log = new Logger('TenantDeletionService');
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+    private readonly mail: EmailService,
+    private readonly cfg: TenantDeletionConfigService,
+  ) {}
+
+  /**
+   * §7 step 1 — POST /tenants/:id/delete-request.
+   *
+   * Refuses if the tenant already has a scheduled deletion
+   * (`deletionScheduledAt IS NOT NULL`) — the Owner must cancel
+   * before requesting again. Also refuses on duplicate-request
+   * (an unconsumed token already exists for this tenant) — the
+   * Owner should consume / cancel the prior token first.
+   *
+   * Email fan-out goes to ALL active Owners. SMTP failure is
+   * logged but does NOT roll back the token row (the operator
+   * fallback is to read the audit row + resend manually). One
+   * token row per request — every Owner's email references the
+   * same token, ANY Owner consumes.
+   */
+  async request(input: {
+    tenantId: string;
+    requestedByUserId: string;
+  }): Promise<RequestResult> {
+    const { plaintext, tokenHash } = this.generateToken();
+    const expiresAt = new Date(
+      Date.now() + this.cfg.config.tokenTtlHours * 60 * 60 * 1000,
+    );
+
+    const result = await this.prisma.runAsSuperAdmin(
+      async (tx) => {
+        const tenant = await tx.tenant.findUnique({
+          where: { id: input.tenantId },
+          select: {
+            id: true,
+            displayName: true,
+            deletionScheduledAt: true,
+          },
+        });
+        if (!tenant) return { kind: 'duplicate_request' as const };
+        if (tenant.deletionScheduledAt !== null) {
+          return { kind: 'already_scheduled' as const };
+        }
+        const pending = await tx.tenantDeletionToken.findFirst({
+          where: {
+            tenantId: input.tenantId,
+            consumedAt: null,
+            expiresAt: { gt: new Date() },
+          },
+          select: { id: true },
+        });
+        if (pending) return { kind: 'duplicate_request' as const };
+
+        await tx.tenantDeletionToken.create({
+          data: {
+            tenantId: input.tenantId,
+            requestedByUserId: input.requestedByUserId,
+            tokenHash,
+            expiresAt,
+          },
+        });
+
+        const owners = await tx.tenantMembership.findMany({
+          where: {
+            tenantId: input.tenantId,
+            role: 'owner',
+            status: 'active',
+          },
+          select: {
+            userId: true,
+            user: { select: { email: true, displayName: true } },
+          },
+        });
+        const requester = await tx.user.findUnique({
+          where: { id: input.requestedByUserId },
+          select: { email: true, displayName: true },
+        });
+
+        await this.audit.recordWithin(tx, {
+          action: PanoramaAuditAction.TenantDeleteRequested,
+          resourceType: 'tenant',
+          resourceId: input.tenantId,
+          tenantId: input.tenantId,
+          actorUserId: input.requestedByUserId,
+          metadata: {
+            requestedByUserId: input.requestedByUserId,
+            ownerCount: owners.length,
+            tokenKeyPrefix: tokenHash.slice(0, 8),
+          },
+        });
+
+        return {
+          kind: 'ok' as const,
+          tokenKeyPrefix: tokenHash.slice(0, 8),
+          ownerCount: owners.length,
+          tenantDisplayName: tenant.displayName,
+          owners,
+          requester: requester ?? { email: 'unknown', displayName: 'Unknown' },
+        };
+      },
+      { reason: `tenant-deletion:request:${input.tenantId}` },
+    );
+
+    if (result.kind !== 'ok') return result;
+
+    // Email fan-out happens AFTER the tx commits — a tx that holds
+    // an SMTP roundtrip is fragile. Per-recipient send is best-
+    // effort; a partial fan-out logs each failure but does not
+    // unwind the request.
+    for (const owner of result.owners) {
+      if (!owner.user) continue;
+      const ctx: DeletionRequestEmailContext = {
+        recipientEmail: owner.user.email,
+        recipientDisplayName: owner.user.displayName,
+        tenantDisplayName: result.tenantDisplayName,
+        requesterDisplayName: result.requester.displayName,
+        requesterEmail: result.requester.email,
+        token: plaintext,
+        manageUrlBase: this.cfg.config.manageUrlBase,
+        tenantId: input.tenantId,
+        expiresAt,
+        coolOffDays: this.cfg.config.coolOffDays,
+      };
+      const rendered = renderDeletionRequestEmail(ctx);
+      try {
+        await this.mail.send({
+          to: owner.user.email,
+          subject: rendered.subject,
+          text: rendered.text,
+          html: rendered.html,
+        });
+      } catch (err) {
+        // Log the recipient as a sha256 prefix so operator can
+        // correlate without leaking the raw email into log
+        // aggregators (mirrors PR 2's `email-verification.service.ts`
+        // log shape — security-reviewer PR 3 review).
+        this.log.error(
+          {
+            err: String(err),
+            recipientHash: createHash('sha256').update(owner.user.email).digest('hex').slice(0, 8),
+          },
+          'tenant_deletion_email_dispatch_failed',
+        );
+      }
+    }
+    return {
+      kind: 'ok',
+      tokenKeyPrefix: result.tokenKeyPrefix,
+      ownerCount: result.ownerCount,
+    };
+  }
+
+  /**
+   * §7 step 2 — POST /tenants/:id/delete-confirm.
+   *
+   * Atomic tx: validate + mark consumed + set scheduledAt.
+   * Race A (ADR §7) — concurrent confirm + cancel — resolves as
+   * last-writer-wins on the `deletionScheduledAt` column; this
+   * function is the WRITE for the confirm side.
+   */
+  async confirm(input: {
+    tenantId: string;
+    actorUserId: string;
+    token: string;
+  }): Promise<ConfirmResult> {
+    if (!input.token || typeof input.token !== 'string') {
+      return { kind: 'missing' };
+    }
+    const tokenHash = hashToken(input.token);
+    return this.prisma.runAsSuperAdmin(
+      async (tx) => {
+        const row = await tx.tenantDeletionToken.findUnique({
+          where: { tokenHash },
+        });
+        if (!row) return { kind: 'missing' } as const;
+        if (row.tenantId !== input.tenantId) {
+          return { kind: 'tenant_mismatch' } as const;
+        }
+        if (row.consumedAt !== null) {
+          return { kind: 'already_consumed' } as const;
+        }
+        if (row.expiresAt.getTime() <= Date.now()) {
+          return { kind: 'expired' } as const;
+        }
+
+        const tenant = await tx.tenant.findUnique({
+          where: { id: row.tenantId },
+          select: { deletionScheduledAt: true },
+        });
+        if (!tenant) return { kind: 'missing' } as const;
+        if (tenant.deletionScheduledAt !== null) {
+          return { kind: 'tenant_already_scheduled' } as const;
+        }
+
+        const scheduledAt = new Date(
+          Date.now() + this.cfg.config.coolOffDays * 24 * 60 * 60 * 1000,
+        );
+        await tx.tenantDeletionToken.update({
+          where: { id: row.id },
+          data: { consumedAt: new Date() },
+        });
+        await tx.tenant.update({
+          where: { id: row.tenantId },
+          data: {
+            deletionScheduledAt: scheduledAt,
+            deletionRequestedByUserId: input.actorUserId,
+          },
+        });
+
+        await this.audit.recordWithin(tx, {
+          action: PanoramaAuditAction.TenantDeleteConfirmed,
+          resourceType: 'tenant',
+          resourceId: row.tenantId,
+          tenantId: row.tenantId,
+          actorUserId: input.actorUserId,
+          metadata: {
+            confirmedByUserId: input.actorUserId,
+            scheduledAt: scheduledAt.toISOString(),
+            tokenKeyPrefix: row.tokenHash.slice(0, 8),
+          },
+        });
+
+        return { kind: 'ok' as const, scheduledAt };
+      },
+      { reason: `tenant-deletion:confirm:${input.tenantId}` },
+    );
+  }
+
+  /**
+   * §7 cancel path — POST /tenants/:id/delete-cancel.
+   * Idempotent: a cancel against an already-cancelled tenant
+   * returns `noop` and does NOT emit a duplicate
+   * `TenantDeleteCancelled` audit row (§7 race C).
+   */
+  async cancel(input: {
+    tenantId: string;
+    actorUserId: string;
+  }): Promise<CancelResult> {
+    return this.prisma.runAsSuperAdmin(
+      async (tx) => {
+        const tenant = await tx.tenant.findUnique({
+          where: { id: input.tenantId },
+          select: { deletionScheduledAt: true },
+        });
+        if (!tenant || tenant.deletionScheduledAt === null) {
+          return { kind: 'noop' as const };
+        }
+        const previouslyScheduledAt = tenant.deletionScheduledAt;
+        await tx.tenant.update({
+          where: { id: input.tenantId },
+          data: {
+            deletionScheduledAt: null,
+            deletionRequestedByUserId: null,
+          },
+        });
+        await this.audit.recordWithin(tx, {
+          action: PanoramaAuditAction.TenantDeleteCancelled,
+          resourceType: 'tenant',
+          resourceId: input.tenantId,
+          tenantId: input.tenantId,
+          actorUserId: input.actorUserId,
+          metadata: {
+            cancelledByUserId: input.actorUserId,
+            previouslyScheduledAt: previouslyScheduledAt.toISOString(),
+          },
+        });
+        return { kind: 'ok' as const, previouslyScheduledAt };
+      },
+      { reason: `tenant-deletion:cancel:${input.tenantId}` },
+    );
+  }
+
+  /**
+   * §7 veto path — POST /tenants/:id/delete-veto.
+   *
+   * Peer-Owner only in PR 3 (the platform-maintainer admin console
+   * surface is deferred). Refuses if the vetoing Owner IS the
+   * original requester — the requester cancels via /delete-cancel,
+   * not by self-vetoing their own request. The peer-Owner check
+   * is the §7 race B mitigation that surfaces compromised-credential
+   * recovery in the audit trail with a distinct action label.
+   */
+  async veto(input: {
+    tenantId: string;
+    actorUserId: string;
+  }): Promise<VetoResult> {
+    return this.prisma.runAsSuperAdmin(
+      async (tx) => {
+        const tenant = await tx.tenant.findUnique({
+          where: { id: input.tenantId },
+          select: {
+            deletionScheduledAt: true,
+            deletionRequestedByUserId: true,
+          },
+        });
+        if (!tenant || tenant.deletionScheduledAt === null) {
+          return { kind: 'noop' as const };
+        }
+        if (tenant.deletionRequestedByUserId === input.actorUserId) {
+          return { kind: 'requester_self_veto_refused' as const };
+        }
+        const previouslyScheduledAt = tenant.deletionScheduledAt;
+        await tx.tenant.update({
+          where: { id: input.tenantId },
+          data: {
+            deletionScheduledAt: null,
+            deletionRequestedByUserId: null,
+          },
+        });
+        await this.audit.recordWithin(tx, {
+          action: PanoramaAuditAction.TenantDeleteVeto,
+          resourceType: 'tenant',
+          resourceId: input.tenantId,
+          tenantId: input.tenantId,
+          actorUserId: input.actorUserId,
+          metadata: {
+            vetoedByUserId: input.actorUserId,
+            vetoSource: 'peer_owner',
+            previouslyScheduledAt: previouslyScheduledAt.toISOString(),
+          },
+        });
+        return { kind: 'ok' as const, previouslyScheduledAt };
+      },
+      { reason: `tenant-deletion:veto:${input.tenantId}` },
+    );
+  }
+
+  /**
+   * Cron purge entry. Finds tenants past their cool-off and
+   * processes them serially. Bounded by `circuitBreaker` to avoid
+   * an unbounded loop if many tenants come due at once.
+   */
+  async runPurgeBatch(circuitBreaker = 50): Promise<{ purged: number }> {
+    const due = await this.prisma.runAsSuperAdmin(
+      (tx) =>
+        tx.tenant.findMany({
+          where: { deletionScheduledAt: { lte: new Date() } },
+          select: { id: true, slug: true, displayName: true },
+          take: circuitBreaker,
+        }),
+      { reason: 'tenant-deletion:purge:list' },
+    );
+    let purged = 0;
+    for (const tenant of due) {
+      try {
+        await this.purgeOne(tenant);
+        purged += 1;
+      } catch (err) {
+        this.log.error(
+          { tenantId: tenant.id, err: String(err) },
+          'tenant_purge_failed',
+        );
+      }
+    }
+    return { purged };
+  }
+
+  private async purgeOne(tenant: {
+    id: string;
+    slug: string;
+    displayName: string;
+  }): Promise<void> {
+    await this.prisma.runAsSuperAdmin(
+      async (tx) => {
+        // The cascade delete on `tenants` cascades into
+        // `tenant_membership` (CASCADE FK), which would otherwise
+        // fire the enforce_at_least_one_owner trigger (migration
+        // 0005) — the trigger refuses any DELETE that takes the
+        // active-owner count to zero. The §7 purge is the
+        // legitimate "everything goes" path, so we set the trigger
+        // bypass GUC inside this tx only (LOCAL → scoped to the tx
+        // commit/rollback, no leak to other connections).
+        await tx.$executeRawUnsafe(
+          "SET LOCAL panorama.bypass_owner_check = 'on'",
+        );
+
+        const fresh = await tx.tenant.findUnique({
+          where: { id: tenant.id },
+          select: {
+            id: true,
+            slug: true,
+            displayName: true,
+            deletionScheduledAt: true,
+            deletionRequestedByUserId: true,
+            systemActorUserId: true,
+          },
+        });
+        if (!fresh) return;
+        if (
+          fresh.deletionScheduledAt === null ||
+          fresh.deletionScheduledAt.getTime() > Date.now()
+        ) {
+          // Tenant was cancelled/vetoed/rescheduled between the
+          // list scan and this tx. Skip.
+          return;
+        }
+
+        // Emit BEFORE the cascade so the row carries
+        // tenantId = <the tenant about to disappear>. audit_events
+        // has no FK to tenants, so the row survives the DELETE.
+        await this.audit.recordWithin(tx, {
+          action: PanoramaAuditAction.TenantDeleted,
+          resourceType: 'tenant',
+          resourceId: fresh.id,
+          tenantId: fresh.id,
+          actorUserId: fresh.deletionRequestedByUserId,
+          metadata: {
+            slug: fresh.slug,
+            displayName: fresh.displayName,
+            scheduledAt: fresh.deletionScheduledAt.toISOString(),
+            requestedByUserId: fresh.deletionRequestedByUserId,
+          },
+        });
+
+        // §7 cascade ordering. The schema has TWO classes of FK that
+        // a single `DELETE tenant` cascade does NOT untangle on its
+        // own:
+        //
+        //   (a) USER-SIDE RESTRICT (table.createdByUserId → users
+        //       ON DELETE RESTRICT) — asset_maintenances,
+        //       inspection_templates, blackout_slots. These block
+        //       a direct `DELETE user` if the rows still exist.
+        //   (b) INTRA-TENANT RESTRICT (table.fkColumn → otherTable
+        //       inside the same tenant) — asset_models.categoryId
+        //       → categories ON DELETE RESTRICT (migration 0001).
+        //       Even though both tables CASCADE-delete from
+        //       `tenants(id)`, PostgreSQL's cascade walker does not
+        //       topologically sort the per-row deletes within ONE
+        //       cascade pass, so the RESTRICT fires while the
+        //       asset_models row still references the category
+        //       row PG is trying to drop.
+        //
+        // Resolution — issue explicit `deleteMany` calls in reverse-
+        // dependency order BEFORE the `DELETE tenant`, then null
+        // systemActorUserId, then DELETE tenant, then DELETE user.
+        // This is the same approach `resetTestDb` uses for the test
+        // teardown; the ordering is a load-bearing invariant that
+        // future tenant-scoped tables MUST extend here.
+        const systemActorUserId = fresh.systemActorUserId;
+        const tenantId = fresh.id;
+
+        // Reverse-dependency delete inside the same tenant.
+        // - Inspection chain: photos → responses → inspections →
+        //   template_items → templates.
+        // - Maintenance chain: photos → asset_maintenances.
+        // - Reservation chain: reservations (depend on assets +
+        //   users, but tenant-scoped).
+        // - Asset chain: assets → asset_models → manufacturers →
+        //   categories (asset_models.categoryId RESTRICT is the
+        //   intra-tenant FK this ordering exists to satisfy).
+        // - Domain: blackouts, invitations, PATs, notification
+        //   events, memberships, signup/deletion artefacts.
+        // audit_events stays — it's append-only with no FK to
+        // tenants(id) and survives the purge intentionally (the
+        // TenantDeleted row written above is part of that strand).
+        await tx.inspectionPhoto.deleteMany({ where: { tenantId } });
+        await tx.inspectionResponse.deleteMany({ where: { tenantId } });
+        await tx.inspection.deleteMany({ where: { tenantId } });
+        await tx.inspectionTemplateItem.deleteMany({ where: { tenantId } });
+        await tx.inspectionTemplate.deleteMany({ where: { tenantId } });
+        await tx.maintenancePhoto.deleteMany({ where: { tenantId } });
+        await tx.assetMaintenance.deleteMany({ where: { tenantId } });
+        await tx.reservation.deleteMany({ where: { tenantId } });
+        await tx.asset.deleteMany({ where: { tenantId } });
+        await tx.assetModel.deleteMany({ where: { tenantId } });
+        await tx.manufacturer.deleteMany({ where: { tenantId } });
+        await tx.category.deleteMany({ where: { tenantId } });
+        await tx.blackoutSlot.deleteMany({ where: { tenantId } });
+        await tx.invitation.deleteMany({ where: { tenantId } });
+        await tx.personalAccessToken.deleteMany({ where: { tenantId } });
+        await tx.notificationEvent.deleteMany({ where: { tenantId } });
+        await tx.emailVerification.deleteMany({ where: { tenantId } });
+        await tx.tenantDeletionToken.deleteMany({ where: { tenantId } });
+        await tx.tenantMembership.deleteMany({ where: { tenantId } });
+
+        if (systemActorUserId !== null) {
+          // (a) drop the User→Tenant RESTRICT pointer so the system
+          // user can be deleted after the tenant goes.
+          await tx.tenant.update({
+            where: { id: tenantId },
+            data: { systemActorUserId: null },
+          });
+        }
+        // With every tenant-scoped row gone, the tenant DELETE
+        // succeeds. The remaining CASCADE FKs back from
+        // tenant-orphan rows (none should exist after the loop
+        // above) are a no-op.
+        await tx.tenant.delete({ where: { id: tenantId } });
+        if (systemActorUserId !== null) {
+          // The system user's tenant_membership row was wiped in
+          // the membership deleteMany above. With no remaining
+          // RESTRICT FK referencing the user, the delete succeeds.
+          await tx.user.delete({ where: { id: systemActorUserId } });
+        }
+      },
+      { reason: `tenant-deletion:purge:${tenant.id}` },
+    );
+  }
+
+  private generateToken(): { plaintext: string; tokenHash: string } {
+    const plaintext = randomBytes(32).toString('base64url');
+    return { plaintext, tokenHash: hashToken(plaintext) };
+  }
+}
+
+function hashToken(plaintext: string): string {
+  return createHash('sha256').update(plaintext).digest('hex');
+}

--- a/apps/core-api/src/modules/tenant-deletion/tenant-deletion.templates.ts
+++ b/apps/core-api/src/modules/tenant-deletion/tenant-deletion.templates.ts
@@ -1,0 +1,107 @@
+/**
+ * ADR-0020 §7 — tenant deletion request email body.
+ *
+ * Sent to ALL active Owners of the tenant when any Owner posts
+ * `/tenants/:id/delete-request`. The email is the multi-Owner peer-
+ * recovery channel from §7 race B: if the requesting Owner's
+ * credentials are compromised, peer Owners receive the email and
+ * can cancel or veto.
+ *
+ * The confirm-link uses a URL FRAGMENT (`#token=...`) so link-
+ * preview bots can't pre-consume the token via GET fetch. The
+ * frontend at `${manageUrlBase}/tenants/:tenantId/deletion` reads
+ * `location.hash`, strips it, and forwards via POST to the actual
+ * consume endpoint.
+ */
+
+export interface DeletionRequestEmailContext {
+  recipientEmail: string;
+  recipientDisplayName: string;
+  tenantDisplayName: string;
+  requesterDisplayName: string;
+  requesterEmail: string;
+  /** Plaintext token surfaced once; never persisted. */
+  token: string;
+  /** Absolute URL the email links to (token rides in fragment). */
+  manageUrlBase: string;
+  tenantId: string;
+  expiresAt: Date;
+  coolOffDays: number;
+}
+
+export interface RenderedEmail {
+  subject: string;
+  text: string;
+  html: string;
+}
+
+export function renderDeletionRequestEmail(
+  ctx: DeletionRequestEmailContext,
+): RenderedEmail {
+  const subject = `Confirm deletion of Panorama tenant "${ctx.tenantDisplayName}"`;
+  const expiresIso = ctx.expiresAt.toISOString();
+  const manageUrl = `${ctx.manageUrlBase}/tenants/${ctx.tenantId}/deletion#token=${encodeURIComponent(ctx.token)}`;
+
+  const text = [
+    `Hello ${ctx.recipientDisplayName},`,
+    '',
+    `${ctx.requesterDisplayName} (${ctx.requesterEmail}) requested the deletion of the Panorama tenant "${ctx.tenantDisplayName}".`,
+    '',
+    `If this was you (or another Owner you trust), confirm the request at:`,
+    manageUrl,
+    '',
+    `Once confirmed, the tenant enters a ${ctx.coolOffDays}-day cool-off window. Any Owner can cancel during that window.`,
+    '',
+    `If this was NOT you, do nothing — the request expires at ${expiresIso} without action. You may also visit the link above to VETO the request (peer-Owner safety net per ADR-0020 §7).`,
+    '',
+    `If the link doesn't work, paste this token into the deletion-confirm page:`,
+    `  ${ctx.token}`,
+    '',
+    `— Panorama`,
+  ].join('\n');
+
+  const html = /* html */ `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>${escapeHtml(subject)}</title></head>
+<body style="font-family:-apple-system,Segoe UI,Roboto,sans-serif;background:#0f172a;color:#e2e8f0;padding:32px 0;margin:0;">
+<table role="presentation" align="center" width="540" cellpadding="0" cellspacing="0"
+       style="background:#1e293b;border-radius:12px;overflow:hidden;">
+<tr><td style="padding:32px;">
+<h1 style="margin:0 0 16px 0;font-size:22px;color:#f8fafc;">Confirm tenant deletion</h1>
+<p style="margin:0 0 16px 0;line-height:1.5;">
+<strong>${escapeHtml(ctx.requesterDisplayName)}</strong>
+<span style="color:#94a3b8;">(${escapeHtml(ctx.requesterEmail)})</span>
+requested the deletion of <strong>${escapeHtml(ctx.tenantDisplayName)}</strong>.
+</p>
+<p style="margin:24px 0;">
+  <a href="${escapeHtml(manageUrl)}"
+     style="display:inline-block;background:#f87171;color:#0f172a;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+     Review request
+  </a>
+</p>
+<p style="margin:16px 0;line-height:1.5;color:#94a3b8;font-size:13px;">
+  Once confirmed, the tenant enters a ${ctx.coolOffDays}-day cool-off window. Any Owner can cancel during that window.
+</p>
+<p style="margin:16px 0;line-height:1.5;color:#94a3b8;font-size:13px;">
+  If this was NOT you, do nothing — the request expires at <code style="color:#e2e8f0;">${escapeHtml(expiresIso)}</code>. You may also visit the link above to VETO the request (peer-Owner safety net).
+</p>
+<p style="margin:24px 0 0 0;color:#94a3b8;font-size:13px;">
+  If the button does not work, paste this token into the deletion page:
+  <br/><code style="display:inline-block;background:#0f172a;padding:6px 12px;border-radius:4px;margin-top:8px;color:#e2e8f0;">${escapeHtml(ctx.token)}</code>
+</p>
+</td></tr>
+</table>
+</body>
+</html>`;
+
+  return { subject, text, html };
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/apps/core-api/test/maintenance-tether.e2e.test.ts
+++ b/apps/core-api/test/maintenance-tether.e2e.test.ts
@@ -190,7 +190,11 @@ describe('maintenance auto-suggest tether e2e', () => {
       where: { id: tenantId },
       select: { systemActorUserId: true },
     });
-    systemActorUserId = tenantRow!.systemActorUserId;
+    // Newly created tenant — systemActorUserId is set by
+    // createTenantWithOwner. Nullable as of migration 0024 to
+    // accommodate the ADR-0020 §7 purge cron's null-then-delete
+    // sequence; not relevant here.
+    systemActorUserId = tenantRow!.systemActorUserId!;
     await adminDb.tenantMembership.create({
       data: { tenantId, userId: driverUser.id, role: 'driver', status: 'active' },
     });

--- a/apps/core-api/test/migration-0015-corrections.test.ts
+++ b/apps/core-api/test/migration-0015-corrections.test.ts
@@ -48,7 +48,9 @@ describe('migration 0015 — Wave 1 corrections', () => {
       where: { id: tenant.id },
       select: { systemActorUserId: true },
     });
-    userId = tenantRow.systemActorUserId;
+    // Migration 0024 makes systemActorUserId nullable; live tenants
+    // always have it set immediately after createTenantWithOwner.
+    userId = tenantRow.systemActorUserId!;
   }, 60_000);
 
   afterAll(async () => {

--- a/apps/core-api/test/migration-0021-audit-chain.test.ts
+++ b/apps/core-api/test/migration-0021-audit-chain.test.ts
@@ -49,7 +49,9 @@ describe('migration 0021 — audit chain reproducibility', () => {
       where: { id: a.id },
       select: { systemActorUserId: true },
     });
-    userId = aRow.systemActorUserId;
+    // Migration 0024 makes systemActorUserId nullable; live tenants
+    // always have it set immediately after createTenantWithOwner.
+    userId = aRow.systemActorUserId!;
 
     const b = await createTenantForTest(admin, {
       slug: 'mig21-b',

--- a/apps/core-api/test/tenant-deletion.e2e.test.ts
+++ b/apps/core-api/test/tenant-deletion.e2e.test.ts
@@ -1,0 +1,391 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Test } from '@nestjs/testing';
+import type { INestApplication } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+import { AppModule } from '../src/app.module.js';
+import { PasswordService } from '../src/modules/auth/password.service.js';
+import { EmailService } from '../src/modules/email/email.service.js';
+import { TenantDeletionService } from '../src/modules/tenant-deletion/tenant-deletion.service.js';
+import { resetTestDb } from './_reset-db.js';
+import { createTenantForTest } from './_create-tenant.js';
+
+/**
+ * E2e coverage for ADR-0020 §7 (PR 3 tenant deletion).
+ *
+ * Tests the four endpoint surfaces + the purge cron service entry,
+ * end-to-end against a real DB. Uses two Owner accounts on one
+ * tenant so peer-Owner veto can be exercised; uses a third tenant
+ * (no overlap) for cross-tenant rejection.
+ *
+ * Email dispatch is mocked via the standard testing-module override
+ * pattern so SMTP failure / capture is observable. The cron sweep
+ * is idle in tests (`OnModuleInit` short-circuits on
+ * `NODE_ENV=test`), so we drive `runPurgeBatch` directly to test
+ * the cascade path.
+ */
+
+const HOST = process.env['PG_HOST'] ?? 'localhost';
+const PORT = process.env['PG_PORT'] ?? '5432';
+const DB = process.env['PG_DB'] ?? 'panorama';
+const ADMIN_URL = `postgres://panorama_super_admin:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+const APP_URL = `postgres://panorama_app:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+
+interface SentEmail {
+  to: string;
+  subject: string;
+  text: string;
+}
+
+describe('tenant deletion (ADR-0020 §7, PR 3)', () => {
+  let app: INestApplication;
+  let url: string;
+  let admin: PrismaClient;
+  let deletion: TenantDeletionService;
+  let sentEmails: SentEmail[];
+  let tenantId: string;
+  let ownerAEmail: string;
+  let ownerBEmail: string;
+  const password = 'correct-horse-battery-staple';
+
+  beforeAll(async () => {
+    process.env['SESSION_SECRET'] = process.env['SESSION_SECRET'] ?? 'a'.repeat(32);
+    process.env['DATABASE_URL'] = APP_URL;
+
+    admin = new PrismaClient({ datasources: { db: { url: ADMIN_URL } } });
+    await resetTestDb(admin);
+
+    sentEmails = [];
+
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] })
+      .overrideProvider(EmailService)
+      .useValue({
+        send: async (input: { to: string; subject: string; text: string }) => {
+          sentEmails.push({ to: input.to, subject: input.subject, text: input.text });
+          return { messageId: `mock-${sentEmails.length}` };
+        },
+        onModuleDestroy: async () => {},
+      })
+      .compile();
+    app = moduleRef.createNestApplication({ logger: ['error', 'warn'] });
+    await app.init();
+    await app.listen(0);
+    url = await app.getUrl();
+    deletion = app.get(TenantDeletionService);
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.close();
+    await admin?.$disconnect();
+  });
+
+  beforeEach(async () => {
+    await resetTestDb(admin);
+    sentEmails.length = 0;
+    ({ tenantId, ownerAEmail, ownerBEmail } = await seedTenantWithTwoOwners(admin, password));
+  });
+
+  it('happy path: request → email fan-out → confirm → scheduledAt set', async () => {
+    const cookieA = await login(url, ownerAEmail, password);
+
+    const reqResp = await fetch(`${url}/tenants/${tenantId}/delete-request`, {
+      method: 'POST',
+      headers: { cookie: cookieA },
+    });
+    expect(reqResp.status).toBe(200);
+    const reqBody = (await reqResp.json()) as { ownerCount: number };
+    expect(reqBody.ownerCount).toBe(2);
+
+    // Both Owners received the email.
+    expect(sentEmails.map((e) => e.to).sort()).toEqual([ownerAEmail, ownerBEmail].sort());
+    const token = extractToken(sentEmails[0]!.text);
+    expect(token).not.toBe('');
+
+    const confirmResp = await fetch(`${url}/tenants/${tenantId}/delete-confirm`, {
+      method: 'POST',
+      headers: { cookie: cookieA, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+    expect(confirmResp.status).toBe(200);
+    const confirmBody = (await confirmResp.json()) as { scheduledAt: string };
+    expect(new Date(confirmBody.scheduledAt).getTime()).toBeGreaterThan(Date.now());
+
+    const tenantRow = await admin.tenant.findUnique({ where: { id: tenantId } });
+    expect(tenantRow?.deletionScheduledAt).not.toBeNull();
+  });
+
+  it('cancel: clears deletionScheduledAt, idempotent on second call', async () => {
+    const cookieA = await login(url, ownerAEmail, password);
+    await fetch(`${url}/tenants/${tenantId}/delete-request`, {
+      method: 'POST',
+      headers: { cookie: cookieA },
+    });
+    const token = extractToken(sentEmails[0]!.text);
+    await fetch(`${url}/tenants/${tenantId}/delete-confirm`, {
+      method: 'POST',
+      headers: { cookie: cookieA, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+
+    const cancel1 = await fetch(`${url}/tenants/${tenantId}/delete-cancel`, {
+      method: 'POST',
+      headers: { cookie: cookieA },
+    });
+    expect(cancel1.status).toBe(200);
+    const cancel2 = await fetch(`${url}/tenants/${tenantId}/delete-cancel`, {
+      method: 'POST',
+      headers: { cookie: cookieA },
+    });
+    expect(cancel2.status).toBe(200);
+
+    // Race C: only ONE delete_cancelled audit row, not two.
+    const cancelled = await admin.auditEvent.count({
+      where: {
+        tenantId,
+        action: 'panorama.tenant.delete_cancelled',
+      },
+    });
+    expect(cancelled).toBe(1);
+    const tenantRow = await admin.tenant.findUnique({ where: { id: tenantId } });
+    expect(tenantRow?.deletionScheduledAt).toBeNull();
+  });
+
+  it('veto: peer Owner cancels with distinct audit signal', async () => {
+    const cookieA = await login(url, ownerAEmail, password);
+    await fetch(`${url}/tenants/${tenantId}/delete-request`, {
+      method: 'POST',
+      headers: { cookie: cookieA },
+    });
+    const token = extractToken(sentEmails[0]!.text);
+    await fetch(`${url}/tenants/${tenantId}/delete-confirm`, {
+      method: 'POST',
+      headers: { cookie: cookieA, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+
+    const cookieB = await login(url, ownerBEmail, password);
+    const vetoResp = await fetch(`${url}/tenants/${tenantId}/delete-veto`, {
+      method: 'POST',
+      headers: { cookie: cookieB },
+    });
+    expect(vetoResp.status).toBe(200);
+
+    const vetoed = await admin.auditEvent.findFirst({
+      where: { tenantId, action: 'panorama.tenant.delete_veto' },
+    });
+    expect(vetoed).not.toBeNull();
+    expect((vetoed!.metadata as { vetoSource?: string }).vetoSource).toBe('peer_owner');
+
+    const tenantRow = await admin.tenant.findUnique({ where: { id: tenantId } });
+    expect(tenantRow?.deletionScheduledAt).toBeNull();
+  });
+
+  it('self-veto refused: requester cannot veto their own request', async () => {
+    const cookieA = await login(url, ownerAEmail, password);
+    await fetch(`${url}/tenants/${tenantId}/delete-request`, {
+      method: 'POST',
+      headers: { cookie: cookieA },
+    });
+    const token = extractToken(sentEmails[0]!.text);
+    await fetch(`${url}/tenants/${tenantId}/delete-confirm`, {
+      method: 'POST',
+      headers: { cookie: cookieA, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+
+    // Same Owner that confirmed now tries to veto — refused. (They
+    // can /delete-cancel instead.)
+    const vetoResp = await fetch(`${url}/tenants/${tenantId}/delete-veto`, {
+      method: 'POST',
+      headers: { cookie: cookieA },
+    });
+    expect(vetoResp.status).toBe(403);
+  });
+
+  it('purge cron: cascade survives asset_maintenances RESTRICT on system user (regression for PR 3 tech-lead review)', async () => {
+    // Tech-lead PR 3 review flagged that asset_maintenances.createdByUserId
+    // ON DELETE RESTRICT points at users(id). If the system user has
+    // authored any auto-suggested maintenance ticket, the old purge
+    // ordering (DELETE user before DELETE tenant) hit the RESTRICT
+    // and the tx aborted. Reversed ordering (tenant first → user
+    // last) lets the tenant CASCADE clear asset_maintenances first.
+    // Seed one ticket authored by the system user to lock the
+    // contract.
+    const cookieA = await login(url, ownerAEmail, password);
+    await fetch(`${url}/tenants/${tenantId}/delete-request`, {
+      method: 'POST',
+      headers: { cookie: cookieA },
+    });
+    const token = extractToken(sentEmails[0]!.text);
+    await fetch(`${url}/tenants/${tenantId}/delete-confirm`, {
+      method: 'POST',
+      headers: { cookie: cookieA, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+
+    // Seed the asset_maintenances row authored by the system user.
+    const tenant = await admin.tenant.findUnique({ where: { id: tenantId } });
+    expect(tenant?.systemActorUserId).not.toBeNull();
+    const category = await admin.category.create({
+      data: { tenantId, name: 'Vehicles', kind: 'VEHICLE' },
+    });
+    const model = await admin.assetModel.create({
+      data: { tenantId, categoryId: category.id, name: 'F-150' },
+    });
+    const asset = await admin.asset.create({
+      data: { tenantId, modelId: model.id, tag: 'PURGE-1', name: 'Purge truck' },
+    });
+    await admin.assetMaintenance.create({
+      data: {
+        tenantId,
+        assetId: asset.id,
+        // Authored by the system user — this is the row that would
+        // RESTRICT a DELETE user pre-fix.
+        createdByUserId: tenant!.systemActorUserId!,
+        status: 'OPEN',
+        maintenanceType: 'CORRECTIVE',
+        title: 'Regression seed',
+      },
+    });
+
+    // Fast-forward + purge.
+    await admin.tenant.update({
+      where: { id: tenantId },
+      data: { deletionScheduledAt: new Date(Date.now() - 60 * 60 * 1000) },
+    });
+    const result = await deletion.runPurgeBatch();
+    expect(result.purged).toBe(1);
+
+    const tenantGone = await admin.tenant.findUnique({ where: { id: tenantId } });
+    expect(tenantGone).toBeNull();
+  });
+
+  it('purge cron: advances scheduledAt to past, runPurgeBatch deletes the tenant', async () => {
+    const cookieA = await login(url, ownerAEmail, password);
+    await fetch(`${url}/tenants/${tenantId}/delete-request`, {
+      method: 'POST',
+      headers: { cookie: cookieA },
+    });
+    const token = extractToken(sentEmails[0]!.text);
+    await fetch(`${url}/tenants/${tenantId}/delete-confirm`, {
+      method: 'POST',
+      headers: { cookie: cookieA, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+
+    // Manually fast-forward the cool-off so the cron picks it up.
+    await admin.tenant.update({
+      where: { id: tenantId },
+      data: { deletionScheduledAt: new Date(Date.now() - 60 * 60 * 1000) },
+    });
+
+    const result = await deletion.runPurgeBatch();
+    expect(result.purged).toBe(1);
+
+    const tenantGone = await admin.tenant.findUnique({ where: { id: tenantId } });
+    expect(tenantGone).toBeNull();
+
+    // TenantDeleted audit row survives the cascade.
+    const audit = await admin.auditEvent.findFirst({
+      where: { action: 'panorama.tenant.deleted', tenantId },
+    });
+    expect(audit).not.toBeNull();
+  });
+
+  it('auth: non-Owner gets 403 / 401', async () => {
+    // Demote owner A to non-owner role first so we have a session
+    // for a non-Owner. We do this by direct DB UPDATE to bypass
+    // the last-Owner trigger (we have Owner B too).
+    const memberA = await admin.tenantMembership.findFirst({
+      where: { tenantId, user: { email: ownerAEmail } },
+    });
+    await admin.tenantMembership.update({
+      where: { id: memberA!.id },
+      data: { role: 'fleet_admin' },
+    });
+
+    const cookieA = await login(url, ownerAEmail, password);
+    const resp = await fetch(`${url}/tenants/${tenantId}/delete-request`, {
+      method: 'POST',
+      headers: { cookie: cookieA },
+    });
+    // Non-Owner trying to hit an Owner-only endpoint — 403.
+    expect(resp.status).toBe(403);
+  });
+});
+
+// -----------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------
+
+async function seedTenantWithTwoOwners(
+  admin: PrismaClient,
+  password: string,
+): Promise<{ tenantId: string; ownerAEmail: string; ownerBEmail: string }> {
+  const passwords = new PasswordService();
+  const secretHash = await passwords.hash(password);
+  const ownerAEmail = `owner-a-${Date.now()}@example.invalid`;
+  const ownerBEmail = `owner-b-${Date.now()}@example.invalid`;
+  const userA = await admin.user.create({
+    data: { email: ownerAEmail, displayName: 'Owner A' },
+  });
+  const userB = await admin.user.create({
+    data: { email: ownerBEmail, displayName: 'Owner B' },
+  });
+  await admin.authIdentity.create({
+    data: {
+      userId: userA.id,
+      provider: 'password',
+      subject: ownerAEmail,
+      emailAtLink: ownerAEmail,
+      secretHash,
+    },
+  });
+  await admin.authIdentity.create({
+    data: {
+      userId: userB.id,
+      provider: 'password',
+      subject: ownerBEmail,
+      emailAtLink: ownerBEmail,
+      secretHash,
+    },
+  });
+  const tenant = await createTenantForTest(admin, {
+    slug: `pr3-${Date.now()}`,
+    name: 'PR3 Test Tenant',
+    displayName: 'PR3 Test Tenant',
+  });
+  await admin.tenantMembership.create({
+    data: { tenantId: tenant.id, userId: userA.id, role: 'owner', status: 'active' },
+  });
+  await admin.tenantMembership.create({
+    data: { tenantId: tenant.id, userId: userB.id, role: 'owner', status: 'active' },
+  });
+  return { tenantId: tenant.id, ownerAEmail, ownerBEmail };
+}
+
+async function login(baseUrl: string, email: string, password: string): Promise<string> {
+  const res = await fetch(`${baseUrl}/auth/login`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  if (res.status !== 200) {
+    throw new Error(`login failed: ${res.status} ${await res.text()}`);
+  }
+  const setCookie = res.headers.get('set-cookie');
+  if (!setCookie) throw new Error('login response missing set-cookie');
+  // Strip attributes; keep only `name=value` segments joined.
+  return setCookie
+    .split(',')
+    .map((c) => c.split(';')[0]!.trim())
+    .join('; ');
+}
+
+function extractToken(text: string): string {
+  // Template renders `#token=<plaintext>` in the link AND a paste-
+  // fallback "paste this token: <plaintext>". Pull from the
+  // fragment shape.
+  const match = text.match(/#token=([A-Za-z0-9_-]+)/);
+  return match ? match[1]! : '';
+}

--- a/docs/adr/0020-self-serve-oidc-signup.md
+++ b/docs/adr/0020-self-serve-oidc-signup.md
@@ -459,11 +459,45 @@ channel when the credential compromise also captures the inbox
   `panorama.tenant.delete_cancelled` event, not two (deduplicate by
   checking `deletionScheduledAt IS NULL` before emitting).
 
-Cascade ordering note (per data-architect C6 in Wave 0 scan):
-`Tenant.systemActorUserId` has `ON DELETE RESTRICT`. The deletion
-service MUST NULL this column (or delete the system user) BEFORE
-attempting the cascade-delete on the tenant row. This is service-
-layer logic, not a schema change.
+Cascade ordering note (per data-architect C6 in Wave 0 scan,
+extended during PR 3 tech-lead review):
+
+The deletion service MUST issue its writes in **this exact order**,
+inside one super-admin transaction with `SET LOCAL
+panorama.bypass_owner_check = 'on'` (so the migration-0005
+`enforce_at_least_one_owner` trigger doesn't refuse the cascade
+when the last Owner membership goes away):
+
+  1. **Emit `panorama.tenant.deleted` audit row** BEFORE any
+     mutation — the row's `tenantId` carries the per-tenant strand
+     anchor; `audit_events` has no FK to `tenants` so the row
+     survives the cascade.
+  2. **NULL `Tenant.systemActorUserId`** — clears the
+     `tenants.systemActorUserId` → `users(id)` `ON DELETE RESTRICT`
+     FK. Migration 0024 made the column nullable specifically for
+     this step.
+  3. **DELETE the tenant** — `ON DELETE CASCADE` clears every
+     tenant-scoped row, including the ones that hold User-side
+     `ON DELETE RESTRICT` FKs against the system user:
+     - `asset_maintenances.createdByUserId` (migration 0014) —
+       auto-suggested tickets the system user authored
+     - `inspection_templates.createdByUserId` (migration 0012) —
+       starter templates (rare for the system user but possible
+       via seed paths)
+     - `blackout_slots.createdByUserId` (migration 0006) — never
+       written by the system user today but ON DELETE RESTRICT
+       holds the same shape, so the order matters if it ever is
+  4. **DELETE the system user** — now an orphan, the user-side
+     RESTRICT FKs are vacuous because the cascading delete in
+     step 3 already cleared every referencing row.
+
+The previous (PR 3 pre-fix) order — `NULL systemActorUserId →
+DELETE user → DELETE tenant` — silently worked for tenants that
+never had a maintenance / inspection / blackout written by the
+system user, and tripped on the `asset_maintenances` RESTRICT for
+every tenant that did. PR 3's e2e regression at `tenant-deletion.
+e2e.test.ts > purge cron: cascade survives asset_maintenances
+RESTRICT` locks the contract.
 
 ### 8. Data export
 


### PR DESCRIPTION
## Summary

Implements ADR-0020 §7 — the 4-endpoint deletion lifecycle with 7-day cool-off, multi-Owner email fan-out, peer-Owner veto, and daily cron purge. Builds on [#212](https://github.com/VitorMRodovalho/panorama/pull/212) (signup) + [#214](https://github.com/VitorMRodovalho/panorama/pull/214) (verify). Closes 3 of 4 Round 3 main PRs.

- Migration 0024 — `tenant_deletion_tokens` table + `tenants.deletionScheduledAt` / `tenants.deletionRequestedByUserId` columns + `tenants.systemActorUserId` becomes nullable (cascade-ordering enabler).
- `modules/tenant-deletion/` — six files: config + templates + service + controller + module + BullMQ sweep.
- 4 endpoints under `/tenants/:tenantId/*` (delete-request / confirm / cancel / veto), all Owner-only.
- Daily BullMQ purge cron with idle-in-tests guard.
- Audit registry: new `TenantDeleted` enum entry (the 4 lifecycle audits — Requested/Confirmed/Cancelled/Veto — were registered in #208).

## Adversarial review log

- **tech-lead 1st pass**: 2 blockers — cascade ordering bug on `asset_maintenances.createdByUserId` ON DELETE RESTRICT + ADR §7 cascade note incomplete. ALL addressed:
    - Purge now does explicit reverse-dependency `deleteMany` across every tenant-scoped table (same pattern as `resetTestDb`). Regression test seeds an `asset_maintenances` row authored by the system user — locks the contract.
    - ADR-0020 §7 rewritten to enumerate the (a) user-side and (b) intra-tenant RESTRICT FK classes with the specific chains each one belongs to.
- **security-reviewer 1st pass**: 1 blocker — PII in SMTP-failure log. FIXED: hash recipient email matching PR 2's pattern.
- **Deferred to follow-ups**:
    - Rate-limit on `/delete-request` (Owner-auth + idempotent at data layer).
    - `TenantDeleteRequestEmailFailed` audit row (parallel to PR 2's `TenantVerificationDispatchFailed`).
    - Response-shape discriminator `cancelled: boolean` on `/delete-cancel`.
    - Refuse `/delete-request` on `pendingVerification=true` tenants.
    - Audit `actorUserId: null` fallback when requester user was deleted between confirm and purge.
    - Stale-session role re-check (universal posture).
    - Platform-maintainer veto admin-console surface (`vetoSource: 'platform_maintainer'`).

## Major surfaces

- **Endpoints** — POST `/delete-request`, `/delete-confirm`, `/delete-cancel`, `/delete-veto` under `/tenants/:tenantId/*`. All Owner-only via `requireOwner` (session + tenant match + role).
- **Email template** — URL FRAGMENT (`#token=...`) so link-preview bots can't pre-consume (ADR §3 pattern carried through). Paste-fallback text-only.
- **Purge cron** — BullMQ daily, mirrors `MaintenanceSweepService` shape. Per-tenant tx: SET LOCAL bypass GUC → emit `TenantDeleted` BEFORE cascade → explicit reverse-dependency `deleteMany` → NULL systemActorUserId → DELETE tenant → DELETE system user.
- **Self-veto refused** — `/delete-veto` returns 403 if `actor === deletionRequestedByUserId`. The requester must use `/delete-cancel`. The audit-row SIEM signal (cancelled vs vetoed) is intentionally distinct.
- **Idempotent cancel** — second cancel against an already-cancelled tenant is a noop; audit row written ONLY on the first non-noop call (ADR §7 race C).

## Test plan

- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean.
- [x] `pnpm rls:allowlist-check` — clean (38 calls across 14 files; budget 6 added for tenant-deletion.service.ts).
- [x] Migration 0024 applied to dev DB + Supabase staging.
- [x] Suite: 50 test files / 471 tests passing locally.
- [x] `test/tenant-deletion.e2e.test.ts` (7 tests):
    - happy path (request → email fan-out to 2 Owners → confirm → scheduledAt set)
    - cancel (idempotent: 2 cancels emit ONE audit row)
    - veto (peer Owner B vetoes Owner A's confirm with `vetoSource=peer_owner`)
    - self-veto refused (Owner A confirms, Owner A tries to veto → 403)
    - **purge cascade regression** (tenant with `asset_maintenances` row authored by the system user — proves the new ordering survives the user-side RESTRICT FK)
    - purge happy (tenant + audit row preserved post-cascade)
    - non-Owner refused (demoted Owner can't hit any of the 4 endpoints)
- [ ] NOT covered (deferred): real Cloudflare R2 / SMTP integration; BullMQ worker live-running (cron is idle-in-tests; `runPurgeBatch` is called directly).

## Operational notes

- `TENANT_DELETE_COOL_OFF_DAYS` (default 7, range 1-30) — cool-off window between confirm and purge.
- `TENANT_DELETE_TOKEN_TTL_HOURS` (default 24, range 1-168) — request-token TTL.
- The 4 endpoints + cron are always-on (no feature flag); Owner-auth is the gate and the cron is a no-op without scheduled tenants.
- Migration 0024 makes `Tenant.systemActorUserId` nullable. Live tenants always have it set; null only during the brief purge sequence.
- ADR-0020 §7 now enumerates the full cascade chain — when a new tenant-scoped table lands, update both the ADR sequence AND the `purgeOne` deleteMany list.

## Round 3 status

| PR | Status |
|----|--------|
| 1 — signup initiate + callback | ✅ merged #212 |
| 1 follow-up — normalize ::ffff: v4 | ✅ merged #213 |
| 2 — email verification + flip | ✅ merged #214 |
| **3 — tenant delete 7d cool-off** | **this PR** |
| 4 — data export | pending |