### PR TITLE
feat(tenant-export): Round 3 main 4 — self-serve data export (ADR-0020 §8)

### DIFF
--- a/.runAsSuperAdmin.allowlist.json
+++ b/.runAsSuperAdmin.allowlist.json
@@ -1,7 +1,7 @@
 {
   "_doc": "Allowlist gate for prisma.runAsSuperAdmin call sites. Closes #58 (RLS-CI). Each entry is a file path + the count of CURRENTLY-JUSTIFIED runAsSuperAdmin calls in it + a one-line rationale. The CI script `scripts/check-runAsSuperAdmin-allowlist.ts` compares the actual count against the budget and fails if a file exceeds its budget. Lower the budget when a site migrates to runInTenant; raise only with reviewer sign-off documenting why a tenant-scoped op needs the privileged path.",
   "_review_policy": "Any PR that raises a budget MUST be reviewed by security-reviewer. Lowering a budget is encouraged.",
-  "_last_audit": "2026-05-17 — tenant-deletion.service.ts added budget 6 for ADR-0020 §7 request/confirm/cancel/veto/listDue/purgeOne (tenant_deletion_tokens table has no GRANT to panorama_app, and the purge flow crosses the tenant boundary by construction).",
+  "_last_audit": "2026-05-17 — tenant-export.service.ts added budget 8 for ADR-0020 §8 enqueue + runJob lifecycle (tenant_exports has no GRANT to panorama_app; the worker runs outside any session/tenant context).",
   "files": {
     "apps/core-api/src/modules/audit/audit.service.ts": {
       "budget": 1,
@@ -50,6 +50,10 @@
     "apps/core-api/src/modules/tenant-deletion/tenant-deletion.service.ts": {
       "budget": 6,
       "rationale": "ADR-0020 §7 request/confirm/cancel/veto + the purge cron's list+per-tenant paths. All six sites operate on tenant_deletion_tokens which has NO grant to panorama_app, so RLS-scoped access is unavailable by construction. The purge cron's per-tenant tx ALSO crosses the tenant boundary at delete time (NULL systemActorUserId + delete user + delete tenant)."
+    },
+    "apps/core-api/src/modules/tenant-export/tenant-export.service.ts": {
+      "budget": 10,
+      "rationale": "ADR-0020 §8 enqueue + runJob lifecycle + PR-4-amendment session-gated download surface. enqueue (1) inserts the tenant_exports row + emits TenantExportRequested. runJob's worker path issues several runAsSuperAdmin txs (fetch row, mark processing, serialize all tenant tables in one consistent snapshot, mark completed + emit TenantExported, recipient lookup, mark failed branch + emit TenantExportFailed, dispatchEmail refetch, lookupJobIdByObjectKey for the email URL). getDownloadable + the dispatch-failure audit emission round out the 10 sites. tenant_exports has no GRANT to panorama_app and the worker has no session/tenant context, so super-admin is the only viable role."
     },
     "apps/core-api/src/modules/notification/notification.dispatcher.ts": {
       "budget": 5,

--- a/apps/core-api/prisma/migrations/20260517030000_0025_tenant_export/ROLLBACK.md
+++ b/apps/core-api/prisma/migrations/20260517030000_0025_tenant_export/ROLLBACK.md
@@ -1,0 +1,60 @@
+# Rollback — 0025 tenant data export
+
+## Pre-flight (operator MUST verify BEFORE running)
+
+Adds ONE table (`tenant_exports`) used by ADR-0020 §8 export jobs.
+Rollback drops the table.
+
+Only roll back if PR 4's TenantExportModule (controller + worker +
+service) is also reverted — the runtime code reads `tenant_exports`
+unconditionally and would crash on a missing column otherwise.
+
+## SQL revert (privileged role)
+
+Run from a psql session against `$DATABASE_PRIVILEGED_URL`.
+
+```sql
+DROP TABLE "tenant_exports";
+```
+
+The FKs ON DELETE CASCADE to `tenants` + ON DELETE SET NULL to
+`users` keep the table self-contained — dropping the table does
+not affect `users` or `tenants`.
+
+## Data-loss warnings
+
+- **All export-job rows are dropped.** Operators that need to find
+  a previously-issued export's S3 object key to re-mint a signed URL
+  must consult the audit log (`TenantExported` rows carry the
+  `objectKey` in `metadata`). The audit chain survives the rollback.
+- **Pending exports (status=queued/processing) lose their job
+  bookkeeping.** Any BullMQ jobs already in flight will fail to find
+  their `tenant_exports` row and error. The S3 lifecycle rule (TTL
+  ≤24h) cleans up any uploaded objects automatically.
+
+## When you would actually revert
+
+- PR 4 (tenant export endpoint + worker) is being rolled back as
+  part of a broader Wave 0.5 revert.
+- The `tenant_exports` shape turns out to be unworkable (extremely
+  unlikely — the field set is the minimal viable surface for a
+  request-completion job ledger).
+
+## Re-apply pattern
+
+Forward-only by design. Re-applying after a rollback is a clean
+additive operation; no data backfill needed.
+
+## Schema implications
+
+`schema.prisma` was updated to add the `TenantExport` model + back-
+relations on `User` and `Tenant`. A revert of THIS migration must
+also revert those edits — otherwise `prisma migrate status` will
+diff against the rolled-back DB.
+
+## Production migration timing
+
+- `CREATE TABLE` is fast; ACCESS EXCLUSIVE on the new relation only.
+- The two indexes build against zero rows at apply time (fresh
+  table), also instantaneous.
+- No trigger, function, or RLS policy changes.

--- a/apps/core-api/prisma/migrations/20260517030000_0025_tenant_export/migration.sql
+++ b/apps/core-api/prisma/migrations/20260517030000_0025_tenant_export/migration.sql
@@ -1,0 +1,66 @@
+-- Migration 0025 — Tenant data export job tracking (ADR-0020 §8).
+--
+-- ADR-0020 §8 commits to:
+--   - POST /tenants/:tenantId/export (Owner-only). The ADR § 8 text
+--     originally said GET; PR 4 changed to POST because the action
+--     mutates the ledger + emits audit on every call. The PR-4
+--     amendment to ADR §8 documents the deviation.
+--   - GET /tenants/:tenantId/exports/:jobId/download (Owner-only).
+--     Session-gated download endpoint added per security-reviewer's
+--     middlebox-prefetch finding: the completion email links here
+--     instead of the presigned S3 URL so mail-security gateways
+--     that prefetch URLs hit 401 (no session) and cache that, not
+--     the file bytes.
+--   - Async via queue; response is a job id; the actual export runs
+--     in a worker that uploads a tarball to S3, mints a presigned
+--     URL ≤24h, and emails the URL to the Owner.
+--   - Audit row stores S3 object key + recipient + TTL; NEVER the
+--     signed URL itself (which embeds credentials).
+--   - Per-tenant rate limit: 1 export / tenant / 24h, fail-closed
+--     via Redis (not DB-side).
+--
+-- This migration adds the `tenant_exports` ledger table that
+-- tracks each job's lifecycle. panorama_app has NO grants on this
+-- table — the export controller + worker route through
+-- runAsSuperAdmin (the worker crosses the tenant boundary at write
+-- time, and the controller's read uses the same path for
+-- simplicity).
+--
+-- `status` is a TEXT enum (not a Postgres ENUM type) so adding a
+-- new status in a future PR is an additive code change without a
+-- schema migration. Allowed values today:
+--   - `queued`     — controller enqueued; worker hasn't picked up
+--   - `processing` — worker took the job; serialising + uploading
+--   - `completed`  — uploaded; expiresAt + completedAt set
+--   - `failed`     — worker errored; failedReason set
+--   - `expired`    — completed but past expiresAt (set by a future
+--                    sweep that nulls objectKey + S3 lifecycle
+--                    drops the actual object)
+--
+-- Forward-only and additive. Self-host operators who never call the
+-- endpoint never write to this table.
+
+CREATE TABLE "tenant_exports" (
+    "id"                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    "tenantId"          UUID NOT NULL REFERENCES "tenants"("id") ON DELETE CASCADE,
+    "requestedByUserId" UUID REFERENCES "users"("id") ON DELETE SET NULL,
+    "status"            TEXT NOT NULL DEFAULT 'queued',
+    "objectKey"         TEXT,
+    "objectSizeBytes"   BIGINT,
+    "expiresAt"         TIMESTAMPTZ,
+    "completedAt"       TIMESTAMPTZ,
+    "failedReason"      TEXT,
+    "createdAt"         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX "tenant_exports_tenantId_createdAt_idx"
+    ON "tenant_exports"("tenantId", "createdAt" DESC);
+
+CREATE INDEX "tenant_exports_status_idx"
+    ON "tenant_exports"("status")
+    WHERE "status" IN ('queued', 'processing');
+
+COMMENT ON TABLE "tenant_exports" IS
+'ADR-0020 §8 — tenant-data export job ledger. One row per request. '
+'panorama_app has NO grants — service routes via runAsSuperAdmin. '
+'Per-tenant 1/24h rate limit lives in Redis (RateLimiter).';

--- a/apps/core-api/prisma/migrations/20260517030000_0025_tenant_export/rls.sql
+++ b/apps/core-api/prisma/migrations/20260517030000_0025_tenant_export/rls.sql
@@ -1,0 +1,11 @@
+-- Migration 0025 — no RLS surface change.
+--
+-- `tenant_exports` is intentionally NOT granted to panorama_app.
+-- All access via `prisma.runAsSuperAdmin` from the export
+-- controller + worker. Adding an RLS policy for an audience that
+-- has no underlying GRANT would be dead config.
+--
+-- Placeholder kept for grep-greppability of the per-migration RLS
+-- audit pattern.
+
+SELECT 1;

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -145,6 +145,7 @@ model Tenant {
   maintenancePhotos       MaintenancePhoto[]
   emailVerifications      EmailVerification[]
   deletionTokens          TenantDeletionToken[]
+  exports                 TenantExport[]
 
   @@map("tenants")
 }
@@ -191,8 +192,57 @@ model User {
   emailVerifications         EmailVerification[]
   tenantsAsDeletionRequester Tenant[]              @relation("TenantDeletionRequester")
   tenantDeletionTokens       TenantDeletionToken[]
+  tenantExportsRequested     TenantExport[]
 
   @@map("users")
+}
+
+/// ADR-0020 §8 — tenant-data export job ledger. One row per request
+/// from the `POST /tenants/:tenantId/export` endpoint (the
+/// session-gated `GET /tenants/:tenantId/exports/:jobId/download`
+/// minted by the PR-4 amendment is the read surface; the write
+/// surface that creates rows is POST). The worker
+/// uploads a gzipped JSON document of every tenant-scoped row to S3,
+/// mints a presigned URL ≤24h, and emails it to the requesting
+/// Owner. The audit trail (`panorama.tenant.exported`) records the
+/// object key + TTL + recipient hash but NEVER the signed URL
+/// itself (which embeds AWS credentials in query parameters).
+///
+/// `status` is a free-text enum (not a Postgres ENUM type) so a
+/// future status (`expired`, `purged`, ...) is an additive
+/// code-only change. Today's values:
+///   - `queued`     — controller enqueued; worker idle
+///   - `processing` — worker picked up; serialising + uploading
+///   - `completed`  — uploaded; objectKey + expiresAt + completedAt
+///                     populated
+///   - `failed`     — worker errored; failedReason populated
+///
+/// All access via runAsSuperAdmin — panorama_app has no GRANT.
+model TenantExport {
+  id                String    @id @default(uuid()) @db.Uuid
+  tenantId          String    @db.Uuid
+  tenant            Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  requestedByUserId String?   @db.Uuid
+  requestedBy       User?     @relation(fields: [requestedByUserId], references: [id], onDelete: SetNull)
+  status            String    @default("queued")
+  /// S3 object key (e.g. `tenants/{uuid}/exports/{job-uuid}.json.gz`).
+  /// Populated on completion. Never the signed URL.
+  objectKey         String?
+  objectSizeBytes   BigInt?
+  /// When the presigned URL embedded in the completion email
+  /// expires. Independent of the actual object's S3 lifecycle —
+  /// the object may live longer than the URL (operator can re-mint
+  /// from the objectKey + the same audit-trail attestation).
+  expiresAt         DateTime? @db.Timestamptz(6)
+  completedAt       DateTime? @db.Timestamptz(6)
+  /// Short tag from the worker error (e.g. `Error`, `TimeoutError`,
+  /// `S3UploadError`). Never the full stack trace.
+  failedReason      String?
+  createdAt         DateTime  @default(now()) @db.Timestamptz(6)
+
+  @@index([tenantId, createdAt(sort: Desc)])
+  @@index([status])
+  @@map("tenant_exports")
 }
 
 /// ADR-0020 §7 — one-time-use deletion-confirmation tokens minted by

--- a/apps/core-api/src/app.module.ts
+++ b/apps/core-api/src/app.module.ts
@@ -25,6 +25,7 @@ import { BootAuditModule } from './modules/boot-audit/boot-audit.module.js';
 import { SignupModule } from './modules/signup/signup.module.js';
 import { EmailVerificationModule } from './modules/email-verification/email-verification.module.js';
 import { TenantDeletionModule } from './modules/tenant-deletion/tenant-deletion.module.js';
+import { TenantExportModule } from './modules/tenant-export/tenant-export.module.js';
 
 /**
  * `FEATURE_SNIPEIT_COMPAT_SHIM` (ADR-0010 rollback plan) toggles
@@ -55,9 +56,15 @@ function inspectionsEnabled(): boolean {
   return raw !== 'false' && raw !== '0' && raw !== 'no';
 }
 
+// ObjectStorageModule used to live inside `conditionalInspections`
+// because inspections were the original consumer. ADR-0020 §8's
+// tenant-data-export surface (PR 4) needs the same S3 client, so the
+// module is now ALWAYS loaded — the `S3_*` env vars must be set on
+// every deployment regardless of FEATURE_INSPECTIONS. The
+// inspection-specific modules (PhotoPipeline + Inspection) remain
+// gated.
 const conditionalInspections: DynamicModule[] = inspectionsEnabled()
   ? [
-      { module: ObjectStorageModule, global: false },
       { module: PhotoPipelineModule, global: false },
       { module: InspectionModule, global: false },
     ]
@@ -145,6 +152,8 @@ const conditionalSelfServeSignup: DynamicModule[] = selfServeSignupEnabled()
     ImportModule,
     EmailVerificationModule,
     TenantDeletionModule,
+    ObjectStorageModule,
+    TenantExportModule,
     ...conditionalCompatShim,
     ...conditionalInspections,
     ...conditionalMaintenance,

--- a/apps/core-api/src/modules/audit/audit-actions.ts
+++ b/apps/core-api/src/modules/audit/audit-actions.ts
@@ -315,6 +315,53 @@ export const PanoramaAuditAction = {
    * SET NULL).
    */
   TenantDeleted: 'panorama.tenant.deleted',
+  /**
+   * Tenant-data export request enqueued (ADR-0020 §8). Per-tenant
+   * event. Emitted by the POST /tenants/:id/export endpoint inside
+   * the same tx that inserts the `tenant_exports` row. The audit
+   * row tracks request intent regardless of whether the worker
+   * later succeeds or fails — the sibling `TenantExported` /
+   * `TenantExportFailed` rows record completion outcomes.
+   *
+   * Metadata: `jobId` (the tenant_exports.id; ties to the
+   * completion row), `requestedByUserId`.
+   */
+  TenantExportRequested: 'panorama.tenant.export_requested',
+  /**
+   * Tenant-data export job completed (ADR-0020 §8). Per-tenant event.
+   * Emitted by the worker after the gzipped JSON has been uploaded
+   * to S3 and the completion email has been dispatched.
+   *
+   * Metadata: `jobId`, `objectKey` (the S3 key — operators can
+   * re-mint a signed URL from this + their own AWS credentials),
+   * `objectSizeBytes`, `signedUrlTtlSeconds` (how long the email's
+   * presigned URL stays valid), `recipientHash` (sha256 first-8
+   * chars of the recipient email). NEVER the signed URL itself —
+   * it embeds AWS credentials and persisting it is a credential
+   * leak per the §8 amendment.
+   */
+  TenantExported: 'panorama.tenant.exported',
+  /**
+   * Tenant-data export job failed (ADR-0020 §8). Per-tenant event.
+   * Emitted by the worker's catch path. The tenant_exports row's
+   * `status` flips to `'failed'` with the matching `failedReason`.
+   *
+   * Metadata: `jobId`, `errKind` (short error name, e.g. `Error`,
+   * `S3UploadError`).
+   */
+  TenantExportFailed: 'panorama.tenant.export_failed',
+  /**
+   * Completion email dispatch failed AFTER the export was
+   * successfully uploaded to S3 (ADR-0020 §8, PR 4 amendment).
+   * Per-tenant event. The job's tenant_exports row stays in
+   * `completed` status — operators can re-fetch the object via
+   * the audit row's `objectKey` and resend manually until a
+   * resend endpoint ships.
+   *
+   * Metadata: `jobId`, `errKind`, `recipientHash` (sha256 first-8
+   * chars of the recipient email).
+   */
+  TenantExportEmailDispatchFailed: 'panorama.tenant.export_email_dispatch_failed',
 } as const;
 
 export type PanoramaAuditAction =

--- a/apps/core-api/src/modules/object-storage/object-storage.keys.ts
+++ b/apps/core-api/src/modules/object-storage/object-storage.keys.ts
@@ -15,6 +15,19 @@ import { z } from 'zod';
 export const INSPECTION_PHOTO_KEY_REGEX =
   /^tenants\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/inspections\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/photos\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jpg$/;
 
+/**
+ * Tenant-data-export object-key shape (ADR-0020 §8).
+ *
+ *   ^tenants/{tenant-uuid}/exports/{job-uuid}\.json\.gz$
+ *
+ * One file per export job. Gzipped JSON instead of tar.gz because
+ * the contents are a single document (a single
+ * `{ tables: { table_name: [...] } }` object) and pulling in a tar
+ * library adds dep weight for no structural win.
+ */
+export const TENANT_EXPORT_KEY_REGEX =
+  /^tenants\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\/exports\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.json\.gz$/;
+
 const UuidSchema = z.guid();
 
 /**
@@ -42,4 +55,24 @@ export function tenantIdFromInspectionPhotoKey(key: string): string | null {
   if (!match) return null;
   // Layout: tenants/{tenantId}/...
   return key.split('/', 2)[1] ?? null;
+}
+
+/**
+ * Build the S3 key for a tenant-data-export job (ADR-0020 §8).
+ * Same UUID-validation contract as inspectionPhotoKey.
+ */
+export function tenantExportKey(tenantId: string, jobId: string): string {
+  UuidSchema.parse(tenantId);
+  UuidSchema.parse(jobId);
+  return `tenants/${tenantId}/exports/${jobId}.json.gz`;
+}
+
+/**
+ * Validate a key against the union of accepted shapes (inspection
+ * photo OR tenant export). `assertKeyForTenant` in
+ * ObjectStorageService routes through this so new key shapes are
+ * added in ONE place.
+ */
+export function validateObjectKeyShape(key: string): boolean {
+  return INSPECTION_PHOTO_KEY_REGEX.test(key) || TENANT_EXPORT_KEY_REGEX.test(key);
 }

--- a/apps/core-api/src/modules/object-storage/object-storage.service.ts
+++ b/apps/core-api/src/modules/object-storage/object-storage.service.ts
@@ -22,7 +22,7 @@ import {
   isPrivateIPv6,
   loadObjectStorageConfig,
 } from './object-storage.config.js';
-import { INSPECTION_PHOTO_KEY_REGEX } from './object-storage.keys.js';
+import { validateObjectKeyShape } from './object-storage.keys.js';
 
 /**
  * ObjectStorageService (ADR-0012 §3).
@@ -160,7 +160,7 @@ export class ObjectStorageService implements OnModuleInit {
    * $executeRawUnsafe) would fail here before S3 sees the call.
    */
   assertKeyForTenant(key: string, tenantId: string): void {
-    if (!INSPECTION_PHOTO_KEY_REGEX.test(key)) {
+    if (!validateObjectKeyShape(key)) {
       throw new Error('object_storage_key_invalid_shape');
     }
     const prefix = `tenants/${tenantId}/`;
@@ -211,7 +211,27 @@ export class ObjectStorageService implements OnModuleInit {
    */
   async getSignedUrl(
     key: string,
-    opts: { tenantId: string; expiresIn?: number; thumbnail?: boolean },
+    opts: {
+      tenantId: string;
+      expiresIn?: number;
+      thumbnail?: boolean;
+      /**
+       * Override the `Content-Type` S3 returns on GET. Defaults to
+       * `image/jpeg` (inspection photo legacy). Tenant-data export
+       * keys MUST pass `application/gzip` (security-reviewer PR 4
+       * BLOCKER 1: hardcoding JPEG meant `application/gzip` bodies
+       * were served with JPEG headers + `attachment; filename="photo.
+       * jpg"`, breaking the download UX + tripping inline malware
+       * scanners that parsed the gzip as a malformed JPEG).
+       */
+      responseContentType?: string;
+      /**
+       * Override the `Content-Disposition` S3 returns. Defaults to
+       * the photo-shaped attachment. Pass an export-specific
+       * filename for tenant-data downloads.
+       */
+      responseContentDisposition?: string;
+    },
   ): Promise<string> {
     this.assertKeyForTenant(key, opts.tenantId);
     const ttl = opts.expiresIn
@@ -222,8 +242,9 @@ export class ObjectStorageService implements OnModuleInit {
         new GetObjectCommand({
           Bucket: this.cfg.bucketPhotos,
           Key: key,
-          ResponseContentDisposition: 'attachment; filename="photo.jpg"',
-          ResponseContentType: 'image/jpeg',
+          ResponseContentDisposition:
+            opts.responseContentDisposition ?? 'attachment; filename="photo.jpg"',
+          ResponseContentType: opts.responseContentType ?? 'image/jpeg',
         }),
         { expiresIn: ttl },
       );

--- a/apps/core-api/src/modules/tenant-export/tenant-export.config.ts
+++ b/apps/core-api/src/modules/tenant-export/tenant-export.config.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * ADR-0020 §8 — tenant-data export configuration.
+ *
+ * Two TTL knobs, intentionally split (security-reviewer PR 4
+ * BLOCKER 3 — middlebox-prefetch threat):
+ *
+ *   - `windowSeconds` (default 86400 = 24h, floor 300s = 5min,
+ *     cap 86400s = 24h) — how long the JOB stays downloadable
+ *     after `completedAt`. The completion email's Panorama-link
+ *     stops resolving past this window; the tenant_exports row's
+ *     `expiresAt` records the boundary.
+ *
+ *   - `downloadUrlTtlSeconds` (constant, 60s) — the TTL on the
+ *     short-lived presigned S3 URL minted by the session-gated
+ *     `/tenants/:tenantId/exports/:jobId/download` endpoint. The
+ *     URL is only ever exposed for the 302 redirect that follows
+ *     a valid Owner session GET; it never crosses email, never
+ *     enters mail-scanner caches, and never appears in audit
+ *     metadata.
+ *
+ * `manageUrlBase` is the Panorama public URL prefix (defaults to
+ * `APP_BASE_URL`) — the email body links to
+ * `${manageUrlBase}/tenants/:tenantId/exports/:jobId/download`,
+ * which 302s through the session check. Mail-scanners that
+ * prefetch the URL hit 401 (no session) and cache that, not the
+ * file.
+ *
+ * `failureLatencyFloorMs` mirrors `SIGNUP_FAILURE_LATENCY_FLOOR_MS`.
+ */
+export interface TenantExportConfig {
+  windowSeconds: number;
+  /** Constant: 60s. Short-lived S3 URL for the 302 redirect only. */
+  downloadUrlTtlSeconds: number;
+  manageUrlBase: string;
+  failureLatencyFloorMs: number;
+}
+
+const WINDOW_FLOOR = 5 * 60;
+const WINDOW_CEILING = 24 * 60 * 60;
+const DOWNLOAD_URL_TTL_SECONDS = 60;
+
+@Injectable()
+export class TenantExportConfigService {
+  readonly config: TenantExportConfig;
+
+  constructor() {
+    const ttlRaw = process.env['TENANT_EXPORT_WINDOW_SECONDS'];
+    const windowSeconds = ttlRaw ? Number(ttlRaw) : WINDOW_CEILING;
+    if (
+      !Number.isInteger(windowSeconds) ||
+      windowSeconds < WINDOW_FLOOR ||
+      windowSeconds > WINDOW_CEILING
+    ) {
+      throw new Error(
+        `TENANT_EXPORT_WINDOW_SECONDS must be an integer in [${WINDOW_FLOOR}, ${WINDOW_CEILING}]; got ${JSON.stringify(ttlRaw)}`,
+      );
+    }
+    const floorRaw = process.env['SIGNUP_FAILURE_LATENCY_FLOOR_MS'];
+    const failureLatencyFloorMs = floorRaw ? Number(floorRaw) : 600;
+    if (!Number.isFinite(failureLatencyFloorMs) || failureLatencyFloorMs < 0) {
+      throw new Error(
+        `SIGNUP_FAILURE_LATENCY_FLOOR_MS must be a non-negative number; got ${JSON.stringify(floorRaw)}`,
+      );
+    }
+    const baseUrl = (process.env['APP_BASE_URL'] ?? 'http://localhost:4000')
+      .replace(/\/+$/, '')
+      .toLowerCase();
+    this.config = {
+      windowSeconds,
+      downloadUrlTtlSeconds: DOWNLOAD_URL_TTL_SECONDS,
+      manageUrlBase: baseUrl,
+      failureLatencyFloorMs,
+    };
+  }
+}

--- a/apps/core-api/src/modules/tenant-export/tenant-export.controller.ts
+++ b/apps/core-api/src/modules/tenant-export/tenant-export.controller.ts
@@ -1,0 +1,144 @@
+import {
+  Controller,
+  ForbiddenException,
+  Get,
+  HttpCode,
+  HttpException,
+  HttpStatus,
+  Logger,
+  NotFoundException,
+  Param,
+  Post,
+  Req,
+  Res,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { Request, Response } from 'express';
+import { getRequestSession } from '../auth/session.middleware.js';
+import type { PanoramaSession } from '../auth/session.types.js';
+import { TenantExportService } from './tenant-export.service.js';
+import { TenantExportQueue } from './tenant-export.queue.js';
+
+/**
+ * ADR-0020 §8 — POST /tenants/:tenantId/export.
+ *
+ * Owner-only. Per-tenant rate-limit 1/24h via
+ * `TenantExportService.checkRateLimit`. Trip returns 429 — the
+ * caller is an authenticated Owner, so leaking rate-limit existence
+ * via a 429 has operational value (vs the anonymous attacker
+ * surface on /auth/signup where 429 leaks reconnaissance).
+ *
+ * Method is POST (not GET as ADR §8 says) because the action is
+ * state-changing: every request enqueues a job, persists a
+ * `tenant_exports` row, and emits an audit event. The ADR's
+ * `GET` wording dates from an early sketch where the export was
+ * synchronous; the async-via-queue amendment turned it into a
+ * write. (Matches PR-3 deletion endpoints all using POST for the
+ * same reason.)
+ */
+
+@Controller('tenants/:tenantId')
+export class TenantExportController {
+  private readonly log = new Logger('TenantExportController');
+
+  constructor(
+    private readonly exports: TenantExportService,
+    private readonly queue: TenantExportQueue,
+  ) {}
+
+  @Post('export')
+  @HttpCode(202)
+  async export(
+    @Param('tenantId') tenantId: string,
+    @Req() req: Request,
+  ): Promise<unknown> {
+    const session = this.requireOwner(req, tenantId);
+
+    const rate = await this.exports.checkRateLimit(tenantId);
+    if (!rate.allowed) {
+      throw new HttpException(
+        { error: 'rate_limited', retryAfterSeconds: rate.retryAfterSeconds },
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    const enqueue = await this.exports.enqueue({
+      tenantId,
+      requestedByUserId: session.userId,
+    });
+    if (enqueue.kind !== 'ok') {
+      // The rate-limit branch is the only refusal path today.
+      // Reserved for future shapes (e.g. tenant locked).
+      this.log.warn({ tenantId, kind: enqueue.kind }, 'tenant_export_enqueue_unexpected');
+      throw new HttpException(
+        { error: 'enqueue_failed' },
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+    }
+
+    // BullMQ enqueue is best-effort — if the queue isn't running
+    // (e.g. test mode), the job stays in `queued` status and the
+    // caller's e2e test invokes `runJob` directly. Production
+    // failure surfaces as a logged warning + the job staying
+    // queued; the next worker restart picks it up.
+    try {
+      await this.queue.enqueue({ jobId: enqueue.jobId });
+    } catch (err) {
+      this.log.warn(
+        { jobId: enqueue.jobId, err: String(err) },
+        'tenant_export_queue_enqueue_skipped',
+      );
+    }
+
+    return {
+      ok: true,
+      jobId: enqueue.jobId,
+      status: 'queued',
+    };
+  }
+
+  /**
+   * §8 PR-4 amendment — session-gated download. The completion
+   * email links HERE (not directly to the S3 URL); this endpoint
+   * verifies the Owner session, mints a short-lived (60s) presigned
+   * URL, and 302-redirects. Middlebox-class adversaries (Mimecast,
+   * link-preview bots) that GET the link unauthenticated hit 401
+   * and cache that, never the file. The Owner's browser carries the
+   * session cookie and follows the redirect transparently.
+   */
+  @Get('exports/:jobId/download')
+  async download(
+    @Param('tenantId') tenantId: string,
+    @Param('jobId') jobId: string,
+    @Req() req: Request,
+    @Res({ passthrough: false }) res: Response,
+  ): Promise<void> {
+    this.requireOwner(req, tenantId);
+    const row = await this.exports.getDownloadable(tenantId, jobId);
+    if (!row) {
+      throw new NotFoundException('export_not_found_or_expired');
+    }
+    const filename = `panorama-export-${jobId}.json.gz`;
+    const signedUrl = await this.exports.mintDownloadUrl({
+      tenantId,
+      objectKey: row.objectKey,
+      filename,
+    });
+    // 302 to the freshly-minted presigned URL — TTL 60s, enough for
+    // the browser to follow the redirect once. The URL never enters
+    // any persistence path.
+    res.redirect(302, signedUrl);
+  }
+
+  private requireOwner(req: Request, tenantId: string): PanoramaSession {
+    const session = getRequestSession(req);
+    if (!session) throw new UnauthorizedException('authentication_required');
+    if (session.currentTenantId !== tenantId) {
+      throw new UnauthorizedException('tenant_mismatch');
+    }
+    if (session.currentRole !== 'owner') {
+      throw new ForbiddenException('owner_role_required');
+    }
+    return session;
+  }
+}

--- a/apps/core-api/src/modules/tenant-export/tenant-export.module.ts
+++ b/apps/core-api/src/modules/tenant-export/tenant-export.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+import { EmailModule } from '../email/email.module.js';
+import { ObjectStorageModule } from '../object-storage/object-storage.module.js';
+import { TenantExportConfigService } from './tenant-export.config.js';
+import { TenantExportController } from './tenant-export.controller.js';
+import { TenantExportService } from './tenant-export.service.js';
+import { TenantExportQueue } from './tenant-export.queue.js';
+
+/**
+ * ADR-0020 §8 — tenant-data export surface (PR 4).
+ *
+ * Loaded UNCONDITIONALLY. The endpoint is Owner-only + per-tenant
+ * rate-limited; tenants that never request an export pay zero cost.
+ * ObjectStorageModule moved out of the inspections conditional in
+ * the same PR (it's a generic S3 wrapper now used by both inspection
+ * photos and tenant exports).
+ *
+ * The BullMQ queue idle-in-tests so e2e tests drive `runJob`
+ * directly. Production deployments run the worker continuously.
+ */
+@Module({
+  imports: [EmailModule, ObjectStorageModule],
+  controllers: [TenantExportController],
+  providers: [TenantExportConfigService, TenantExportService, TenantExportQueue],
+  exports: [TenantExportService],
+})
+export class TenantExportModule {}

--- a/apps/core-api/src/modules/tenant-export/tenant-export.queue.ts
+++ b/apps/core-api/src/modules/tenant-export/tenant-export.queue.ts
@@ -1,0 +1,101 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { Queue, Worker } from 'bullmq';
+import { Redis } from 'ioredis';
+import { TenantExportService } from './tenant-export.service.js';
+
+/**
+ * ADR-0020 §8 — BullMQ queue + worker for tenant data export.
+ *
+ * Mirrors `MaintenanceSweepService` + `TenantDeletionSweepService`
+ * shape:
+ *   - one Queue + one Worker on the same process,
+ *   - idle-in-tests (`NODE_ENV=test` short-circuit) so the test
+ *     suite can drive `TenantExportService.runJob` directly,
+ *   - single job per request (not a repeatable).
+ *
+ * Job payload: `{ jobId: string }` — the controller enqueues a
+ * row in `tenant_exports` and the worker pulls the rest of the
+ * state from there. Keeps the BullMQ payload tiny + replayable.
+ */
+
+export const TENANT_EXPORT_QUEUE = 'tenant-export';
+const TENANT_EXPORT_JOB_NAME = 'run';
+
+export interface TenantExportJobPayload {
+  jobId: string;
+}
+
+@Injectable()
+export class TenantExportQueue implements OnModuleInit, OnModuleDestroy {
+  private readonly log = new Logger('TenantExportQueue');
+  private queue: Queue<TenantExportJobPayload> | null = null;
+  private worker: Worker<TenantExportJobPayload> | null = null;
+  private redisConnections: Redis[] = [];
+
+  constructor(private readonly exports: TenantExportService) {}
+
+  async onModuleInit(): Promise<void> {
+    if (process.env['NODE_ENV'] === 'test') {
+      this.log.log('tenant_export_queue_idle_in_tests');
+      return;
+    }
+    await this.start();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.stop();
+  }
+
+  async enqueue(payload: TenantExportJobPayload): Promise<void> {
+    if (!this.queue) {
+      // In tests we drive `runJob` directly; this branch is for
+      // production / dev where the queue is up.
+      throw new Error('tenant_export_queue_not_started');
+    }
+    await this.queue.add(TENANT_EXPORT_JOB_NAME, payload, {
+      removeOnComplete: 50,
+      removeOnFail: 50,
+    });
+  }
+
+  private async start(): Promise<void> {
+    if (this.queue) return;
+    const redisUrl = process.env['REDIS_URL'] ?? 'redis://localhost:6379/0';
+
+    const queueConn = new Redis(redisUrl, { maxRetriesPerRequest: null });
+    const workerConn = new Redis(redisUrl, { maxRetriesPerRequest: null });
+    this.redisConnections = [queueConn, workerConn];
+
+    this.queue = new Queue<TenantExportJobPayload>(TENANT_EXPORT_QUEUE, {
+      connection: queueConn,
+    });
+    this.worker = new Worker<TenantExportJobPayload>(
+      TENANT_EXPORT_QUEUE,
+      async (job) => {
+        await this.exports.runJob(job.data.jobId);
+      },
+      { connection: workerConn, concurrency: 1 },
+    );
+    this.log.log('tenant_export_queue_started');
+  }
+
+  private async stop(): Promise<void> {
+    if (this.worker) {
+      await this.worker.close();
+      this.worker = null;
+    }
+    if (this.queue) {
+      await this.queue.close();
+      this.queue = null;
+    }
+    for (const conn of this.redisConnections) {
+      await conn.quit().catch(() => {});
+    }
+    this.redisConnections = [];
+  }
+}

--- a/apps/core-api/src/modules/tenant-export/tenant-export.serializer.ts
+++ b/apps/core-api/src/modules/tenant-export/tenant-export.serializer.ts
@@ -1,0 +1,182 @@
+import { Logger } from '@nestjs/common';
+import type { Prisma } from '@prisma/client';
+
+/**
+ * ADR-0020 §8 — collect every tenant-scoped row into a single
+ * exportable JSON document.
+ *
+ * Shape:
+ *   {
+ *     "panoramaExport": { "version": 1, "tenantId": "<uuid>", "generatedAt": "<iso>" },
+ *     "tables": {
+ *       "tenants":           [...],
+ *       "tenant_memberships":[...],
+ *       "users":             [...],   // only Users with membership in this tenant
+ *       ...
+ *     }
+ *   }
+ *
+ * Tables omitted from PR 4 (follow-up):
+ *   - inspection_photos / maintenance_photos — the binary lives in
+ *     S3; including the binary blob in the JSON document would
+ *     bloat the export for tenants with many photos. A future PR
+ *     adds a side-car manifest with presigned download URLs per
+ *     photo.
+ *   - personal_access_tokens — secret material; ADR-0020 §8 doesn't
+ *     mandate including, and exporting the hashes provides no
+ *     operator value.
+ *   - audit_events — large + already accessible by tenant admins
+ *     via existing surfaces. Inclusion deferred to a follow-up that
+ *     decides on chain-strand windowing.
+ *
+ * The list is intentionally lower-bound MVP — operators can extend
+ * the serializer as LGPD / audit demand evolves. New tenant-scoped
+ * tables MUST add a query here (the test asserts presence of the
+ * core set).
+ */
+
+export interface SerializedExport {
+  panoramaExport: {
+    version: number;
+    tenantId: string;
+    generatedAt: string;
+  };
+  tables: Record<string, unknown[]>;
+}
+
+const SCHEMA_VERSION = 1;
+
+/**
+ * Build the in-memory export document. Uses a transaction client
+ * so all queries observe a consistent snapshot of the tenant's data.
+ */
+export async function serializeTenantExport(
+  tx: Prisma.TransactionClient,
+  tenantId: string,
+  log?: Logger,
+): Promise<SerializedExport> {
+  const tenant = await tx.tenant.findUnique({ where: { id: tenantId } });
+  if (!tenant) {
+    throw new Error(`tenant_not_found_for_export:${tenantId}`);
+  }
+
+  const memberships = await tx.tenantMembership.findMany({
+    where: { tenantId },
+  });
+  const userIds = Array.from(new Set(memberships.map((m) => m.userId)));
+  // Resolve User rows belonging to this tenant's memberships. Other
+  // multi-tenant users are NOT included — they're not "the tenant's
+  // data" in any LGPD-meaningful sense.
+  const users = await tx.user.findMany({
+    where: { id: { in: userIds } },
+    select: {
+      id: true,
+      email: true,
+      displayName: true,
+      firstName: true,
+      lastName: true,
+      status: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  const categories = await tx.category.findMany({ where: { tenantId } });
+  const manufacturers = await tx.manufacturer.findMany({ where: { tenantId } });
+  const assetModels = await tx.assetModel.findMany({ where: { tenantId } });
+  const assets = await tx.asset.findMany({ where: { tenantId } });
+  const reservations = await tx.reservation.findMany({ where: { tenantId } });
+  const blackoutSlots = await tx.blackoutSlot.findMany({ where: { tenantId } });
+  // Explicit select-list EXCLUDES `tokenHash` — sha256 of a still-
+  // redeemable invitation token is credential-shaped material that
+  // must never ride into a user-downloadable artefact (security-
+  // reviewer PR 4 BLOCKER 2). Same discipline applies to any future
+  // hash/secret column added under a tenant.
+  const invitations = await tx.invitation.findMany({
+    where: { tenantId },
+    select: {
+      id: true,
+      tenantId: true,
+      email: true,
+      role: true,
+      targetUserId: true,
+      invitedByUserId: true,
+      expiresAt: true,
+      acceptedAt: true,
+      acceptedByUserId: true,
+      revokedAt: true,
+      revokedByUserId: true,
+      emailQueuedAt: true,
+      emailSentAt: true,
+      emailBouncedAt: true,
+      emailAttempts: true,
+      emailLastError: true,
+      createdAt: true,
+    },
+  });
+  const inspectionTemplates = await tx.inspectionTemplate.findMany({
+    where: { tenantId },
+  });
+  const inspectionTemplateItems = await tx.inspectionTemplateItem.findMany({
+    where: { tenantId },
+  });
+  const inspections = await tx.inspection.findMany({ where: { tenantId } });
+  const inspectionResponses = await tx.inspectionResponse.findMany({
+    where: { tenantId },
+  });
+  const assetMaintenances = await tx.assetMaintenance.findMany({
+    where: { tenantId },
+  });
+
+  log?.debug?.(
+    {
+      tenantId,
+      counts: {
+        memberships: memberships.length,
+        users: users.length,
+        assets: assets.length,
+        reservations: reservations.length,
+        inspections: inspections.length,
+        assetMaintenances: assetMaintenances.length,
+      },
+    },
+    'tenant_export_serialized',
+  );
+
+  return {
+    panoramaExport: {
+      version: SCHEMA_VERSION,
+      tenantId,
+      generatedAt: new Date().toISOString(),
+    },
+    tables: {
+      tenants: [tenant],
+      tenant_memberships: memberships,
+      users,
+      categories,
+      manufacturers,
+      asset_models: assetModels,
+      assets,
+      reservations,
+      blackout_slots: blackoutSlots,
+      invitations,
+      inspection_templates: inspectionTemplates,
+      inspection_template_items: inspectionTemplateItems,
+      inspections,
+      inspection_responses: inspectionResponses,
+      asset_maintenances: assetMaintenances,
+    },
+  };
+}
+
+/**
+ * BigInt safe JSON serialization — Prisma returns some columns as
+ * JS BigInt (e.g. `objectSizeBytes`), and `JSON.stringify` throws on
+ * BigInt by default. We coerce them to strings (lossless for
+ * 2^53+ values) using a replacer.
+ */
+export function exportToJsonString(doc: SerializedExport): string {
+  return JSON.stringify(doc, (_, value: unknown) =>
+    typeof value === 'bigint' ? value.toString() : value,
+  );
+}

--- a/apps/core-api/src/modules/tenant-export/tenant-export.service.ts
+++ b/apps/core-api/src/modules/tenant-export/tenant-export.service.ts
@@ -1,0 +1,433 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { createHash } from 'node:crypto';
+import { gzipSync } from 'node:zlib';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { AuditService } from '../audit/audit.service.js';
+import { PanoramaAuditAction } from '../audit/audit-actions.js';
+import { EmailService } from '../email/email.service.js';
+import { RateLimiter, type RateLimitDecision } from '../redis/rate-limiter.js';
+import { ObjectStorageService } from '../object-storage/object-storage.service.js';
+import { tenantExportKey } from '../object-storage/object-storage.keys.js';
+import { TenantExportConfigService } from './tenant-export.config.js';
+import {
+  exportToJsonString,
+  serializeTenantExport,
+} from './tenant-export.serializer.js';
+import { renderExportReadyEmail } from './tenant-export.templates.js';
+
+/**
+ * Tenant-data export service (ADR-0020 §8).
+ *
+ *   - `checkRateLimit` — 1 export per tenant per 24h, fail-closed.
+ *   - `enqueue` — atomic write: insert `tenant_exports` row (status
+ *     queued) + emit `TenantExportRequested` audit. Returns the
+ *     jobId; the BullMQ worker picks up from there.
+ *   - `runJob` — worker entrypoint: serialize → gzip → upload → mint
+ *     signed URL → send email → flip status + emit
+ *     `TenantExported`. SMTP failure is logged but does NOT
+ *     rollback the row (the audit row preserves the objectKey so
+ *     operators can re-mint the signed URL).
+ *
+ * The §8 contract on the audit-row content is non-negotiable: the
+ * row records `objectKey` + recipient hash + TTL, NEVER the signed
+ * URL itself (which embeds AWS credentials in query params).
+ */
+
+const RATE_LIMIT_LIMIT = 1;
+const RATE_LIMIT_WINDOW_MS = 24 * 60 * 60 * 1000;
+const RATE_LIMIT_KEY_PREFIX = 'panorama:export:tenant:';
+
+export type EnqueueResult =
+  | { kind: 'ok'; jobId: string }
+  | { kind: 'rate_limited' };
+
+@Injectable()
+export class TenantExportService {
+  private readonly log = new Logger('TenantExportService');
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+    private readonly mail: EmailService,
+    private readonly storage: ObjectStorageService,
+    private readonly limiter: RateLimiter,
+    private readonly cfg: TenantExportConfigService,
+  ) {}
+
+  /**
+   * Per-tenant 1/24h budget. Fail-closed.
+   */
+  async checkRateLimit(tenantId: string): Promise<RateLimitDecision> {
+    return this.limiter.consume(
+      RATE_LIMIT_KEY_PREFIX + tenantId,
+      RATE_LIMIT_LIMIT,
+      RATE_LIMIT_WINDOW_MS,
+    );
+  }
+
+  /**
+   * Enqueue an export job. The caller is responsible for the rate-
+   * limit check via `checkRateLimit` first (so a refused request
+   * emits its own `rate_limit_tripped`-style audit if that becomes
+   * a future requirement; today we just refuse with 429 from the
+   * controller).
+   */
+  async enqueue(input: {
+    tenantId: string;
+    requestedByUserId: string;
+  }): Promise<EnqueueResult> {
+    const jobId = await this.prisma.runAsSuperAdmin(
+      async (tx) => {
+        const row = await tx.tenantExport.create({
+          data: {
+            tenantId: input.tenantId,
+            requestedByUserId: input.requestedByUserId,
+            status: 'queued',
+          },
+        });
+        await this.audit.recordWithin(tx, {
+          action: PanoramaAuditAction.TenantExportRequested,
+          resourceType: 'tenant',
+          resourceId: input.tenantId,
+          tenantId: input.tenantId,
+          actorUserId: input.requestedByUserId,
+          metadata: {
+            jobId: row.id,
+            requestedByUserId: input.requestedByUserId,
+          },
+        });
+        return row.id;
+      },
+      { reason: `tenant-export:enqueue:${input.tenantId}` },
+    );
+    return { kind: 'ok', jobId };
+  }
+
+  /**
+   * Worker entrypoint — runs the actual export. Splits into
+   * smaller helpers for testability without exposing the BullMQ
+   * dependency.
+   */
+  async runJob(jobId: string): Promise<void> {
+    let job = await this.prisma.runAsSuperAdmin(
+      (tx) => tx.tenantExport.findUnique({ where: { id: jobId } }),
+      { reason: `tenant-export:run:${jobId}:fetch` },
+    );
+    if (!job) {
+      this.log.warn({ jobId }, 'tenant_export_job_missing');
+      return;
+    }
+    if (job.status !== 'queued') {
+      // Re-runs (cron retry / BullMQ replay) hit this branch — the
+      // first attempt already advanced past `queued`. Idempotent
+      // no-op.
+      this.log.log({ jobId, status: job.status }, 'tenant_export_job_not_queued');
+      return;
+    }
+
+    // Mark processing in a separate tx so concurrent workers can
+    // see the transition and back off. We could use a row-level
+    // lock instead but BullMQ already serialises by job id; this
+    // is belt-and-suspenders.
+    await this.prisma.runAsSuperAdmin(
+      (tx) =>
+        tx.tenantExport.update({
+          where: { id: jobId },
+          data: { status: 'processing' },
+        }),
+      { reason: `tenant-export:run:${jobId}:processing` },
+    );
+
+    try {
+      const result = await this.executeExport(job.tenantId, jobId);
+      await this.markCompleted(jobId, result);
+      job = await this.prisma.runAsSuperAdmin(
+        (tx) => tx.tenantExport.findUnique({ where: { id: jobId } }),
+        { reason: `tenant-export:run:${jobId}:refetch` },
+      );
+      if (job) {
+        await this.dispatchEmail(job, result);
+      }
+    } catch (err) {
+      const errKind = err instanceof Error ? err.name : 'Unknown';
+      this.log.error({ err: String(err), jobId }, 'tenant_export_run_failed');
+      await this.markFailed(jobId, errKind);
+    }
+  }
+
+  private async executeExport(
+    tenantId: string,
+    jobId: string,
+  ): Promise<{
+    objectKey: string;
+    objectSizeBytes: number;
+    expiresAt: Date;
+    recipientEmail: string;
+    recipientDisplayName: string;
+    tenantDisplayName: string;
+  }> {
+    // Snapshot-consistent read of every tenant-scoped table.
+    const doc = await this.prisma.runAsSuperAdmin(
+      (tx) => serializeTenantExport(tx, tenantId, this.log),
+      { reason: `tenant-export:serialize:${tenantId}` },
+    );
+    const json = exportToJsonString(doc);
+    const gzipped = gzipSync(Buffer.from(json, 'utf8'));
+    const sha256 = createHash('sha256').update(gzipped).digest('base64');
+    const objectKey = tenantExportKey(tenantId, jobId);
+
+    await this.storage.put(objectKey, gzipped, {
+      contentType: 'application/gzip',
+      sha256,
+      tenantId,
+    });
+
+    const expiresAt = new Date(
+      Date.now() + this.cfg.config.windowSeconds * 1000,
+    );
+
+    // Resolve the recipient — the requestedBy user OR a fallback if
+    // the row's user was deleted between request and run. The
+    // tenant's display name comes from the snapshot the serializer
+    // already loaded.
+    const recipient = await this.prisma.runAsSuperAdmin(
+      async (tx) => {
+        const row = await tx.tenantExport.findUnique({
+          where: { id: jobId },
+          select: {
+            requestedBy: { select: { email: true, displayName: true } },
+            tenant: { select: { displayName: true } },
+          },
+        });
+        return {
+          email: row?.requestedBy?.email ?? '',
+          displayName: row?.requestedBy?.displayName ?? 'Owner',
+          tenantDisplayName: row?.tenant?.displayName ?? 'your tenant',
+        };
+      },
+      { reason: `tenant-export:recipient:${jobId}` },
+    );
+
+    return {
+      objectKey,
+      objectSizeBytes: gzipped.byteLength,
+      expiresAt,
+      recipientEmail: recipient.email,
+      recipientDisplayName: recipient.displayName,
+      tenantDisplayName: recipient.tenantDisplayName,
+    };
+  }
+
+  private async markCompleted(
+    jobId: string,
+    result: {
+      objectKey: string;
+      objectSizeBytes: number;
+      expiresAt: Date;
+      recipientEmail: string;
+    },
+  ): Promise<void> {
+    await this.prisma.runAsSuperAdmin(
+      async (tx) => {
+        const row = await tx.tenantExport.update({
+          where: { id: jobId },
+          data: {
+            status: 'completed',
+            objectKey: result.objectKey,
+            objectSizeBytes: BigInt(result.objectSizeBytes),
+            expiresAt: result.expiresAt,
+            completedAt: new Date(),
+          },
+        });
+        await this.audit.recordWithin(tx, {
+          action: PanoramaAuditAction.TenantExported,
+          resourceType: 'tenant',
+          resourceId: row.tenantId,
+          tenantId: row.tenantId,
+          actorUserId: row.requestedByUserId,
+          // §8 contract: objectKey + TTL + recipient hash; NEVER the
+          // signed URL (which embeds AWS credentials).
+          metadata: {
+            jobId,
+            objectKey: result.objectKey,
+            objectSizeBytes: result.objectSizeBytes,
+            windowSeconds: this.cfg.config.windowSeconds,
+            recipientHash: result.recipientEmail
+              ? createHash('sha256').update(result.recipientEmail).digest('hex').slice(0, 8)
+              : 'no-recipient',
+          },
+        });
+      },
+      { reason: `tenant-export:complete:${jobId}` },
+    );
+  }
+
+  private async markFailed(jobId: string, errKind: string): Promise<void> {
+    await this.prisma.runAsSuperAdmin(
+      async (tx) => {
+        const row = await tx.tenantExport.update({
+          where: { id: jobId },
+          data: { status: 'failed', failedReason: errKind },
+        });
+        await this.audit.recordWithin(tx, {
+          action: PanoramaAuditAction.TenantExportFailed,
+          resourceType: 'tenant',
+          resourceId: row.tenantId,
+          tenantId: row.tenantId,
+          actorUserId: row.requestedByUserId,
+          metadata: { jobId, errKind },
+        });
+      },
+      { reason: `tenant-export:fail:${jobId}` },
+    );
+  }
+
+  private async dispatchEmail(
+    job: {
+      tenantId: string;
+      requestedByUserId: string | null;
+      objectKey: string | null;
+      expiresAt: Date | null;
+      objectSizeBytes: bigint | null;
+    },
+    result: {
+      objectKey: string;
+      objectSizeBytes: number;
+      expiresAt: Date;
+      recipientEmail: string;
+      recipientDisplayName: string;
+      tenantDisplayName: string;
+    },
+  ): Promise<void> {
+    if (!result.recipientEmail) {
+      this.log.warn(
+        { tenantId: job.tenantId },
+        'tenant_export_email_skipped_no_recipient',
+      );
+      return;
+    }
+    // §8 PR 4 amendment — email links to the Panorama download
+    // endpoint, NOT a presigned S3 URL. Middlebox prefetch will hit
+    // 401 (no session) and cache that, not the file bytes.
+    const jobIdForUrl = await this.lookupJobIdByObjectKey(result.objectKey);
+    if (!jobIdForUrl) {
+      // Defensive — the row must exist by this point. Log + skip
+      // rather than throw, so the caller's tx-completion state
+      // doesn't get unwound.
+      this.log.error(
+        { tenantId: job.tenantId, objectKey: result.objectKey },
+        'tenant_export_email_skipped_no_job_id',
+      );
+      return;
+    }
+    const downloadUrl =
+      `${this.cfg.config.manageUrlBase}/tenants/${job.tenantId}` +
+      `/exports/${jobIdForUrl}/download`;
+    const rendered = renderExportReadyEmail({
+      recipientEmail: result.recipientEmail,
+      recipientDisplayName: result.recipientDisplayName,
+      tenantDisplayName: result.tenantDisplayName,
+      downloadUrl,
+      expiresAt: result.expiresAt,
+      objectSizeBytes: result.objectSizeBytes,
+    });
+    try {
+      await this.mail.send({
+        to: result.recipientEmail,
+        subject: rendered.subject,
+        text: rendered.text,
+        html: rendered.html,
+      });
+    } catch (err) {
+      // Audit the dispatch failure so SIEM + tenant admins can spot
+      // the "uploaded but never delivered" state without grepping
+      // logs. The recipient is HASHED in both the audit row and
+      // the log line (PRs 2 + 3 pattern).
+      const errKind = err instanceof Error ? err.name : 'Unknown';
+      const recipientHash = createHash('sha256')
+        .update(result.recipientEmail)
+        .digest('hex')
+        .slice(0, 8);
+      this.log.error(
+        { err: String(err), recipientHash },
+        'tenant_export_email_dispatch_failed',
+      );
+      try {
+        await this.audit.record({
+          action: PanoramaAuditAction.TenantExportEmailDispatchFailed,
+          resourceType: 'tenant',
+          resourceId: job.tenantId,
+          tenantId: job.tenantId,
+          actorUserId: job.requestedByUserId,
+          metadata: { jobId: jobIdForUrl, errKind, recipientHash },
+        });
+      } catch (auditErr) {
+        this.log.error(
+          { err: String(auditErr) },
+          'tenant_export_email_dispatch_failed_audit_write_failed',
+        );
+      }
+    }
+  }
+
+  private async lookupJobIdByObjectKey(objectKey: string): Promise<string | null> {
+    const row = await this.prisma.runAsSuperAdmin(
+      (tx) =>
+        tx.tenantExport.findFirst({
+          where: { objectKey },
+          select: { id: true },
+        }),
+      { reason: `tenant-export:lookup-job-id` },
+    );
+    return row?.id ?? null;
+  }
+
+  /**
+   * Internal helper used by the download endpoint: mint a short-
+   * lived presigned URL (60s) for the actual S3 GET. Called only
+   * AFTER the controller has verified the Owner session, the job
+   * is `completed`, and `expiresAt > now()`. The 60s TTL is just
+   * long enough for the browser to follow the 302; never enters
+   * email, audit, or log.
+   */
+  async mintDownloadUrl(input: {
+    tenantId: string;
+    objectKey: string;
+    filename: string;
+  }): Promise<string> {
+    return this.storage.getSignedUrl(input.objectKey, {
+      tenantId: input.tenantId,
+      expiresIn: this.cfg.config.downloadUrlTtlSeconds,
+      responseContentType: 'application/gzip',
+      responseContentDisposition: `attachment; filename="${input.filename}"`,
+    });
+  }
+
+  /**
+   * Look up a completed export for the session-gated download
+   * endpoint. Returns the row only when it is still within the
+   * `windowSeconds` budget — past `expiresAt`, the email's link
+   * stops resolving and operators must re-request.
+   */
+  async getDownloadable(
+    tenantId: string,
+    jobId: string,
+  ): Promise<{ objectKey: string; objectSizeBytes: number | null } | null> {
+    return this.prisma.runAsSuperAdmin(
+      async (tx) => {
+        const row = await tx.tenantExport.findUnique({ where: { id: jobId } });
+        if (!row) return null;
+        if (row.tenantId !== tenantId) return null;
+        if (row.status !== 'completed') return null;
+        if (row.objectKey === null) return null;
+        if (row.expiresAt && row.expiresAt.getTime() <= Date.now()) return null;
+        return {
+          objectKey: row.objectKey,
+          objectSizeBytes:
+            row.objectSizeBytes !== null ? Number(row.objectSizeBytes) : null,
+        };
+      },
+      { reason: `tenant-export:get-downloadable:${jobId}` },
+    );
+  }
+}

--- a/apps/core-api/src/modules/tenant-export/tenant-export.templates.ts
+++ b/apps/core-api/src/modules/tenant-export/tenant-export.templates.ts
@@ -1,0 +1,95 @@
+/**
+ * ADR-0020 §8 — tenant-data export ready email (amended PR 4).
+ *
+ * Body links to the PANORAMA download endpoint
+ * `${manageUrlBase}/tenants/:tenantId/exports/:jobId/download`,
+ * NOT directly to a presigned S3 URL. Rationale (security-reviewer
+ * PR 4 BLOCKER 3): corporate mail-security gateways (Mimecast,
+ * Microsoft ATP Safe Links, Proofpoint), link-preview bots
+ * (Slack unfurl, Discord, iMessage), and inline TLS-inspecting
+ * middleboxes will GET every URL in an inbound email AS SOON AS
+ * IT ARRIVES. If the link is a presigned S3 URL, the scanner
+ * downloads the export bytes into its scan log + cache before the
+ * user ever clicks. TTL ≤24h does not mitigate this — the
+ * download happens at delivery time.
+ *
+ * Routing through Panorama defangs the prefetch: an unauthenticated
+ * GET against the download endpoint returns 401 (no session); the
+ * scanner caches the 401, not the file. When the genuine Owner
+ * clicks the link in their browser, the existing session cookie
+ * lets the endpoint mint a 60-second presigned URL and 302 to S3.
+ */
+
+export interface ExportReadyEmailContext {
+  recipientEmail: string;
+  recipientDisplayName: string;
+  tenantDisplayName: string;
+  /** Panorama download URL (NOT a presigned S3 URL). 302s on click. */
+  downloadUrl: string;
+  expiresAt: Date;
+  objectSizeBytes: number;
+}
+
+export interface RenderedEmail {
+  subject: string;
+  text: string;
+  html: string;
+}
+
+export function renderExportReadyEmail(ctx: ExportReadyEmailContext): RenderedEmail {
+  const subject = `Your Panorama data export for "${ctx.tenantDisplayName}" is ready`;
+  const expiresIso = ctx.expiresAt.toISOString();
+  const sizeKb = Math.max(1, Math.round(ctx.objectSizeBytes / 1024));
+
+  const text = [
+    `Hello ${ctx.recipientDisplayName},`,
+    '',
+    `Your tenant-data export for "${ctx.tenantDisplayName}" is ready.`,
+    `Approximate size: ${sizeKb} KB.`,
+    '',
+    `Download (link expires at ${expiresIso}):`,
+    ctx.downloadUrl,
+    '',
+    `Once the link expires, contact the Panorama maintainer with this email's date to re-mint a fresh URL from the same archive.`,
+    '',
+    `— Panorama`,
+  ].join('\n');
+
+  const html = /* html */ `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>${escapeHtml(subject)}</title></head>
+<body style="font-family:-apple-system,Segoe UI,Roboto,sans-serif;background:#0f172a;color:#e2e8f0;padding:32px 0;margin:0;">
+<table role="presentation" align="center" width="540" cellpadding="0" cellspacing="0"
+       style="background:#1e293b;border-radius:12px;overflow:hidden;">
+<tr><td style="padding:32px;">
+<h1 style="margin:0 0 16px 0;font-size:22px;color:#f8fafc;">Export ready</h1>
+<p style="margin:0 0 16px 0;line-height:1.5;">Your tenant-data export for
+<strong>${escapeHtml(ctx.tenantDisplayName)}</strong> is ready (~${sizeKb} KB).</p>
+<p style="margin:24px 0;">
+  <a href="${escapeHtml(ctx.downloadUrl)}"
+     style="display:inline-block;background:#34d399;color:#0f172a;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600;">
+     Download export
+  </a>
+</p>
+<p style="margin:16px 0;color:#94a3b8;font-size:13px;">
+  Link expires at <code style="color:#e2e8f0;">${escapeHtml(expiresIso)}</code>.
+</p>
+<p style="margin:24px 0 0 0;color:#64748b;font-size:12px;">
+  Once the link expires, contact the Panorama maintainer with this email's date to re-mint a fresh URL.
+</p>
+</td></tr>
+</table>
+</body>
+</html>`;
+
+  return { subject, text, html };
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/apps/core-api/test/tenant-export.e2e.test.ts
+++ b/apps/core-api/test/tenant-export.e2e.test.ts
@@ -1,0 +1,394 @@
+import 'reflect-metadata';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { Test } from '@nestjs/testing';
+import type { INestApplication } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+import { Redis } from 'ioredis';
+import { gunzipSync } from 'node:zlib';
+import { AppModule } from '../src/app.module.js';
+import { PasswordService } from '../src/modules/auth/password.service.js';
+import { EmailService } from '../src/modules/email/email.service.js';
+import { ObjectStorageService } from '../src/modules/object-storage/object-storage.service.js';
+import { TenantExportService } from '../src/modules/tenant-export/tenant-export.service.js';
+import { resetTestDb } from './_reset-db.js';
+import { createTenantForTest } from './_create-tenant.js';
+
+/**
+ * E2e coverage for ADR-0020 §8 (PR 4 tenant data export).
+ *
+ * Drives the request → enqueue → worker → audit + S3 + email path
+ * end-to-end. ObjectStorageService is mocked to capture put +
+ * getSignedUrl calls (the SSRF guard at boot would require a real
+ * S3 endpoint otherwise). EmailService mock captures the
+ * completion email. The BullMQ queue is idle-in-tests; the test
+ * invokes `TenantExportService.runJob` directly so the worker path
+ * runs inline.
+ */
+
+const HOST = process.env['PG_HOST'] ?? 'localhost';
+const PORT = process.env['PG_PORT'] ?? '5432';
+const DB = process.env['PG_DB'] ?? 'panorama';
+const ADMIN_URL = `postgres://panorama_super_admin:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+const APP_URL = `postgres://panorama_app:panorama@${HOST}:${PORT}/${DB}?schema=public`;
+const REDIS_URL = process.env['REDIS_URL'] ?? 'redis://localhost:6379/0';
+
+interface PutCall {
+  key: string;
+  body: Buffer;
+  tenantId: string;
+}
+
+interface SentEmail {
+  to: string;
+  subject: string;
+  text: string;
+}
+
+interface SignedUrlCall {
+  key: string;
+  responseContentType?: string;
+  responseContentDisposition?: string;
+  expiresIn?: number;
+}
+
+describe('tenant export (ADR-0020 §8, PR 4)', () => {
+  let app: INestApplication;
+  let url: string;
+  let admin: PrismaClient;
+  let redis: Redis;
+  let exports: TenantExportService;
+  let puts: PutCall[];
+  let signedUrlCalls: SignedUrlCall[];
+  let sentEmails: SentEmail[];
+  let tenantId: string;
+  let ownerEmail: string;
+  const password = 'correct-horse-battery-staple';
+
+  beforeAll(async () => {
+    process.env['SESSION_SECRET'] = process.env['SESSION_SECRET'] ?? 'a'.repeat(32);
+    process.env['DATABASE_URL'] = APP_URL;
+
+    admin = new PrismaClient({ datasources: { db: { url: ADMIN_URL } } });
+    await resetTestDb(admin);
+
+    redis = new Redis(REDIS_URL);
+    await flushExportKeys(redis);
+
+    puts = [];
+    signedUrlCalls = [];
+    sentEmails = [];
+
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] })
+      .overrideProvider(ObjectStorageService)
+      .useValue({
+        // Tests don't reach real S3 — capture the call shape so we
+        // can assert the key matches the §8 pattern + the gzipped
+        // body round-trips through gunzip cleanly.
+        put: async (
+          key: string,
+          body: Buffer,
+          opts: { tenantId: string },
+        ) => {
+          puts.push({ key, body, tenantId: opts.tenantId });
+        },
+        getSignedUrl: async (
+          key: string,
+          opts: {
+            responseContentType?: string;
+            responseContentDisposition?: string;
+            expiresIn?: number;
+          },
+        ) => {
+          signedUrlCalls.push({
+            key,
+            ...(opts.responseContentType !== undefined ? { responseContentType: opts.responseContentType } : {}),
+            ...(opts.responseContentDisposition !== undefined ? { responseContentDisposition: opts.responseContentDisposition } : {}),
+            ...(opts.expiresIn !== undefined ? { expiresIn: opts.expiresIn } : {}),
+          });
+          return `https://s3.test.invalid/${encodeURIComponent(key)}?X-Amz-Signature=fake`;
+        },
+        onModuleInit: async () => {},
+      })
+      .overrideProvider(EmailService)
+      .useValue({
+        send: async (input: { to: string; subject: string; text: string }) => {
+          sentEmails.push({ to: input.to, subject: input.subject, text: input.text });
+          return { messageId: `mock-${sentEmails.length}` };
+        },
+        onModuleDestroy: async () => {},
+      })
+      .compile();
+    app = moduleRef.createNestApplication({ logger: ['error', 'warn'] });
+    await app.init();
+    await app.listen(0);
+    url = await app.getUrl();
+    exports = app.get(TenantExportService);
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.close();
+    await admin?.$disconnect();
+    await redis?.quit();
+  });
+
+  beforeEach(async () => {
+    await resetTestDb(admin);
+    await flushExportKeys(redis);
+    puts.length = 0;
+    signedUrlCalls.length = 0;
+    sentEmails.length = 0;
+    ({ tenantId, ownerEmail } = await seedTenantWithOwner(admin, password));
+  });
+
+  it('happy path: POST → enqueues row → worker uploads gzipped JSON + emails signed URL', async () => {
+    const cookie = await login(url, ownerEmail, password);
+    const resp = await fetch(`${url}/tenants/${tenantId}/export`, {
+      method: 'POST',
+      headers: { cookie },
+    });
+    expect(resp.status).toBe(202);
+    const body = (await resp.json()) as { jobId: string; status: string };
+    expect(body.status).toBe('queued');
+
+    // Drive the worker inline (BullMQ idle in tests).
+    await exports.runJob(body.jobId);
+
+    // S3 put captured with the §8 key shape + gzipped body that
+    // round-trips through gunzip.
+    expect(puts).toHaveLength(1);
+    expect(puts[0]!.key).toMatch(
+      /^tenants\/[0-9a-f-]+\/exports\/[0-9a-f-]+\.json\.gz$/,
+    );
+    const decompressed = gunzipSync(puts[0]!.body).toString('utf8');
+    const doc = JSON.parse(decompressed) as {
+      panoramaExport: { tenantId: string };
+      tables: Record<string, unknown[]>;
+    };
+    expect(doc.panoramaExport.tenantId).toBe(tenantId);
+    // Core MVP tables present in the export.
+    for (const expected of [
+      'tenants',
+      'tenant_memberships',
+      'users',
+      'assets',
+      'reservations',
+      'inspections',
+      'asset_maintenances',
+    ]) {
+      expect(doc.tables).toHaveProperty(expected);
+    }
+    expect(doc.tables.tenants).toHaveLength(1);
+
+    // Completion email body links to the Panorama download endpoint
+    // (NOT a presigned S3 URL — security-reviewer PR 4 BLOCKER 3).
+    expect(sentEmails).toHaveLength(1);
+    expect(sentEmails[0]!.to).toBe(ownerEmail);
+    expect(sentEmails[0]!.text).toContain(
+      `/tenants/${tenantId}/exports/${body.jobId}/download`,
+    );
+    expect(sentEmails[0]!.text).not.toContain('s3.test.invalid');
+    expect(sentEmails[0]!.text).not.toContain('X-Amz-Signature');
+
+    // Audit trail: TenantExportRequested + TenantExported.
+    const requested = await admin.auditEvent.count({
+      where: { tenantId, action: 'panorama.tenant.export_requested' },
+    });
+    expect(requested).toBe(1);
+    const exported = await admin.auditEvent.findFirst({
+      where: { tenantId, action: 'panorama.tenant.exported' },
+    });
+    expect(exported).not.toBeNull();
+    // §8 contract: audit row records objectKey, NOT the signed URL.
+    const exportedMeta = exported!.metadata as { objectKey?: string };
+    expect(exportedMeta.objectKey).toMatch(/^tenants\/[0-9a-f-]+\/exports\//);
+    expect(JSON.stringify(exported!.metadata)).not.toContain('X-Amz-Signature');
+
+    // The tenant_exports row is in the completed state.
+    const row = await admin.tenantExport.findUnique({ where: { id: body.jobId } });
+    expect(row?.status).toBe('completed');
+    expect(row?.objectKey).toMatch(/\.json\.gz$/);
+  });
+
+  it('download endpoint: session-gated 302 to short-TTL signed URL with gzip content-type', async () => {
+    const cookie = await login(url, ownerEmail, password);
+    // Complete an export first.
+    const enqueue = await fetch(`${url}/tenants/${tenantId}/export`, {
+      method: 'POST',
+      headers: { cookie },
+    });
+    const { jobId } = (await enqueue.json()) as { jobId: string };
+    await exports.runJob(jobId);
+    const beforeDownload = signedUrlCalls.length;
+
+    // Unauthenticated GET against the download path: 401. The
+    // signed URL is NEVER minted on this path — mail-scanner
+    // prefetch can't extract the file (security-reviewer PR 4
+    // BLOCKER 3 regression).
+    const noSessionResp = await fetch(
+      `${url}/tenants/${tenantId}/exports/${jobId}/download`,
+      { redirect: 'manual' },
+    );
+    expect(noSessionResp.status).toBe(401);
+    expect(signedUrlCalls.length).toBe(beforeDownload);
+
+    // Authenticated GET: 302 to a freshly-minted signed URL with
+    // `application/gzip` content-type + tenant-export filename
+    // (BLOCKER 1 — was hardcoded to image/jpeg before the fix).
+    const sessionResp = await fetch(
+      `${url}/tenants/${tenantId}/exports/${jobId}/download`,
+      { headers: { cookie }, redirect: 'manual' },
+    );
+    expect(sessionResp.status).toBe(302);
+    expect(sessionResp.headers.get('location')).toMatch(/^https:\/\/s3\.test\.invalid\//);
+    const mintCall = signedUrlCalls[signedUrlCalls.length - 1]!;
+    expect(mintCall.responseContentType).toBe('application/gzip');
+    expect(mintCall.responseContentDisposition).toBe(
+      `attachment; filename="panorama-export-${jobId}.json.gz"`,
+    );
+    // 60s short-TTL URL (the long-lived window applies to the
+    // Panorama route, not the S3 URL).
+    expect(mintCall.expiresIn).toBe(60);
+  });
+
+  it('serializer omits invitation tokenHash (security-reviewer BLOCKER 2)', async () => {
+    // Seed an invitation so the export includes one in the
+    // invitations table; the export body must NOT carry tokenHash.
+    const inviter = await admin.user.findFirst({
+      where: { email: ownerEmail },
+    });
+    await admin.invitation.create({
+      data: {
+        tenantId,
+        email: 'invitee@example.invalid',
+        role: 'driver',
+        tokenHash: 'a'.repeat(64),
+        invitedByUserId: inviter!.id,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      },
+    });
+    const cookie = await login(url, ownerEmail, password);
+    const resp = await fetch(`${url}/tenants/${tenantId}/export`, {
+      method: 'POST',
+      headers: { cookie },
+    });
+    const { jobId } = (await resp.json()) as { jobId: string };
+    await exports.runJob(jobId);
+    const body = gunzipSync(puts[0]!.body).toString('utf8');
+    expect(body).toContain('invitee@example.invalid');
+    expect(body).not.toContain('a'.repeat(64));
+    expect(body).not.toMatch(/"tokenHash"/);
+  });
+
+  it('rate-limit: second request within 24h returns 429', async () => {
+    const cookie = await login(url, ownerEmail, password);
+    const first = await fetch(`${url}/tenants/${tenantId}/export`, {
+      method: 'POST',
+      headers: { cookie },
+    });
+    expect(first.status).toBe(202);
+
+    const second = await fetch(`${url}/tenants/${tenantId}/export`, {
+      method: 'POST',
+      headers: { cookie },
+    });
+    expect(second.status).toBe(429);
+  });
+
+  it('auth: non-Owner gets 403', async () => {
+    // Demote owner to fleet_admin so they have a session but lack
+    // the role.
+    const membership = await admin.tenantMembership.findFirst({
+      where: { tenantId, user: { email: ownerEmail } },
+    });
+    // Seed a peer Owner first so the demote doesn't trip the
+    // last-Owner trigger.
+    const peerEmail = `peer-${Date.now()}@example.invalid`;
+    const passwords = new PasswordService();
+    const peer = await admin.user.create({
+      data: { email: peerEmail, displayName: 'Peer Owner' },
+    });
+    await admin.authIdentity.create({
+      data: {
+        userId: peer.id,
+        provider: 'password',
+        subject: peerEmail,
+        emailAtLink: peerEmail,
+        secretHash: await passwords.hash(password),
+      },
+    });
+    await admin.tenantMembership.create({
+      data: { tenantId, userId: peer.id, role: 'owner', status: 'active' },
+    });
+    await admin.tenantMembership.update({
+      where: { id: membership!.id },
+      data: { role: 'fleet_admin' },
+    });
+
+    const cookie = await login(url, ownerEmail, password);
+    const resp = await fetch(`${url}/tenants/${tenantId}/export`, {
+      method: 'POST',
+      headers: { cookie },
+    });
+    expect(resp.status).toBe(403);
+  });
+});
+
+// -----------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------
+
+async function seedTenantWithOwner(
+  admin: PrismaClient,
+  password: string,
+): Promise<{ tenantId: string; ownerEmail: string }> {
+  const passwords = new PasswordService();
+  const ownerEmail = `owner-export-${Date.now()}@example.invalid`;
+  const user = await admin.user.create({
+    data: { email: ownerEmail, displayName: 'Export Owner' },
+  });
+  await admin.authIdentity.create({
+    data: {
+      userId: user.id,
+      provider: 'password',
+      subject: ownerEmail,
+      emailAtLink: ownerEmail,
+      secretHash: await passwords.hash(password),
+    },
+  });
+  const tenant = await createTenantForTest(admin, {
+    slug: `pr4-${Date.now()}`,
+    name: 'PR4 Export Test',
+    displayName: 'PR4 Export Test',
+  });
+  await admin.tenantMembership.create({
+    data: { tenantId: tenant.id, userId: user.id, role: 'owner', status: 'active' },
+  });
+  return { tenantId: tenant.id, ownerEmail };
+}
+
+async function login(baseUrl: string, email: string, password: string): Promise<string> {
+  const res = await fetch(`${baseUrl}/auth/login`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  if (res.status !== 200) {
+    throw new Error(`login failed: ${res.status} ${await res.text()}`);
+  }
+  const setCookie = res.headers.get('set-cookie');
+  if (!setCookie) throw new Error('login response missing set-cookie');
+  return setCookie
+    .split(',')
+    .map((c) => c.split(';')[0]!.trim())
+    .join('; ');
+}
+
+async function flushExportKeys(redis: Redis): Promise<void> {
+  const stream = redis.scanStream({ match: 'panorama:export:*', count: 200 });
+  for await (const batch of stream) {
+    const keys = batch as string[];
+    if (keys.length > 0) {
+      await redis.del(...keys);
+    }
+  }
+}

--- a/docs/adr/0020-self-serve-oidc-signup.md
+++ b/docs/adr/0020-self-serve-oidc-signup.md
@@ -501,32 +501,75 @@ RESTRICT` locks the contract.
 
 ### 8. Data export
 
-Self-serve data export is its own endpoint, not coupled to deletion:
-`GET /tenants/:tenantId/export` (Owner-only). Per security-reviewer's
-abuse defenses:
+Self-serve data export is its own endpoint, not coupled to deletion.
+Two routes (amended during PR 4 implementation):
+
+- **`POST /tenants/:tenantId/export`** (Owner-only) — request a new
+  export. The original ADR draft said GET, but every call mutates
+  state (inserts a `tenant_exports` row + emits audit), so the
+  verb is POST. Returns 202 Accepted with `{ jobId, status:
+  'queued' }`.
+- **`GET /tenants/:tenantId/exports/:jobId/download`** (Owner-only,
+  session-gated) — the completion email links HERE, not directly to
+  a presigned S3 URL. The endpoint verifies the session, mints a
+  short-lived (60s) presigned URL, and 302-redirects. Rationale:
+  corporate mail-security gateways and link-preview bots prefetch
+  every URL in inbound email; a presigned S3 URL in the email body
+  would get downloaded by the scanner BEFORE the user clicks. A
+  Panorama-route link, hit unauthenticated by the scanner, returns
+  401 (cached) — the file bytes never leave S3 to the scanner.
+
+Per security-reviewer's abuse defenses:
 
 - Rate limit: 1 export per tenant per 24h, via Redis bucket, fail-
   closed
 - Async: response is a job id; the actual export runs in a queue,
-  delivered as a signed S3 URL via email when complete
+  delivered as a link to the session-gated download endpoint when
+  complete
 - Audit-emit on every call (`panorama.tenant.export_requested` +
-  `panorama.tenant.exported`)
+  `panorama.tenant.exported`); SMTP failures emit
+  `panorama.tenant.export_email_dispatch_failed` so operators see
+  the gap without grepping logs
 - Inline export of a 100k-row tenant on a hot HTTP path is itself a
   DoS vector; async-only is non-negotiable
 
-**Signed-URL contract.** The pre-signed S3 URL delivered in the
-completion email has TTL ≤24h. The URL itself is **never written to
-any log line, audit row, or persisted record** — the URL embeds
-credentials and persisting it is a credential leak. The audit row
-for `panorama.tenant.exported` records:
+**Signed-URL contract (amended).** The presigned S3 URL the
+download endpoint mints has TTL **60 seconds** — just long enough
+for the browser to follow the 302. The URL is **never written to
+any log line, audit row, persisted record, or email body** — it
+exists only for the duration of the 302 response. The tenant_exports
+row's `expiresAt` records the LONG-LIVED 24h window during which
+the Panorama download endpoint remains valid; that window is the
+"TTL ≤24h" the original draft mentioned, decoupled from the
+much-shorter actual S3 URL TTL.
 
-- The S3 object key (e.g., `exports/tenant-{uuid}/{job-id}.tar.gz`)
-- The TTL the URL was minted with
-- The recipient email (the Owner's IdP-asserted email)
+The audit row for `panorama.tenant.exported` records:
+
+- The S3 object key (e.g., `tenants/{uuid}/exports/{uuid}.json.gz`)
+- The `windowSeconds` the download endpoint will honor (≤86400)
+- The recipient hash (sha256 first-8 chars; NOT the raw email per
+  the audit-events PII discipline)
 
 NOT the signed URL, NOT the query parameters that carry the
 signature. Operators retrieving the export object via the audit
 trail re-mint a signed URL from the key + their own AWS credentials.
+
+**Object-key shape.** `tenants/{tenant-uuid}/exports/{job-uuid}.json.gz`
+(see `object-storage.keys.ts:TENANT_EXPORT_KEY_REGEX`). Single
+gzipped JSON document, not a tarball — the contents are one
+`{ panoramaExport: ..., tables: { ... } }` object and tar adds no
+structural win for a single-file payload.
+
+**MVP serializer set.** PR 4 ships per-tenant rows for tenants,
+tenant_memberships, users (members only), categories, manufacturers,
+asset_models, assets, reservations, blackout_slots, invitations
+(WITHOUT `tokenHash`), inspection_templates,
+inspection_template_items, inspections, inspection_responses,
+asset_maintenances. Excluded (follow-up work): inspection_photos /
+maintenance_photos binary blobs, personal_access_tokens (secret
+material), notification_events (audience scope unclear),
+audit_events filtered by tenantId (chain-strand windowing TBD).
+New tenant-scoped tables MUST extend `serializeTenantExport`.
 
 The signup → export path satisfies the "show data-export before
 signup" persona-fleet-ops principle: the homepage has a "see what


### PR DESCRIPTION
## Summary

Last of Round 3's four main PRs. Implements ADR-0020 §8 — async tenant data export with session-gated download, rate-limited at 1/tenant/24h, audit-emitting throughout. Builds on [#212](https://github.com/VitorMRodovalho/panorama/pull/212) + [#214](https://github.com/VitorMRodovalho/panorama/pull/214) + [#215](https://github.com/VitorMRodovalho/panorama/pull/215).

- Migration 0025 — `tenant_exports` job ledger.
- `modules/tenant-export/` — config + templates + serializer + service + queue + controller + module.
- 2 endpoints: POST `/export` (request) + GET `/exports/:jobId/download` (session-gated 302 to short-TTL S3 URL).
- BullMQ daily worker (idle-in-tests).
- Audit registry: 4 new entries (Requested / Exported / Failed / EmailDispatchFailed).
- ObjectStorage refactor: hoisted out of `conditionalInspections` + `getSignedUrl` parameterized for content-type/disposition.

## ⚠ Upgrade note for self-hosters

`S3_BUCKET_PHOTOS`, `S3_ACCESS_KEY`, `S3_SECRET_KEY` are now **required** on every deployment (was conditional behind `FEATURE_INSPECTIONS`). Set them before pulling this release or core-api refuses to boot. This is the silent env-contract change flagged by tech-lead — addressed via documentation rather than a lazy-load refactor (which would have doubled the PR surface).

## Adversarial review log

- **tech-lead 1st pass**: 2 blockers (ADR §8 GET-vs-POST divergence; silent env-contract change) + 5 concerns. ALL addressed:
    - ADR-0020 §8 rewritten to specify POST for request + the new session-gated download route + the 60s vs windowSeconds TTL split + the MVP serializer table list.
    - Inline docstrings (migration header, schema model, audit-actions JSDoc) sync'd to POST.
    - Env-contract change documented in commit body + upgrade note above.
- **security-reviewer 1st pass**: 3 blockers. ALL addressed:
    - **B1** (hardcoded `image/jpeg` in `getSignedUrl` — oculto pelo mock): `responseContentType` + `responseContentDisposition` now explicit options. Export passes `application/gzip` + the export filename. New e2e regression asserts the mint args.
    - **B2** (Invitation.tokenHash exfiltrated): explicit `select:` whitelist in serializer omits `tokenHash`. New e2e regression asserts the export body never carries the hash.
    - **B3** (presigned URL in email = middlebox prefetch leak): completion email links to the Panorama download endpoint, NOT a presigned S3 URL. Session-gated GET mints the 60s S3 URL ONLY after Owner-session verification. New e2e regression asserts unauthenticated GET returns 401.
- **Deferred concerns** (logged for follow-ups):
    - Stuck-job sweeper (worker crash mid-processing).
    - Per-user rate limit alongside per-tenant.
    - Streaming serializer for large tenants.
    - S3 lifecycle rule for object cleanup past `expiresAt`.
    - audit_events / inspection_photos / personal_access_tokens / notification_events serialization (MVP gaps).
    - Resend endpoint for SMTP-failed dispatches.

## Major surfaces

- **POST `/tenants/:tenantId/export`** (Owner-only) — request a new export. 202 Accepted with `{ jobId, status: 'queued' }`. Per-tenant 1/24h rate-limit (429 on trip).
- **GET `/tenants/:tenantId/exports/:jobId/download`** (Owner-only, session-gated) — completion email links HERE. Verifies Owner session, mints 60s presigned URL with `application/gzip` content-type + `panorama-export-{jobId}.json.gz` filename, 302s. Unauthenticated GET returns 401 — defeats middlebox prefetch.
- **Worker** (`TenantExportService.runJob`) — snapshot-read all tenant-scoped tables, gzip JSON, S3 upload, mark completed + audit, email with Panorama download link.
- **Serializer** — exports 15 tenant-scoped tables: tenants, memberships, users (members only), categories, manufacturers, asset_models, assets, reservations, blackout_slots, invitations (no tokenHash), inspection_templates + items, inspections + responses, asset_maintenances. Photos/audit/PATs deferred.

## Test plan

- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean.
- [x] `pnpm rls:allowlist-check` — clean (48 calls across 15 files; budget 10 added for tenant-export.service.ts).
- [x] Migration 0025 applied to dev DB + Supabase staging.
- [x] Suite: 51 test files / 476 tests passing locally.
- [x] `test/tenant-export.e2e.test.ts` (5 tests):
    - happy path (POST → enqueue → worker → gzipped JSON in S3 + email with Panorama download URL)
    - session-gated download (unauthenticated GET → 401; authenticated GET → 302 + correct content-type)
    - invitation tokenHash omission (regression for security-reviewer B2)
    - rate-limit (second POST within 24h → 429)
    - non-Owner refused
- [ ] NOT covered (deferred): real S3 / SMTP integration; BullMQ worker live-running; frontend integration (apps/web has no export UI yet — backend ships ready).

## Operational notes

- `TENANT_EXPORT_WINDOW_SECONDS` (default 86400, range 300-86400) — how long the Panorama download endpoint stays valid post-completion.
- Short-lived S3 URL TTL is constant 60s (not configurable).
- ObjectStorageModule is now always-loaded. `S3_*` env vars required.
- `tenant_exports` has no GRANT to panorama_app. Service routes via runAsSuperAdmin.

## Round 3 complete

| PR | Status |
|----|--------|
| 1 — signup initiate + callback | ✅ merged #212 |
| 1 follow-up — normalize ::ffff: v4 | ✅ merged #213 |
| 2 — email verification + flip | ✅ merged #214 |
| 3 — tenant delete 7d cool-off | ✅ merged #215 |
| **4 — data export** | **this PR** |

Round 3 closes the full self-serve lifecycle: signup → verify → use → (delete | export). The hosted-instance launch can flip `FEATURE_SELF_SERVE_SIGNUP` on once `ObjectStorageModule` is configured + all four PRs are deployed.