### PR TITLE
fix(tenant-export): scope runJob's catch to export work only (closes #228)

### DIFF
--- a/apps/core-api/src/modules/tenant-export/tenant-export.service.ts
+++ b/apps/core-api/src/modules/tenant-export/tenant-export.service.ts
@@ -109,7 +109,7 @@ export class TenantExportService {
    * dependency.
    */
   async runJob(jobId: string): Promise<void> {
-    let job = await this.prisma.runAsSuperAdmin(
+    const job = await this.prisma.runAsSuperAdmin(
       (tx) => tx.tenantExport.findUnique({ where: { id: jobId } }),
       { reason: `tenant-export:run:${jobId}:fetch` },
     );
@@ -138,20 +138,43 @@ export class TenantExportService {
       { reason: `tenant-export:run:${jobId}:processing` },
     );
 
+    let result;
     try {
-      const result = await this.executeExport(job.tenantId, jobId);
+      result = await this.executeExport(job.tenantId, jobId);
       await this.markCompleted(jobId, result);
-      job = await this.prisma.runAsSuperAdmin(
-        (tx) => tx.tenantExport.findUnique({ where: { id: jobId } }),
-        { reason: `tenant-export:run:${jobId}:refetch` },
-      );
-      if (job) {
-        await this.dispatchEmail(job, result);
-      }
     } catch (err) {
       const errKind = err instanceof Error ? err.name : 'Unknown';
       this.log.error({ err: String(err), jobId }, 'tenant_export_run_failed');
       await this.markFailed(jobId, errKind);
+      return;
+    }
+
+    // Email dispatch lives outside the export-failure catch (issue
+    // #228). Before this fix, a throw from `lookupJobIdByObjectKey`
+    // or any other path inside `dispatchEmail` that bypassed its own
+    // inner try/catch would propagate up to the outer catch and call
+    // `markFailed` — overwriting a `completed` row even though the
+    // export file was already uploaded to S3. The tenant would see
+    // "failed" in the UI while the file sat in the bucket with no
+    // surface to retrieve it.
+    //
+    // After this fix, an email-side error logs a warn and emits the
+    // already-existing `tenant_export_email_dispatch_failed` audit
+    // row (per `dispatchEmail`'s inner catch). The row stays
+    // `completed`; the tenant can still download the export.
+    try {
+      const refetched = await this.prisma.runAsSuperAdmin(
+        (tx) => tx.tenantExport.findUnique({ where: { id: jobId } }),
+        { reason: `tenant-export:run:${jobId}:refetch` },
+      );
+      if (refetched) {
+        await this.dispatchEmail(refetched, result);
+      }
+    } catch (err) {
+      this.log.warn(
+        { err: String(err), jobId },
+        'tenant_export_email_failed_but_completed',
+      );
     }
   }
 

--- a/apps/core-api/test/tenant-export.e2e.test.ts
+++ b/apps/core-api/test/tenant-export.e2e.test.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
 import { Test } from '@nestjs/testing';
 import type { INestApplication } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
@@ -330,6 +330,49 @@ describe('tenant export (ADR-0020 §8, PR 4)', () => {
       headers: { cookie },
     });
     expect(resp.status).toBe(403);
+  });
+
+  it('issue #228: email-side failure does NOT overwrite completed → failed', async () => {
+    // Regression test for the dispatchEmail bug carried across the
+    // PR1 / PR2 / PR3 handoffs as risk item #6 (PR1) → persona N1
+    // (PR2) → follow-up #4 (PR3). Before the fix, a throw anywhere
+    // inside dispatchEmail beyond its own inner try/catch
+    // (lookupJobIdByObjectKey, renderExportReadyEmail) propagated
+    // to the outer catch in runJob and called markFailed —
+    // overwriting a completed row whose export file was already in
+    // S3, leaving the tenant with "failed" in the UI but the bytes
+    // sitting in the bucket.
+    const cookie = await login(url, ownerEmail, password);
+    const resp = await fetch(`${url}/tenants/${tenantId}/export`, {
+      method: 'POST',
+      headers: { cookie },
+    });
+    expect(resp.status).toBe(202);
+    const body = (await resp.json()) as { jobId: string };
+
+    const dispatchSpy = vi
+      .spyOn(
+        exports as unknown as { dispatchEmail: (...args: unknown[]) => Promise<void> },
+        'dispatchEmail',
+      )
+      .mockRejectedValueOnce(new Error('synthetic post-completion failure'));
+
+    await exports.runJob(body.jobId);
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+
+    const row = await admin.tenantExport.findUnique({ where: { id: body.jobId } });
+    // The export file was already uploaded to S3 by markCompleted's
+    // moment; the row MUST stay completed so the tenant can download.
+    expect(
+      row?.status,
+      'email failure must not reverse the completed terminal state',
+    ).toBe('completed');
+    expect(row?.objectKey).toMatch(/\.json\.gz$/);
+    // S3 upload happened (markCompleted ran before dispatchEmail).
+    expect(puts).toHaveLength(1);
+
+    dispatchSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #228. Surgical fix to a bug carried unfixed across PR1 / PR2 / PR3 handoffs of the Round 5 sequence.

Before this fix, a throw anywhere inside \`dispatchEmail\` beyond its own inner \`try/catch\` (\`lookupJobIdByObjectKey\`, \`renderExportReadyEmail\`, or any Prisma error mid-flow) propagated to \`runJob\`'s outer catch and called \`markFailed\` — overwriting a \`completed\` row whose export file was already in S3. The tenant would see "failed" in the UI while the bytes sat in the bucket with no surface to retrieve them.

After this fix:
- \`executeExport\` + \`markCompleted\` stay in the outer try; if either throws, the row is correctly marked failed (the file was never uploaded or the row was never updated).
- \`dispatchEmail\` lives in its own try; any throw beyond its existing inner catch logs a warn (\`tenant_export_email_failed_but_completed\`) but does NOT touch the row state. The row stays \`completed\`; the tenant can still download the export from the existing endpoint.
- \`dispatchEmail\`'s internal try/catch around \`mail.send\` plus its audit-write fallback continue to handle the dominant email failure mode (SMTP outage) the same way they did before.

## Test

\`vi.spyOn(exports, 'dispatchEmail').mockRejectedValueOnce(...)\` → call \`runJob\` → assert the row terminal state stays \`completed\` and the S3 upload still happened.

## History

- HANDOFF-2026-05-17-round-5-pr1-complete.md "Risks / known-stale items" #6 (PR1 explicitly out-of-scope)
- HANDOFF-2026-05-17-round-5-pr2-complete.md "Follow-ups filed" persona N1
- HANDOFF-2026-05-17-round-5-complete.md "Follow-ups filed" #4
- Issue #228 filed during PR2 review

## Test plan

- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm exec eslint\` on changed files clean
- [x] Core-api suite 522/522 passing (was 521 after Round 5 PR3; +1 new regression case)
- [x] tenant-export.e2e.test.ts 6/6 passing (was 5/5; +1 new case)
- [x] community-smoke essentials:csv-export-end-to-end still passing