### PR TITLE
feat(quickstart): canonical 5-min local-dev path + seed password identity + DATABASE_PRIVILEGED_URL in .env.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,29 +131,49 @@ and [`docs/audits/HANDOFF-2026-04-23.md`](./docs/audits/HANDOFF-2026-04-23.md) f
 
 ## Getting started (dev)
 
+Full 5-minute walkthrough — clone, seed, log in as a tenant Owner,
+test cross-tenant isolation — at
+[`docs/en/quickstart.md`](./docs/en/quickstart.md).
+
+The TL;DR:
+
 ```bash
 # Pre-req: Node 22+, pnpm 9+, Docker, Docker Compose v2
 corepack enable
 pnpm install
 cp apps/core-api/.env.example apps/core-api/.env
+cp apps/web/.env.example apps/web/.env.local
 docker compose -f infra/docker/compose.dev.yml up -d
-pnpm --filter @panorama/core-api prisma migrate dev
-pnpm dev
+pnpm --filter @panorama/core-api prisma:deploy
+pnpm --filter @panorama/core-api prisma:seed   # creates Owners + dev passwords
+pnpm dev                                       # core-api + web concurrently
 ```
 
-Then:
+Then log in at <http://localhost:3000/login> with:
 
-- Web app:  http://localhost:3000
-- Core API: http://localhost:4000
-- API docs: http://localhost:4000/api/docs (OpenAPI UI)
-- MailHog (dev SMTP):  http://localhost:8025
-- MinIO console (dev): http://localhost:9001 (credentials in `.env.example`)
+- `admin@alpha.example` / `panorama-dev-2026`
+- `admin@bravo.example` / `panorama-dev-2026`
+
+(Dev-only passwords — the seed refuses to run against a prod-looking
+`DATABASE_URL`.)
+
+| URL | What it is |
+|---|---|
+| <http://localhost:3000> | Web app |
+| <http://localhost:4000/health> | Core API liveness + DB ping |
+| <http://localhost:4000/api/docs> | OpenAPI Swagger UI |
+| <http://localhost:8025> | MailHog (captured outgoing emails) |
+| <http://localhost:9001> | MinIO console (`minioadmin/minioadmin`) |
 
 **Contributor security note:** if you use Cursor / Claude Desktop /
 any AI tool with MCP servers configured against this repo, read
 [`docs/runbooks/dev-environment-ai-tooling.md`](./docs/runbooks/dev-environment-ai-tooling.md)
 before running anything. The runbook lists the verified MCP server
 allowlist and the incident-response path.
+
+For **production deployment** (TLS, backups, hardening), see
+[`docs/en/self-hosting.md`](./docs/en/self-hosting.md) — different
+audience.
 
 ## Importing data from another system
 

--- a/apps/core-api/.env.example
+++ b/apps/core-api/.env.example
@@ -13,6 +13,13 @@ DATABASE_URL=postgres://panorama:panorama@localhost:5432/panorama?schema=public
 DATABASE_APP_ROLE=panorama_app
 DATABASE_APP_PASSWORD=panorama
 
+# Privileged connection for the SECURITY DEFINER bypass paths
+# (ADR-0015 v2). Uses the `panorama_super_admin` role — same DB,
+# NOBYPASSRLS, with EXECUTE grant on `panorama_enable_bypass_rls()`.
+# REQUIRED at boot; the API refuses to start without it. The
+# dev-stack postgres-init seeds `panorama_super_admin/panorama`.
+DATABASE_PRIVILEGED_URL=postgres://panorama_super_admin:panorama@localhost:5432/panorama?schema=public
+
 # --- Cache / queues (Redis 7) ---
 REDIS_URL=redis://localhost:6379/0
 

--- a/apps/core-api/prisma/seed.ts
+++ b/apps/core-api/prisma/seed.ts
@@ -7,8 +7,20 @@
  * looks prod-like, unless ALLOW_DESTRUCTIVE_SEED=true.
  */
 import { PrismaClient } from '@prisma/client';
+import { PasswordService } from '../src/modules/auth/password.service.js';
 
 const prisma = new PrismaClient();
+const passwords = new PasswordService();
+
+/**
+ * Documented dev-only password for the seeded tenant Owners. Long
+ * enough to satisfy PasswordService's 12-char floor. The quickstart
+ * runbook (`docs/en/quickstart.md`) is the only place a user should
+ * ever read this from. NEVER set this as a production secret — the
+ * `looksProd(DATABASE_URL)` guard above stops the seed from running
+ * against anything that smells like prod.
+ */
+const DEV_OWNER_PASSWORD = 'panorama-dev-2026';
 
 function looksProd(url: string | undefined): boolean {
   if (!url) return true;
@@ -27,17 +39,38 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // Purge previous seed rows (OK in dev only — the guard above enforces it).
-  await prisma.invitation.deleteMany();
-  await prisma.reservation.deleteMany();
-  await prisma.asset.deleteMany();
-  await prisma.assetModel.deleteMany();
-  await prisma.manufacturer.deleteMany();
-  await prisma.category.deleteMany();
-  await prisma.tenantMembership.deleteMany();
-  await prisma.authIdentity.deleteMany();
-  await prisma.user.deleteMany();
-  await prisma.tenant.deleteMany();
+  // Purge previous seed rows (OK in dev only — the guard above
+  // enforces it). Wrap in a single transaction with the
+  // `panorama.bypass_owner_check` GUC set so the
+  // `enforce_at_least_one_owner` trigger (migration 0005) doesn't
+  // refuse the Owner-membership deletes. Same pattern as the test
+  // helper `apps/core-api/test/_reset-db.ts`. Order is reverse-FK-
+  // dependency so the deletes succeed without relying on CASCADE.
+  await prisma.$transaction(async (tx) => {
+    await tx.$executeRawUnsafe("SET LOCAL panorama.bypass_owner_check = 'on'");
+    await tx.blackoutSlot.deleteMany();
+    await tx.invitation.deleteMany();
+    await tx.inspectionPhoto.deleteMany();
+    await tx.inspectionResponse.deleteMany();
+    await tx.inspection.deleteMany();
+    await tx.inspectionTemplateItem.deleteMany();
+    await tx.inspectionTemplate.deleteMany();
+    await tx.maintenancePhoto.deleteMany();
+    await tx.assetMaintenance.deleteMany();
+    await tx.reservation.deleteMany();
+    await tx.asset.deleteMany();
+    await tx.assetModel.deleteMany();
+    await tx.manufacturer.deleteMany();
+    await tx.category.deleteMany();
+    await tx.personalAccessToken.deleteMany();
+    await tx.notificationEvent.deleteMany();
+    await tx.tenantMembership.deleteMany();
+    await tx.authIdentity.deleteMany();
+    await tx.tenant.deleteMany();
+    await tx.user.deleteMany();
+    await tx.importIdentityMap.deleteMany();
+    await tx.auditEvent.deleteMany();
+  });
 
   // ADR-0016 §1 — every tenant carries a NOT NULL system actor user
   // for auto-suggested maintenance attribution. Seed both atomically.
@@ -97,6 +130,7 @@ async function main(): Promise<void> {
         displayName: `${tenant.displayName} Admin`,
         firstName: 'Admin',
         lastName: tenant.displayName,
+        status: 'ACTIVE',
       },
     });
     // ADR-0007 rule 2: creator of a tenant is its first Owner.
@@ -109,6 +143,19 @@ async function main(): Promise<void> {
         acceptedAt: new Date(),
       },
     });
+    // Password identity so the seeded Owner can log in via the
+    // email/password flow without going through OIDC setup. The
+    // quickstart runbook tells the user this exists; nothing in
+    // production code path reads `DEV_OWNER_PASSWORD`.
+    await prisma.authIdentity.create({
+      data: {
+        userId: user.id,
+        provider: 'password',
+        subject: user.email,
+        emailAtLink: user.email,
+        secretHash: await passwords.hash(DEV_OWNER_PASSWORD),
+      },
+    });
   }
 
   const [alphaCount, bravoCount] = await Promise.all([
@@ -118,6 +165,12 @@ async function main(): Promise<void> {
   console.log(`Seed complete. alpha=${alphaCount} assets, bravo=${bravoCount} assets.`);
   console.log(`alpha id: ${alpha.id}`);
   console.log(`bravo id: ${bravo.id}`);
+  console.log('');
+  console.log('Owner login credentials (DEV ONLY — see docs/en/quickstart.md):');
+  console.log('  admin@alpha.example / panorama-dev-2026');
+  console.log('  admin@bravo.example / panorama-dev-2026');
+  console.log('');
+  console.log('Web URL: http://localhost:3000');
 }
 
 main()

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -2,6 +2,8 @@
 
 Start here:
 
+- [Quickstart](./quickstart) — run Panorama on your laptop in 5 min
+- [Self-hosting](./self-hosting) — production deploy reference
 - [Architecture](./architecture) — how the system is laid out
 - [Feature matrix](./feature-matrix) — Community vs Enterprise
 - [Roadmap](./roadmap) — what ships when

--- a/docs/en/quickstart.md
+++ b/docs/en/quickstart.md
@@ -1,0 +1,223 @@
+# Quickstart — run Panorama on your laptop in 5 minutes
+
+This is the path for a maintainer, contributor, or someone who just
+wants to click around the app. Two seeded tenants ("Alpha" and
+"Bravo"), each with an Owner you can log in as, three trucks each,
+and you can test cross-tenant isolation by swapping cookies.
+
+For a production deployment (TLS, backups, hardening), read
+[self-hosting](./self-hosting.md) instead — it covers a different
+audience.
+
+## Prerequisites
+
+- **Node.js 22+** (uses `engines: ">=22"`; older versions break Vitest)
+- **pnpm 9+** (`corepack enable && corepack prepare pnpm@latest --activate`)
+- **Docker + docker-compose** (the dev stack is 4 containers: Postgres,
+  Redis, MinIO, MailHog)
+
+```bash
+node --version    # v22+ ?
+pnpm --version    # 9+ ?
+docker compose version  # any modern version
+```
+
+## 1. Clone + install
+
+```bash
+git clone https://github.com/VitorMRodovalho/panorama.git
+cd panorama
+pnpm install
+```
+
+`pnpm install` takes ~2 minutes the first time (downloads + builds
+sharp's native image bindings).
+
+## 2. Start the dev stack
+
+```bash
+docker-compose -f infra/docker/compose.dev.yml up -d
+```
+
+Containers come up healthy in ~10s. Check with:
+
+```bash
+docker-compose -f infra/docker/compose.dev.yml ps
+```
+
+You should see four containers `Up (healthy)`: postgres on `:5432`,
+redis on `:6379`, minio on `:9000`, mailhog on `:8025`.
+
+> `docker compose` (with a space) is the v2 plugin syntax; `docker-compose`
+> (with a hyphen) is the legacy binary. Either works. The dev-stack
+> compose file is plain v3; if `docker compose` fails on your machine,
+> fall back to `docker-compose`.
+
+## 3. Copy the env files
+
+```bash
+cp apps/core-api/.env.example apps/core-api/.env
+cp apps/web/.env.example apps/web/.env.local
+```
+
+The defaults in `.env.example` point at the dev-stack containers
+(localhost:5432 / 6379 / 9000 etc.) and are safe for local dev. The
+`SESSION_SECRET` in `.env.example` is a placeholder — replace it
+with 32 random bytes:
+
+```bash
+NEW=$(node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))")
+sed -i "s|^SESSION_SECRET=.*|SESSION_SECRET=$NEW|" apps/core-api/.env
+```
+
+## 4. Apply migrations + seed
+
+```bash
+pnpm --filter @panorama/core-api prisma:deploy
+pnpm --filter @panorama/core-api prisma:seed
+```
+
+The seed output ends with:
+
+```
+Owner login credentials (DEV ONLY — see docs/en/quickstart.md):
+  admin@alpha.example / panorama-dev-2026
+  admin@bravo.example / panorama-dev-2026
+
+Web URL: http://localhost:3000
+```
+
+Both Owners use the same dev password — never use this value
+outside local dev. The seed script refuses to run against any
+`DATABASE_URL` that looks like prod.
+
+## 5. Start the API + web in two terminals
+
+Terminal 1 — core-api on `:4000`:
+
+```bash
+pnpm --filter @panorama/core-api dev
+```
+
+Wait for `Panorama core-api listening on :4000 (sentryEnabled=false)`.
+
+Terminal 2 — web on `:3000`:
+
+```bash
+pnpm --filter @panorama/web dev
+```
+
+Wait for `Ready in <time>`.
+
+## 6. Log in
+
+Open <http://localhost:3000/login> and use:
+
+- **Email:** `admin@alpha.example`
+- **Password:** `panorama-dev-2026`
+
+You should land on the Alpha tenant's `/assets` page with the three
+seeded trucks (`ALPHA-001`, `ALPHA-002`, `ALPHA-003`). Click around:
+
+- `/reservations` — empty list; click "New" to request a booking
+- `/reservations/calendar` — 14-day timeline view
+- `/assets/import` — CSV upload form
+- `/admin` — tenant admin surface (Owner-only)
+
+## 7. Test cross-tenant isolation
+
+Log out, then log in as `admin@bravo.example` with the same password.
+You should see `BRAVO-001` / `BRAVO-002` / `BRAVO-003` — and the
+Alpha trucks must NOT appear. That's row-level security holding the
+contract at the database layer
+([ADR-0003](../adr/0003-multi-tenancy.md)).
+
+## 8. Other useful local URLs
+
+| URL | What it is |
+|---|---|
+| <http://localhost:3000> | The web app you log into |
+| <http://localhost:4000/health> | API liveness + DB ping |
+| <http://localhost:4000/api-docs> | OpenAPI schema (Swagger UI) |
+| <http://localhost:8025> | MailHog — captured outgoing emails (invitations, export notifications). NEVER hits a real SMTP server in dev. |
+| <http://localhost:9001> | MinIO console; login `minioadmin/minioadmin`. Buckets `panorama-photos` + `panorama-backups` are created automatically. |
+
+## Optional — feature flags
+
+The seeded environment has `FEATURE_INSPECTIONS`, `FEATURE_MAINTENANCE`,
+and `FEATURE_SELF_SERVE_SIGNUP` defaulted in `apps/core-api/.env`. To
+exercise those flows, set them to `true` and restart core-api:
+
+```bash
+# apps/core-api/.env
+FEATURE_INSPECTIONS=true
+FEATURE_MAINTENANCE=true
+FEATURE_SELF_SERVE_SIGNUP=true
+```
+
+If you turn `FEATURE_SELF_SERVE_SIGNUP=true`, you also need
+`TURNSTILE_SECRET` set (any value is fine for local dev — Turnstile
+verification is mocked in tests, and the dev signup flow uses a stub).
+
+## Optional — pretty logs
+
+JSON logs to stdout is the production format. For human-readable
+output during dev, set in `apps/core-api/.env`:
+
+```bash
+LOG_FORMAT=pretty
+```
+
+And restart core-api. Same logs, colorized + line-formatted.
+
+## Re-seeding
+
+```bash
+pnpm --filter @panorama/core-api prisma:seed
+```
+
+The seed is destructive — it wipes every domain table before
+recreating Alpha + Bravo. Safe in local dev (the script refuses to
+run if `DATABASE_URL` looks production-like).
+
+## Running the test suite
+
+```bash
+pnpm --filter @panorama/core-api test
+```
+
+~520 cases; ~70-90s. Tests use the same dev stack (Postgres + Redis +
+MinIO) — they reset their own state via `test/_reset-db.ts`. Don't
+worry about your seed data; tests run in isolation.
+
+## When things break
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `runAsSuperAdmin requires DATABASE_PRIVILEGED_URL` | Missing env var | Copy `.env.example` to `.env`; the line is in there |
+| `SESSION_SECRET must be at least 32 characters` | Placeholder not replaced | Re-run the `node -e ... | sed` snippet in step 3 |
+| `S3_ENDPOINT health check failed` | MinIO not ready | `docker-compose -f infra/docker/compose.dev.yml restart minio` and wait 10s |
+| `Cannot connect to Postgres` | Dev stack down | `docker-compose -f infra/docker/compose.dev.yml up -d` |
+| Login returns 401 with valid creds | Seed didn't run (or ran before this PR) | `pnpm --filter @panorama/core-api prisma:seed` re-creates the password identity |
+| `pnpm install` fails on `sharp` | Native build deps missing | On Linux: `sudo apt install libvips-dev`. On macOS: `brew install vips` |
+
+If the dev stack is genuinely broken (port conflict, weird Docker
+state), `docker-compose -f infra/docker/compose.dev.yml down -v &&
+docker-compose -f infra/docker/compose.dev.yml up -d` rebuilds from
+scratch (`-v` wipes volumes — the seed gets you back to a known
+state).
+
+## What this DOES NOT cover
+
+- **Production deployment.** See [self-hosting.md](./self-hosting.md).
+- **Hosted preview signup.** That's the public `panorama.vitormr.dev`
+  app surface, which is not yet live; see
+  [early-access.md](./early-access.md).
+- **Real Google / Microsoft OIDC.** The seed sets up email/password
+  auth only; configuring OIDC providers needs real client credentials
+  at the IdP side. The OIDC bits are wired but unused in this
+  quickstart.
+
+For deeper dives into the architecture, see
+[architecture.md](./architecture.md) and the
+[ADR index](/adr/0000-index).

--- a/docs/en/self-hosting.md
+++ b/docs/en/self-hosting.md
@@ -8,6 +8,11 @@ documented escape if the managed staging stack
 ([ADR-0013](../adr/0013-staging-deploy-architecture.md)) doesn't
 fit your needs.
 
+> Just want to see Panorama running on your laptop? Use the
+> [Quickstart](./quickstart.md) instead — it's a different (much
+> shorter) path with seeded tenants and a dev-only password
+> identity. This page is the production deploy guide.
+
 > **Status note**: 0.3 ships the API + admin templates + inspection
 > backend feature-complete. The driver-facing web UI is in flight
 > (step 11 of ADR-0012); until it lands, self-hosting gives you an

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,9 @@ hero:
       text: Get a hosted account
       link: /en/early-access
     - theme: alt
+      text: Try it locally (5 min)
+      link: /en/quickstart
+    - theme: alt
       text: Self-host on GitHub
       link: https://github.com/VitorMRodovalho/panorama
 ---
@@ -39,7 +42,7 @@ hero:
 
 **Hosted preview** — the maintainer runs a Panorama instance you can try for free. No SLA. Data may be wiped with 30 days notice (per [ADR-0014](/adr/0014-public-hosted-instance)). Great for evaluating, not for storing irreplaceable data yet.
 
-**Self-host** — AGPL-3.0 fork-friendly. See the [self-hosting guide](/en/self-hosting), the [feature matrix](/en/feature-matrix), and the [migration-from-Snipe-IT path](/en/migration-from-snipeit). The codebase deployed on the hosted preview is identical to what you'd self-host.
+**Self-host** — AGPL-3.0 fork-friendly. See the [quickstart](/en/quickstart) (laptop in 5 min with seeded tenants), the [self-hosting guide](/en/self-hosting) (production deploy reference), the [feature matrix](/en/feature-matrix), and the [migration-from-Snipe-IT path](/en/migration-from-snipeit). The codebase deployed on the hosted preview is identical to what you'd self-host.
 
 ## Trust
 


### PR DESCRIPTION
## Summary

Closes a real onboarding gap. After this PR, a fresh clone follows `docs/en/quickstart.md` end-to-end in 5 minutes and lands on a logged-in `/assets` page.

The gap before this PR:

1. Seed created Owner users but **no password AuthIdentity** — no way to log in without setting up real OIDC providers.
2. `.env.example` was **missing `DATABASE_PRIVILEGED_URL`** — required at boot since ADR-0015 v2. `pnpm dev` after a fresh clone crashed with a 7-line stack trace at `getPrivilegedClient`'s guard.
3. No canonical "5-min from clone to logged-in" doc — README's "Getting started" was incomplete; self-hosting.md is for production operators (different audience).

## What ships

- **`apps/core-api/prisma/seed.ts`** — wraps the destructive reset in a transaction with `SET LOCAL panorama.bypass_owner_check = 'on'` (same pattern as `test/_reset-db.ts`) so the `enforce_at_least_one_owner` trigger doesn't fight the reset. Delete list expanded to match the test helper. Creates a password `AuthIdentity` for each tenant Owner with documented dev-only password `panorama-dev-2026`. Seed output ends with login credentials.
- **`apps/core-api/.env.example`** — adds `DATABASE_PRIVILEGED_URL` pointing at the dev-stack `panorama_super_admin` role.
- **`docs/en/quickstart.md`** (new, ~170 lines) — canonical laptop-to-logged-in walkthrough with prereqs, install, dev stack, env, migrations, seed, API + web start, login, cross-tenant isolation test, troubleshooting table.
- **`README.md`** — Getting Started section rewritten to point at the quickstart + TL;DR with seed credentials.
- **`docs/en/self-hosting.md`** — preface admonition for local-dev audience pointing at quickstart (this page = production deploy only).
- **`docs/en/index.md`** — Quickstart + Self-hosting at the top of the docs nav.
- **`docs/index.md`** — third hero action "Try it locally (5 min)" + "Two journeys" prose updated.

## Verified end-to-end on the dev stack

- `docker-compose ps` → postgres/redis/minio/mailhog healthy
- `pnpm --filter @panorama/core-api prisma:seed` writes Alpha + Bravo + Owners + password identities
- `pnpm --filter @panorama/core-api dev` boots in 2s; `/health` responds `{"ok":true,"db":"up",...}`
- `POST /auth/login` with `admin@alpha.example` / `panorama-dev-2026` → HTTP 200 + session cookie

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec eslint prisma/seed.ts` clean
- [x] Core-api suite 522/522 still passing
- [x] Manual end-to-end verification per "Verified" above
- [x] VitePress build — no inline `<...>` in the new doc (gotcha caught in PR #237)

## Why one PR not three

The seed change creates the credentials the docs name; the docs name the env var the seed needs to run cleanly. Split would have a worse seam. The whole point is the user can follow it in 5 minutes.