### PR TITLE
Round 6 PR3 — secrets-rotation matrix + AuditEvent.requestId column (#229)

### DIFF
--- a/apps/core-api/prisma/migrations/20260517040000_0026_audit_event_request_id/ROLLBACK.md
+++ b/apps/core-api/prisma/migrations/20260517040000_0026_audit_event_request_id/ROLLBACK.md
@@ -1,0 +1,68 @@
+# Rollback — 0026 audit event request-id correlation column
+
+## Pre-flight
+
+This migration is additive and observational only. Rollback restores
+the pre-0026 state where audit-row → log-line correlation must be
+inferred from `tenantId + occurredAt` (the workaround the column was
+added to replace).
+
+There is no chain-integrity implication: `requestId` is not part of
+the digest pre-image, so dropping the column does not invalidate any
+selfHash / prevHash. The chain-verify CLI was never updated to read
+this column (by design — the column is metadata, not anchor).
+
+## SQL revert (privileged role)
+
+Run from a psql session against `$DATABASE_PRIVILEGED_URL`.
+
+```sql
+ALTER TABLE "audit_events"
+    DROP COLUMN "requestId";
+```
+
+That's it. One column, no triggers, no policies, no indexes.
+
+## Schema implications
+
+`schema.prisma` was updated to mirror the new column at line 718:
+
+```prisma
+model AuditEvent {
+  // ...
+  requestId      String?
+}
+```
+
+A revert of THIS migration must also revert that line from
+`schema.prisma` — otherwise `prisma migrate status` will diff
+against the rolled-back DB.
+
+## Data loss
+
+Any `requestId` values written between 0026 apply and rollback are
+permanently lost. Re-applying 0026 starts a fresh blank-NULL column;
+the pre-rollback values cannot be recovered. Acceptable: the column
+was a correlation aid, never a system-of-record.
+
+## When you would actually revert
+
+Hard to imagine. The column is:
+
+- Optional (NULL-able at the schema level)
+- Read-only outside the AuditService write path (no app code joins
+  on it; triage is by ad-hoc psql)
+- Off the digest path (no chain implication)
+- Backed by no index (no operational cost)
+
+The realistic rollback scenario is *if migration 0026 somehow
+introduces a corruption mode in `audit.service.ts`'s write path*
+— which would be a service-layer bug, not a schema bug. Patch the
+service; do not revert the column.
+
+## Production migration timing
+
+- `ALTER TABLE ADD COLUMN TEXT NULL` is metadata-only (no row
+  rewrite); takes ACCESS EXCLUSIVE on `audit_events` for sub-
+  millisecond. Safe under load.
+- `COMMENT ON COLUMN` is a catalog-only write; no relation lock.

--- a/apps/core-api/prisma/migrations/20260517040000_0026_audit_event_request_id/migration.sql
+++ b/apps/core-api/prisma/migrations/20260517040000_0026_audit_event_request_id/migration.sql
@@ -1,0 +1,48 @@
+-- Migration 0026 — Audit event request-id correlation column.
+--
+-- Closes issue #229 (Round 6 follow-up to ADR-0018 §3). Adds
+-- `audit_events.requestId TEXT NULL` so an operator triaging a 500
+-- can `WHERE requestId = 'req_…'` directly against the audit row
+-- instead of inferring the match by (tenantId + occurredAt window)
+-- — the workaround documented in
+-- docs/audits/HANDOFF-2026-05-17-round-5-pr2-complete.md §"Triage".
+--
+-- Scope (per data-architect's #229 pre-impl scoping):
+--
+--   * Forward-only ADD COLUMN. No backfill — pre-0026 rows stay
+--     NULL by design. The triage flow already handles the
+--     mixed-NULL state (operator falls back to tenantId + occurredAt
+--     for legacy rows).
+--   * No new index. The existing `(tenantId, occurredAt DESC)`
+--     index (line 719 of schema.prisma) covers the realistic query
+--     shape: request-id lookups are point-in-time + naturally
+--     bounded by the requesting tenant. Add an index only when a
+--     runbook query justifies it.
+--   * Not part of the digest pre-image. `requestId` is observational
+--     metadata about *who* requested (analogous to ipAddress and
+--     userAgent, which migration 0021's header explicitly calls out
+--     as "stored but not hashed — observational metadata about the
+--     actor, not part of the audit-row's logical identity"). Adding
+--     it to the digest would change the canonical pre-image format
+--     and break chain-verify on pre-0026 rows.
+--   * Both the TypeScript service path and the SECURITY DEFINER
+--     trigger functions write rows; only the service path has access
+--     to `currentRequestId()` (the trigger functions run inside a
+--     SQL trigger, no Node ALS). Trigger-emitted rows keep
+--     `requestId = NULL`, which is correct: a trigger fire is a
+--     DB-internal correctness check, not a request-bound action.
+--
+-- `ALTER TABLE ADD COLUMN TEXT NULL` is metadata-only — takes
+-- ACCESS EXCLUSIVE on `audit_events` for sub-millisecond, no
+-- rewrite. Safe under load. The advisory lock from migration 0021
+-- is unaffected (it's a runtime advisory, not a relation lock).
+
+ALTER TABLE "audit_events"
+    ADD COLUMN "requestId" TEXT NULL;
+
+COMMENT ON COLUMN "audit_events"."requestId" IS
+'Per-request correlation id (ADR-0018 §3). NULL for rows written before migration 0026, '
+'for trigger-emitted rows (SECURITY DEFINER triggers run without Node ALS context), '
+'and for service-driven writes outside an HTTP request (BootAuditModule, BullMQ workers, '
+'scripts). Not part of the audit chain digest — observational metadata about the actor, '
+'analogous to ipAddress / userAgent (per migration 0021 header).';

--- a/apps/core-api/prisma/migrations/20260517040000_0026_audit_event_request_id/rls.sql
+++ b/apps/core-api/prisma/migrations/20260517040000_0026_audit_event_request_id/rls.sql
@@ -1,0 +1,12 @@
+-- Migration 0026 — no RLS surface change.
+--
+-- `audit_events.requestId` is a metadata column on a table that
+-- already has its RLS policies set up (`audit_events_tenant_read`
+-- per ADR-0003). Adding a new nullable column does not change the
+-- visibility predicates — a row's `requestId` is visible to the
+-- same audience as the rest of the row's columns.
+--
+-- Placeholder kept for grep-greppability of the per-migration RLS
+-- audit pattern.
+
+SELECT 1;

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -720,6 +720,9 @@ model AuditEvent {
   /// outside an HTTP request frame (BootAuditModule, BullMQ workers, scripts).
   /// Observational metadata — NOT part of the digest pre-image (see migration
   /// 0026 header for the rationale tying back to ipAddress/userAgent precedent).
+  /// Folding this into the digest would change the canonical pre-image format
+  /// and make every pre-0026 row un-verifiable by chain-verify CLI. The
+  /// audit-chain-integrity.e2e.test.ts requestId assertion is the canary.
   requestId      String?
 
   @@index([tenantId, occurredAt(sort: Desc)])

--- a/apps/core-api/prisma/schema.prisma
+++ b/apps/core-api/prisma/schema.prisma
@@ -715,6 +715,12 @@ model AuditEvent {
   /// Verifier asserts sha256(COALESCE(prevHash, '') || digestPreImage) == selfHash.
   /// NULL for pre-0021 rows (legacy, unverifiable from columns alone).
   digestPreImage Bytes?
+  /// Per-request correlation id from ADR-0018 §3 RequestContextMiddleware ALS.
+  /// Migration 0026+. NULL for pre-0026 rows, trigger-emitted rows, and writes
+  /// outside an HTTP request frame (BootAuditModule, BullMQ workers, scripts).
+  /// Observational metadata — NOT part of the digest pre-image (see migration
+  /// 0026 header for the rationale tying back to ipAddress/userAgent precedent).
+  requestId      String?
 
   @@index([tenantId, occurredAt(sort: Desc)])
   @@map("audit_events")

--- a/apps/core-api/src/modules/audit/audit.service.ts
+++ b/apps/core-api/src/modules/audit/audit.service.ts
@@ -167,6 +167,13 @@ export class AuditService {
       select: { selfHash: true },
     });
     const occurredAt = new Date();
+    // `payload` and `data` below are TWO separate literals BY
+    // DESIGN. `payload` is the digest pre-image (frozen at the
+    // post-0021 shape); `data` is the Prisma create input. DO NOT
+    // merge them, DRY them up, or refactor into a shared object —
+    // doing so folds observational columns (ipAddress, userAgent,
+    // requestId, future siblings) into the chain digest and breaks
+    // verification of every pre-0026 row.
     const payload = {
       action: event.action,
       resourceType: event.resourceType,
@@ -189,6 +196,8 @@ export class AuditService {
     // §"What it does NOT cover"). null fallback covers code paths
     // outside an HTTP request (BootAuditModule, BullMQ workers,
     // scripts) per tenant.context.ts's currentRequestId contract.
+    // The audit-chain-integrity.e2e test asserts pre-image lacks
+    // `requestId`; that test is the canary for this invariant.
     const data: Prisma.AuditEventCreateInput = {
       action: event.action,
       resourceType: event.resourceType,

--- a/apps/core-api/src/modules/audit/audit.service.ts
+++ b/apps/core-api/src/modules/audit/audit.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import type { Prisma } from '@prisma/client';
 import { createHash } from 'node:crypto';
 import { PrismaService } from '../prisma/prisma.service.js';
+import { currentRequestId } from '../tenant/tenant.context.js';
 
 /**
  * Hash-chained audit log writer. Every row links to the previous row's
@@ -181,6 +182,13 @@ export class AuditService {
     hash.update(digestPreImage);
     const selfHash = hash.digest();
 
+    // requestId is observational metadata (ADR-0018 §3) — written
+    // to the column but NOT included in `payload` above, so the
+    // digest pre-image is unchanged from the pre-0026 format. Same
+    // precedent as ipAddress / userAgent (see migration 0021 header
+    // §"What it does NOT cover"). null fallback covers code paths
+    // outside an HTTP request (BootAuditModule, BullMQ workers,
+    // scripts) per tenant.context.ts's currentRequestId contract.
     const data: Prisma.AuditEventCreateInput = {
       action: event.action,
       resourceType: event.resourceType,
@@ -193,6 +201,7 @@ export class AuditService {
       prevHash: prev?.selfHash ?? null,
       selfHash,
       digestPreImage,
+      requestId: currentRequestId(),
     };
     if (event.metadata !== undefined) {
       data.metadata = event.metadata as Prisma.InputJsonValue;

--- a/apps/core-api/test/audit-chain-integrity.e2e.test.ts
+++ b/apps/core-api/test/audit-chain-integrity.e2e.test.ts
@@ -7,6 +7,7 @@ import { createHash } from 'node:crypto';
 import { AppModule } from '../src/app.module.js';
 import { AuditService } from '../src/modules/audit/audit.service.js';
 import { PrismaService } from '../src/modules/prisma/prisma.service.js';
+import { runInContext } from '../src/modules/tenant/tenant.context.js';
 import { resetTestDb } from './_reset-db.js';
 import { createTenantForTest } from './_create-tenant.js';
 
@@ -306,5 +307,76 @@ describe('audit hash-chain integrity — batched recordWithin', () => {
     for (let i = 1; i < rows.length; i++) {
       expect(Buffer.compare(rows[i]!.prevHash!, rows[i - 1]!.selfHash)).toBe(0);
     }
+  }, 30_000);
+
+  it('writes requestId from the current request context (#229 / migration 0026)', async () => {
+    // Locks the ADR-0018 §3 → audit-row correlation contract:
+    // RequestContextMiddleware sets `requestId` on the ALS frame,
+    // recordWithin reads it via currentRequestId() and persists it
+    // on the new column. Rows written outside a request frame stay
+    // NULL (the BootAuditModule, BullMQ workers, this test's other
+    // batches above).
+    const PROBE_REQUEST_ID = 'req_audit_chain_test_correlation';
+    const batchTenantId = '00000000-0000-4000-8000-000000000046';
+
+    await runInContext(
+      { tenantId: null, userId: null, actorEmail: null, requestId: PROBE_REQUEST_ID },
+      async () => {
+        await prisma.runAsSuperAdmin(
+          async (tx) => {
+            await audit.recordWithin(tx, {
+              action: 'panorama.audit_chain_test.with_request_id',
+              resourceType: 'audit_chain_test',
+              resourceId: 'request-id-row',
+              tenantId: batchTenantId,
+              actorUserId: null,
+              metadata: { probe: 'requestId' },
+            });
+          },
+          { reason: 'audit_chain_test:request_id' },
+        );
+      },
+    );
+
+    const probed = await adminDb.auditEvent.findFirst({
+      where: { tenantId: batchTenantId, action: 'panorama.audit_chain_test.with_request_id' },
+      select: { requestId: true, selfHash: true, digestPreImage: true },
+    });
+    expect(probed).not.toBeNull();
+    expect(probed!.requestId).toBe(PROBE_REQUEST_ID);
+
+    // The chain digest must NOT depend on requestId — pre-image is
+    // payload-only (action/resourceType/resourceId/tenantId/actorUserId/
+    // metadata/occurredAt). If a future change folds requestId into
+    // the digest, pre-0026 rows and trigger-emitted rows fail to
+    // verify. Recompute the digest from columns, asserting the
+    // existing pre-image shape still matches selfHash even with a
+    // non-null requestId on the same row.
+    const preImage = JSON.parse(Buffer.from(probed!.digestPreImage!).toString('utf8'));
+    expect(preImage).not.toHaveProperty('requestId');
+
+    // And a write outside any runInContext frame writes NULL,
+    // documenting the BootAuditModule / BullMQ / script behaviour.
+    const outsideTenantId = '00000000-0000-4000-8000-000000000047';
+    await prisma.runAsSuperAdmin(
+      async (tx) => {
+        await audit.recordWithin(tx, {
+          action: 'panorama.audit_chain_test.no_request_id',
+          resourceType: 'audit_chain_test',
+          resourceId: 'no-request-id-row',
+          tenantId: outsideTenantId,
+          actorUserId: null,
+          metadata: { probe: 'noRequestId' },
+        });
+      },
+      { reason: 'audit_chain_test:no_request_id' },
+    );
+
+    const outside = await adminDb.auditEvent.findFirst({
+      where: { tenantId: outsideTenantId, action: 'panorama.audit_chain_test.no_request_id' },
+      select: { requestId: true },
+    });
+    expect(outside).not.toBeNull();
+    expect(outside!.requestId).toBeNull();
   }, 30_000);
 });

--- a/docs/runbooks/secrets-rotation.md
+++ b/docs/runbooks/secrets-rotation.md
@@ -1,17 +1,53 @@
 # Secrets rotation runbook
 
-> **Status — stub.** Round 5 PR3 lands the rotation primitive for
-> `SESSION_SECRET` and this short procedure. The full per-secret
-> rotation matrix (OIDC client secrets, S3, SMTP, Sentry DSN,
-> Turnstile) lands in Round 6 alongside the incident + restore drill.
-> See [`secrets-inventory.md`](./secrets-inventory.md) for the
+> **Status.** Per-secret rotation matrix landed in Round 6 PR3
+> (2026-05-17). Cross-reference
+> [`incident.md`](./incident.md) Phase 3 for the in-incident decision
+> tree and [`secrets-inventory.md`](./secrets-inventory.md) for the
 > authoritative list of secrets in scope.
 
-This page is the runbook a self-hosting operator follows when
-rotating `SESSION_SECRET`. Two paths exist; the rest of the document
-walks each one.
+This page tells the operator how to rotate every secret listed in
+[`secrets-inventory.md`](./secrets-inventory.md). Each section follows
+the same shape:
 
-## Path A — Emergency rotation (suspected key leak)
+- **When to rotate** — emergency (suspected leak) vs routine
+  (scheduled hygiene) vs in-incident (driven by
+  [`incident.md`](./incident.md)).
+- **Procedure** — concrete shell commands; copy-paste safe on a
+  standard Fly + Cloudflare + Supabase deploy. Self-hosters running
+  Kubernetes / Coolify / bare docker compose substitute the
+  platform-equivalent secret-set command.
+- **Blast radius** — what breaks during the rotation window and for
+  how long. Read this before you click "rotate" on a Saturday night.
+- **Verification** — how to confirm the rotation took.
+- **Rollback** — how to revert if the new value doesn't work.
+
+The runbook covers the **Community / single-operator** rotation
+contract. The fleet-wide managed-service variant (one rotation
+across many hosted customer instances at once, with audit emission
+per tenant and a per-customer rotation report) ships in the
+**Enterprise edition** — see the [§Multi-tenant rotation
+orchestration](#multi-tenant-rotation-orchestration) section at the
+end.
+
+## Decision tree — which path?
+
+| Trigger | Path |
+|---|---|
+| Suspected leak (committed `.env` file, departing administrator with shell access, accidental log dump) | **Emergency path** for the leaked secret — invalidates sessions and revokes the leaked credential at the issuer. Skip the wait step. |
+| Scheduled rotation (quarterly hygiene per org policy) | **Routine path** for each secret — zero-downtime where the secret supports it (SESSION_SECRET via `_PREVIOUS`), short-window for the rest. |
+| Active incident already in [Phase 3 Contain](./incident.md#phase-3--contain) | Follow that phase's decision tree. It dispatches into this runbook per-secret; the entry points there are the section anchors below. |
+| New self-host bringing up first deployment | No rotation needed — generate fresh values from scratch per [`secrets-inventory.md`](./secrets-inventory.md). |
+
+## SESSION_SECRET — iron-session cookie encryption key
+
+Iron-session encrypts every session cookie under the value of
+`SESSION_SECRET`. A leaked value lets a holder forge or decrypt any
+issued cookie until rotation. The rotation primitive (added in PR
+#232) supports a single secondary key via `SESSION_SECRET_PREVIOUS`
+so a routine rotation does not log users out.
+
+### Path A — Emergency rotation (suspected key leak)
 
 When to use:
 - `.env` was accidentally committed to a public repository
@@ -45,7 +81,7 @@ for one of: `SESSION_SECRET must be at least 32...` (the new value
 is too short) or `SESSION_SECRET_PREVIOUS must be a different
 value...` (you copy-pasted into both vars).
 
-## Path B — Routine zero-downtime rotation
+### Path B — Routine zero-downtime rotation
 
 When to use:
 - Quarterly hygiene per organisational policy
@@ -55,7 +91,7 @@ When to use:
 
 Goal: rotate without forcing users to re-log in.
 
-### Step 1 — flip
+#### Step 1 — flip
 
 Move the current `SESSION_SECRET` to `SESSION_SECRET_PREVIOUS`; set a
 fresh primary.
@@ -68,7 +104,7 @@ sed -i "s|^SESSION_SECRET_PREVIOUS=.*|SESSION_SECRET_PREVIOUS=$OLD|" .env
 docker compose -f infra/docker/compose.prod.yml up -d core-api
 ```
 
-### Step 2 — verify the rotation window
+#### Step 2 — verify the rotation window
 
 Check the boot logs for the rotation marker:
 
@@ -97,10 +133,10 @@ users routed to the other.
 Also verify a fresh login succeeds AND an existing browser session
 (opened before the flip) continues to work without re-login.
 
-### Step 3 — wait
+#### Step 3 — wait
 
 Wait at least `SESSION_MAX_AGE_SECONDS` (default 7 days,
-`apps/core-api/src/modules/auth/auth.config.ts:127`). Every cookie
+`apps/core-api/src/modules/auth/auth.config.ts:169`). Every cookie
 sealed before the flip will either re-issue under the new key on its
 next request, or expire and force a fresh login.
 
@@ -119,7 +155,7 @@ is a leaked key waiting to happen.
 > user is bounced to the login page. The wait is the entire reason
 > this procedure is zero-downtime.
 
-### Step 4 — drop
+#### Step 4 — drop
 
 Clear `SESSION_SECRET_PREVIOUS` and redeploy. Single-key steady
 state.
@@ -131,30 +167,750 @@ docker compose -f infra/docker/compose.prod.yml up -d core-api
 
 Confirm the rotation-active log line is no longer emitted on boot.
 
-## What this runbook does NOT cover (yet)
+### Blast radius reference (SESSION_SECRET)
 
-Round 6 will expand to include:
+- **Path A** invalidates every active session. UX impact: every
+  user is bounced to the login page on their next request; they
+  re-enter credentials and proceed. No data loss. No downtime to
+  the API surface itself.
+- **Path B** is zero-impact when executed correctly. The only way
+  to break users is by skipping Step 3 (the wait) or rolling out
+  Step 1 to only some replicas.
 
-- Rotating OIDC client secrets without breaking in-flight logins
-- Rotating S3 and SMTP credentials
-- Rotating the Sentry DSN (per ADR-0018)
-- Rotating the Turnstile secret
-- Per-secret blast radius + recovery checklist
-- The full incident-response procedure (LGPD 72h ANPD clock)
-- The integration with the restore drill
+## DATABASE_URL / DATABASE_DIRECT_URL / DATABASE_PRIVILEGED_URL — Supabase pooler + direct connections
 
-Until that lands, the [`secrets-inventory.md`](./secrets-inventory.md)
-table identifies every secret in scope; rotate each one via its
-platform's standard procedure (Fly secrets, Doppler, Vault — whatever
-your deployment uses).
+These three URLs share one **pooler password** (the Postgres role
+that all three URLs authenticate as) on managed Supabase. Rotating
+the pooler password rotates all three URLs together; you cannot
+rotate one without the others. The `panorama_app` role password
+(`DATABASE_APP_PASSWORD`) is independent — see the next section.
+
+### When to rotate
+
+| Trigger | Path |
+|---|---|
+| Suspected leak of `.env` or Fly secrets dump | **Path A — emergency** below |
+| Quarterly hygiene | **Path B — routine** below |
+| Supabase support rotated it for you (regional incident, account compromise) | The change is already done provider-side; only the Panorama-side `fly secrets set` is left |
+
+### Path A — Emergency rotation
+
+Rotation on Supabase managed Postgres is **not zero-downtime**:
+every connection in the pool must reconnect under the new password.
+For a single-replica Community deployment this is a 5-10s blip; for
+a Fly multi-replica it's a rolling-deploy window.
+
+```bash
+# 1. Supabase dashboard → Project Settings → Database → "Reset
+#    database password". Capture the new pooler URL (a single string
+#    that contains the password and the hostname); the form gives
+#    you the pooler URL (port 6543) and the direct URL (port 5432).
+#
+# 2. Locally regenerate the .env.staging from the new pooler URL:
+./scripts/setup-staging-env.sh
+
+# 3. Push to Fly:
+fly secrets set --app panorama-staging \
+    DATABASE_URL="$NEW_POOLER_URL" \
+    DATABASE_DIRECT_URL="$NEW_DIRECT_URL" \
+    DATABASE_PRIVILEGED_URL="$NEW_DIRECT_URL"
+# `fly secrets set` triggers an automatic redeploy; for rolling
+# behavior add `--stage` then `fly deploy --strategy rolling`.
+
+# 4. Watch the rolling deploy until every instance reports healthy.
+fly status --app panorama-staging
+```
+
+### Path B — Routine rotation
+
+Identical commands to Path A. The difference is **timing**: schedule
+during a low-traffic window (UTC weekend graveyard), pre-announce in
+the status page (once it exists per Round 7 §9), and have the
+Supabase dashboard tab open in a second browser before issuing the
+reset.
+
+### Blast radius
+
+- **5-10 second connection-pool blip** as Prisma's pool drops the
+  old connections and dials new ones. In-flight requests fail with
+  `PrismaClientKnownRequestError: P1017 (Server has closed the
+  connection)` and the client retries; the user sees a 503 if the
+  retry budget exhausts.
+- **BullMQ workers** (invitation email, tenant export, photo
+  thumbnailer) reconnect on the next job pick; queued jobs
+  back-pressure during the window. No job loss — BullMQ holds the
+  job in Redis until a worker acks it.
+- **Migration tooling** (`pnpm migrate deploy`) uses
+  `DATABASE_DIRECT_URL`; if a migration is mid-flight during
+  rotation, the migration may fail mid-statement. **Do not rotate
+  during a migration apply.** Cross-reference `apply-migrations.sh`
+  output to confirm a clean state before issuing the reset.
+
+### Verification
+
+```bash
+# Health endpoint returns 200 + DB-reachable
+curl -fsSL https://api.panorama.example/health | jq
+
+# Confirm prisma can read after rotation
+fly ssh console --app panorama-staging \
+    --command "node -e 'require(\"/app/node_modules/@prisma/client\").PrismaClient().auditEvent.count().then(c => console.log(c))'"
+```
+
+### Rollback
+
+If the new pooler password is wrong or Panorama cannot reach the
+new pooler URL, restore the previous secrets:
+
+```bash
+fly secrets set --app panorama-staging \
+    DATABASE_URL="$OLD_POOLER_URL" \
+    DATABASE_DIRECT_URL="$OLD_DIRECT_URL" \
+    DATABASE_PRIVILEGED_URL="$OLD_DIRECT_URL"
+```
+
+…then re-issue the Supabase reset to get back to a state where
+Panorama can authenticate. If the OLD value was never captured, the
+recovery path is "have Supabase reset the password to a known value
+via support ticket".
+
+## DATABASE_APP_PASSWORD — panorama_app role password
+
+The `panorama_app` Postgres role (per ADR-0013) is the role
+Panorama's runtime connects as. Its password rotates independently
+of the Supabase pooler password — pooler authenticates as the
+Supabase-provided role, then Panorama's runtime authenticates as
+`panorama_app` via the connection string in `DATABASE_URL` after
+the pooler hands off.
+
+### Procedure
+
+```bash
+# 1. Generate new app-role password.
+NEW=$(node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))")
+
+# 2. Connect to the DB as the privileged role (Supabase dashboard
+#    SQL editor, or psql on $DATABASE_PRIVILEGED_URL):
+psql "$DATABASE_PRIVILEGED_URL" \
+    -c "ALTER ROLE panorama_app WITH PASSWORD '$NEW'"
+
+# 3. Update the env on Fly:
+fly secrets set --app panorama-staging \
+    DATABASE_APP_PASSWORD="$NEW" \
+    DATABASE_URL="postgres://panorama_app:$NEW@$POOLER_HOST:6543/postgres?schema=public"
+# (DATABASE_URL embeds the password inline; you must update both
+# values atomically. DATABASE_DIRECT_URL and DATABASE_PRIVILEGED_URL
+# do NOT embed the app-role password — they authenticate as the
+# Supabase pooler role and the panorama_super_admin role
+# respectively. Don't update them here.)
+
+# 4. Rolling deploy.
+fly deploy --strategy rolling --app panorama-staging
+```
+
+### Blast radius
+
+- **No connection-pool blip** if you set the secret + redeploy in
+  one `fly secrets set` call (the new password takes effect on the
+  next pool connect, and the rolling deploy issues fresh
+  connections).
+- **Pool of in-flight requests** authenticated under the old
+  password continue to work until their connection is recycled.
+  Prisma's idle-connection recycler closes them within
+  `connection_limit` cycles; no manual intervention needed.
+- **`bootstrap.sql` and `apply-migrations.sh`** do not use the app
+  role, so migration tooling is unaffected.
+
+### Verification
+
+```bash
+# 1. New connections authenticate.
+fly ssh console --app panorama-staging \
+    --command "psql \$DATABASE_URL -c 'SELECT current_user'"
+# Expected output: current_user = panorama_app
+
+# 2. RLS still works as expected (panorama_app should NOT bypass).
+fly ssh console --app panorama-staging \
+    --command "psql \$DATABASE_URL -c 'SHOW row_security'"
+# Expected output: row_security = on
+```
+
+### Rollback
+
+```bash
+psql "$DATABASE_PRIVILEGED_URL" \
+    -c "ALTER ROLE panorama_app WITH PASSWORD '$OLD'"
+fly secrets set --app panorama-staging \
+    DATABASE_APP_PASSWORD="$OLD" \
+    DATABASE_URL="postgres://panorama_app:$OLD@$POOLER_HOST:6543/postgres?schema=public"
+```
+
+## OIDC_GOOGLE_CLIENT_SECRET / OIDC_MICROSOFT_CLIENT_SECRET — IdP credentials
+
+These secrets authenticate Panorama to the Identity Provider during
+the OIDC authorization-code exchange. A leak does NOT give the
+attacker direct access to tenant data — they would need a valid
+authorization code from a real user's IdP login on the same
+deployment's callback URL. The threat is **token forgery against
+this Panorama deployment specifically** + the operator's IdP-side
+client identity.
+
+### When to rotate
+
+| Trigger | Path |
+|---|---|
+| Suspected leak | Emergency path; the procedure is the same as routine but the IdP-side revoke step must precede the Panorama-side set step |
+| IdP-driven rotation (Google or Microsoft expiring the secret on schedule, common for Microsoft Entra) | Routine path; the IdP gives you a window with both secrets active |
+| Quarterly hygiene | Routine path |
+
+### Procedure
+
+```bash
+# 1. At the IdP — Google Cloud Console (Google) or Azure portal
+#    "App registrations" → "Certificates and secrets" (Microsoft).
+#    Issue a new client secret. Both providers let you create the
+#    new secret BEFORE revoking the old one (preferred for routine
+#    rotation; both secrets are accepted during the window).
+#
+#    Microsoft displays the secret VALUE only once; capture it
+#    immediately into your secret manager before navigating away.
+#    Google shows it indefinitely under the OAuth client.
+
+# 2. Push the new secret to Fly:
+fly secrets set --app panorama-staging \
+    OIDC_GOOGLE_CLIENT_SECRET="$NEW_GOOGLE_SECRET"
+# (or OIDC_MICROSOFT_CLIENT_SECRET for the Microsoft side)
+
+# 3. Wait for the rolling deploy to complete:
+fly status --app panorama-staging
+
+# 4. At the IdP — revoke the OLD secret. From this point forward,
+#    only the new secret is accepted by the IdP for token exchange.
+#    Order matters: revoking before Panorama has the new secret in
+#    effect breaks every in-flight OIDC dance.
+```
+
+### Blast radius
+
+- **In-flight OIDC dances** (a user mid-login) running against the
+  old secret fail at the token-exchange step. They retry the login
+  and succeed under the new secret. UX: one extra "log in" click,
+  no data loss.
+- **Active sessions** are unaffected. OIDC client secrets are used
+  only at the initial auth code → token exchange; session cookies
+  are minted by Panorama from that token, not by the IdP. Existing
+  cookies stay valid until `SESSION_MAX_AGE_SECONDS`.
+- **Per-tenant trust:** the OIDC client is configured against the
+  hosted-instance callback URL (and any sister self-host URLs). A
+  rotation does NOT change the client ID, so trust at the IdP-side
+  consent screen + admin-side approved-clients list is preserved.
+
+### Verification
+
+```bash
+# 1. Trigger a fresh login from a clean browser:
+#    Open https://panorama.example/login → click Google → consent →
+#    callback should succeed. Confirm a session cookie is issued.
+#
+# 2. Check that the audit log emitted the login event:
+psql "$DATABASE_PRIVILEGED_URL" \
+    -c "SELECT id, action, occurredAt FROM audit_events
+        WHERE action = 'panorama.auth.session_started'
+        ORDER BY id DESC LIMIT 5"
+```
+
+### Rollback
+
+Re-set the old secret in Fly + at the IdP (don't revoke the OLD
+secret in step 4 above if you're not confident the new one works
+end-to-end). Restore the previous active client on Google/Microsoft.
+
+## S3_ACCESS_KEY / S3_SECRET_KEY — object storage credentials
+
+S3-compatible object storage credentials (Cloudflare R2 in
+production, MinIO in dev). A leak of these credentials gives the
+holder read/write access to the bucket(s) listed in `S3_BUCKET_PHOTOS`
+(and any sister buckets the credential was scoped to). The threat
+is **bucket-scope confidentiality + integrity**, not session
+forgery or DB access.
+
+### When to rotate
+
+| Trigger | Path |
+|---|---|
+| Suspected leak | Emergency path; provider-side revoke before Panorama-side set |
+| Quarterly hygiene | Routine path; both keys active during the rolling deploy |
+| Bucket migration (changing buckets / providers) | Routine path for the new credentials; the OLD credentials may be retired immediately after migration is verified |
+
+### Procedure
+
+```bash
+# 1. At Cloudflare R2 → API Tokens → "Create R2 API token". Scope
+#    the new token to the same buckets and permissions as the
+#    current token. Capture the access-key-id + secret pair (the
+#    secret is shown ONCE).
+#
+#    (AWS S3 equivalent: IAM → Users → security credentials →
+#    "Create access key". For other providers: their equivalent
+#    flow.)
+
+# 2. Push the new credentials to Fly:
+fly secrets set --app panorama-staging \
+    S3_ACCESS_KEY="$NEW_ACCESS_KEY" \
+    S3_SECRET_KEY="$NEW_SECRET_KEY"
+
+# 3. Wait for the rolling deploy:
+fly status --app panorama-staging
+
+# 4. At Cloudflare R2 (or your provider) — revoke the OLD token.
+```
+
+### Blast radius
+
+- **Existing pre-signed URLs minted under the OLD credential
+  continue to work until their TTL expires** — the URL embeds the
+  signature, which is bound to the credential that minted it. Photo
+  download URLs default to `signedUrlTtlSeconds` (typically 60s) per
+  `apps/core-api/src/modules/object-storage/object-storage.service.ts:237-249`;
+  tenant-export download URLs run up to 24h per ADR-0020 §8.
+  Driver phones with a cached presigned URL keep working until that
+  TTL ticks down.
+- **NEW pre-signed URLs minted post-rotation** require the new
+  credentials to be live; the rolling deploy is the boundary. A
+  driver's photo upload in-flight at the moment of rotation fails
+  with `SignatureDoesNotMatch` and the client retries — UX: one
+  extra "tap to retry" click.
+- **No data loss.** The bucket and its contents are unaffected by
+  credential rotation. You're rotating *access*, not *data*.
+
+### Verification
+
+```bash
+# 1. Upload a test photo via the staging app (driver login → asset
+#    detail → camera capture → upload) and confirm it lands in R2.
+#
+# 2. Fetch a download URL and confirm it serves the bytes:
+fly ssh console --app panorama-staging \
+    --command "curl -fsSL '$DOWNLOAD_URL' | head -c 16 | xxd"
+# Expected: JPEG magic bytes ffd8ffe0
+#
+# 3. Check the audit chain for any S3-related operational errors
+#    emitted during the rotation window:
+psql "$DATABASE_PRIVILEGED_URL" \
+    -c "SELECT id, action, metadata FROM audit_events
+        WHERE action LIKE 'panorama.object_storage.%'
+        AND occurredAt >= NOW() - INTERVAL '1 hour'
+        ORDER BY id DESC"
+```
+
+### Rollback
+
+```bash
+fly secrets set --app panorama-staging \
+    S3_ACCESS_KEY="$OLD_ACCESS_KEY" \
+    S3_SECRET_KEY="$OLD_SECRET_KEY"
+```
+
+If the OLD token was already revoked at the provider, you must
+issue a third (fresh) token and use that — there is no way to
+un-revoke an R2 token. Document the rollback path explicitly in
+your incident notes so the next operator knows the original token
+is dead.
+
+## SMTP_USER / SMTP_PASSWORD — outbound email credentials
+
+The Panorama runtime sends invitation + notification + tenant-export
+completion emails through these credentials. A leak gives the holder
+the ability to send email *from* the Panorama deployment's verified
+sender domain — a spam / phishing risk to the operator's reputation,
+not a data exfiltration risk.
+
+### When to rotate
+
+| Trigger | Path |
+|---|---|
+| Suspected leak | Emergency path; provider-side revoke before Panorama-side set |
+| Quarterly hygiene | Routine path |
+| Provider-driven (SendGrid API key expiry, Postmark token reissue) | Routine path; pair both old + new for the cutover window |
+
+### Procedure
+
+```bash
+# 1. At the SMTP provider (Mailgun / SendGrid / SES / Postmark /
+#    Resend / etc.) — issue a new credential. Naming convention is
+#    provider-specific:
+#    - SES: IAM access keys → SMTP credentials
+#    - SendGrid: API Keys → "Mail Send" scope
+#    - Postmark: Server tokens → new server token
+#    - Resend: API Keys → "Sending access"
+#    Capture the new SMTP_USER + SMTP_PASSWORD values.
+
+# 2. Push to Fly:
+fly secrets set --app panorama-staging \
+    SMTP_USER="$NEW_SMTP_USER" \
+    SMTP_PASSWORD="$NEW_SMTP_PASSWORD"
+
+# 3. Wait for rolling deploy:
+fly status --app panorama-staging
+
+# 4. Revoke the OLD credentials at the provider.
+```
+
+### Blast radius
+
+- **In-flight email sends fail** during the rolling deploy with a
+  provider-specific 535 auth error. The BullMQ retry queue picks
+  them up with the new credentials on the next attempt; emails are
+  delayed by the retry-backoff (default 2-5 minutes), not lost.
+  The `notification_events` table tracks delivery status so the
+  operator can see the retry chain.
+- **Sender-domain trust** is unaffected — SPF, DKIM, DMARC are
+  domain-level records that don't change with SMTP credential
+  rotation. Recipients' deliverability is unchanged.
+
+### Verification
+
+```bash
+# 1. Trigger a test email via the invitation flow or a staging
+#    re-send of the most recent notification:
+fly ssh console --app panorama-staging \
+    --command "node /app/scripts/smoke-staging-seed.ts --send-test-email"
+# (Or trigger a real invitation via the app to a known-good
+# recipient.)
+
+# 2. Confirm the notification queue drained any backed-up events:
+psql "$DATABASE_PRIVILEGED_URL" \
+    -c "SELECT id, status, COUNT(*) FROM notification_events
+        WHERE occurredAt >= NOW() - INTERVAL '1 hour'
+        GROUP BY id, status"
+# Expected: a row for status = DISPATCHED matching the post-rotation
+# count; status = DEAD only if a permanent failure (not a transient
+# auth error).
+
+# 3. Check MailHog (dev) / inbox (prod) for the test email.
+```
+
+### Rollback
+
+```bash
+fly secrets set --app panorama-staging \
+    SMTP_USER="$OLD_SMTP_USER" \
+    SMTP_PASSWORD="$OLD_SMTP_PASSWORD"
+```
+
+If the OLD credentials were already revoked at the provider, the
+recovery path is "issue a third (fresh) credential at the provider
++ set that one". As with S3, document the dead OLD credentials in
+your incident notes.
+
+## REDIS_URL — Upstash connection URL
+
+The Redis connection URL embeds the access token in the userinfo
+portion: `rediss://default:<TOKEN>@<endpoint>:6379`. A leak of the
+URL leaks the token. The threat is **rate-limiter bypass + BullMQ
+job tampering** — both have downstream blast radius (signup-flood
+defenses dropped, queued tenant exports inspectable) but neither is
+DB-level confidentiality.
+
+### Procedure
+
+```bash
+# 1. At Upstash dashboard → REST → reset token. The dashboard
+#    issues a new URL; the OLD URL is invalidated server-side at
+#    the moment the new one is created (Upstash does NOT support
+#    a transition window).
+
+# 2. Push to Fly:
+fly secrets set --app panorama-staging \
+    REDIS_URL="$NEW_REDIS_URL"
+```
+
+### Blast radius
+
+- **Brief auth errors** during the rolling deploy as BullMQ workers
+  reconnect and rate-limiter clients re-handshake. Per
+  [`secrets-inventory.md`](./secrets-inventory.md) §Redis: "BullMQ
+  workers will see auth errors briefly. This is expected; the
+  rolling deploy resolves it within the deploy window."
+- **Rate-limiter fail-closed:** sliding-window rate-limiters
+  configured to fail-closed on Redis outage (per ADR-0020 §4) will
+  reject signup attempts during the rotation window. Acceptable
+  for a 5-10s blip; not acceptable if the deploy stalls. Watch the
+  status surface during rotation.
+- **In-flight BullMQ jobs:** held in Redis until a worker acks;
+  the new Redis token sees the same Redis instance (Upstash only
+  rotates the *token*, not the underlying instance), so the jobs
+  are visible to the post-rotation worker.
+
+### Verification
+
+```bash
+# 1. Health endpoint reports Redis OK:
+curl -fsSL https://api.panorama.example/health | jq .redis
+# Expected: { "ok": true }
+
+# 2. A queued background job processes (best path: trigger an
+#    invitation send, observe NotificationEvent status flip from
+#    PENDING to DISPATCHED within a minute):
+psql "$DATABASE_PRIVILEGED_URL" \
+    -c "SELECT id, status, occurredAt FROM notification_events
+        WHERE occurredAt >= NOW() - INTERVAL '5 minutes'
+        ORDER BY id DESC LIMIT 10"
+```
+
+### Rollback
+
+```bash
+fly secrets set --app panorama-staging \
+    REDIS_URL="$OLD_REDIS_URL"
+```
+
+The OLD URL is invalid post-rotation; you must issue a third token
+at Upstash to recover if the new URL doesn't work. Document the
+dead OLD credentials.
+
+## SENTRY_DSN — error reporting endpoint
+
+Per [ADR-0018](../adr/0018-observability-stack.md), Sentry is
+**opt-in**: unset → no-op, set → Sentry initializes. The DSN is
+**quasi-secret** — a leak does not give the holder access to your
+event data, but it does let them spam your project's quota with
+fake events (a soft denial-of-quality, not a confidentiality
+breach).
+
+### Procedure
+
+```bash
+# 1. At sentry.io → Project Settings → Client Keys (DSN) → Create
+#    New Key. The new DSN is shown on creation; capture it.
+
+# 2. Push to Fly:
+fly secrets set --app panorama-staging \
+    SENTRY_DSN="$NEW_SENTRY_DSN"
+
+# 3. Wait for rolling deploy.
+
+# 4. At sentry.io — revoke (delete) the OLD client key.
+```
+
+### Blast radius
+
+- **Briefly missed events** during the rolling deploy as the SDK
+  re-initializes. Acceptable trade-off; the SDK buffers in-flight
+  events for `BUFFER_DEPTH` seconds (default 30s) and flushes them
+  on shutdown. The post-rotation worker picks up event reporting
+  with the new DSN.
+- **No effect on tenants or end users.** Sentry reporting is
+  observational; it never gates a request or alters response
+  behavior.
+
+### Verification
+
+```bash
+# 1. Trigger an intentional error and confirm it lands in Sentry
+#    under the NEW key:
+fly ssh console --app panorama-staging \
+    --command "curl -X POST https://api.panorama.example/_test/sentry"
+# (If no test endpoint exists, the next real 5xx will surface in
+# Sentry; check the Issues panel.)
+
+# 2. Confirm the OLD key has stopped receiving events: in Sentry,
+#    view the deleted-key event history. Should taper to zero
+#    within 30s of the rotation window.
+```
+
+### Rollback
+
+Restore the old DSN in Fly:
+
+```bash
+fly secrets set --app panorama-staging \
+    SENTRY_DSN="$OLD_SENTRY_DSN"
+```
+
+If the OLD DSN was already deleted at Sentry, re-create it (Sentry
+supports up to 5 client keys per project; deleting a key removes
+it but a new key can take its place). Note the rotation in Sentry's
+audit log if the project has it enabled.
+
+## TURNSTILE_SECRET — Cloudflare Turnstile (self-serve signup CAPTCHA)
+
+Per [ADR-0020 §5](../adr/0020-self-serve-signup.md). Consumed
+**only when `FEATURE_SELF_SERVE_SIGNUP=true`**. Self-hosts that
+keep the signup flag off can rotate or omit `TURNSTILE_SECRET`
+without effect.
+
+A leak of the secret lets the holder verify Turnstile tokens
+against Cloudflare's API on the operator's behalf — there is no
+data exfiltration risk; the threat is **signup-protection bypass**
+(an attacker scripting against the leaked secret can verify their
+own captcha tokens locally without ever interacting with the
+human-facing CAPTCHA widget).
+
+### Procedure
+
+```bash
+# 1. At Cloudflare dashboard → Turnstile → your site → Settings →
+#    rotate secret key. Cloudflare keeps the prior secret valid
+#    briefly during rotation; the dashboard shows the exact window.
+
+# 2. Push to Fly:
+fly secrets set --app panorama-hosted \
+    TURNSTILE_SECRET="$NEW_TURNSTILE_SECRET"
+
+# 3. Wait for rolling deploy.
+
+# 4. At Cloudflare — revoke the OLD secret after the rolling deploy
+#    completes.
+```
+
+### Blast radius
+
+- **In-flight signup attempts** mid-CAPTCHA-verification (between
+  the widget completing and Panorama's siteverify POST) fail their
+  CAPTCHA verification. UX: the user re-tries from the homepage form;
+  Cloudflare issues them a fresh challenge. Per ADR-0020 §5's
+  constant-latency 400 envelope, the failure is indistinguishable
+  from a normal rate-limit trip.
+- **Signup endpoint refuses to start without the secret** when
+  `FEATURE_SELF_SERVE_SIGNUP=true` (boot guard in
+  `apps/core-api/src/modules/signup/signup.config.ts:44-48`). A
+  rolling deploy that pushes the new secret to only some replicas
+  results in the secret-missing replicas refusing to boot — an
+  obvious failure mode caught by the rolling deploy's health
+  checks. Same-secret-on-all-replicas is the only viable steady
+  state.
+
+### Verification
+
+```bash
+# 1. Submit a real signup from a fresh browser on the homepage
+#    form. Confirm Cloudflare's widget renders, the user completes
+#    the challenge, and the signup proceeds (or fails for unrelated
+#    reasons — e.g., domain restrictions).
+
+# 2. Check the audit log for the signup attempt:
+psql "$DATABASE_PRIVILEGED_URL" \
+    -c "SELECT id, action, occurredAt FROM audit_events
+        WHERE action LIKE 'panorama.signup.%'
+        AND occurredAt >= NOW() - INTERVAL '10 minutes'
+        ORDER BY id DESC"
+```
+
+### Rollback
+
+```bash
+fly secrets set --app panorama-hosted \
+    TURNSTILE_SECRET="$OLD_TURNSTILE_SECRET"
+```
+
+If the OLD secret was already revoked at Cloudflare, signup is
+broken until you generate a fresh secret. Self-hosters can
+temporarily disable the signup endpoint by setting
+`FEATURE_SELF_SERVE_SIGNUP=false` while they work the recovery.
+
+## Cross-cutting concerns
+
+### Integration with the restore drill
+
+Once `docs/runbooks/restore.md` lands in Round 6 PR2, the restore
+drill will exercise a full reconstitution from a database backup
+into a clean environment. Rotation procedures interact with the
+drill in two places:
+
+- **Pre-drill:** the drill scenario assumes the secrets in the
+  restore target are *fresh* (rotated at restore time, not copied
+  from production). The drill's setup step issues new credentials
+  for each secret class, not because production rotation is
+  required, but because the restored environment must be sealed
+  from production traffic by construction.
+- **Post-drill:** the drill's verification step asserts that all
+  per-secret rotation procedures still pass. A drift between this
+  runbook and the actual platform UIs (Supabase reset password
+  moving locations, Cloudflare R2 token form re-shaped) gets caught
+  during the quarterly drill.
+
+`restore.md` will cross-reference this runbook for each per-secret
+step. Until `restore.md` lands, treat this section as a forward
+reference.
+
+### Multi-replica rolling-deploy hazards
+
+Two failure modes recur across the secrets in this runbook:
+
+1. **Partial rollout state.** Some replicas have the new secret;
+   some still have the old. Symptoms differ per secret:
+   - SESSION_SECRET: silent logout for users routed to old
+     replicas.
+   - DATABASE_*: connection-pool errors on the old replicas.
+   - OIDC: in-flight token exchanges fail on old replicas.
+   - Sentry / Turnstile: silent drift (events to the wrong project;
+     CAPTCHA tokens reject).
+2. **Failed health check on new secret.** The new value is wrong
+   (typo, truncated, wrong-secret-paste). The rolling deploy halts
+   at the first failing instance and rolls back; the running
+   instances stay on the OLD value, so traffic is unaffected. This
+   is the *good* failure mode — `fly deploy` makes it the default.
+
+Best practice: every rotation runs through the rolling deploy +
+`/health` check. Never `fly secrets set --stage` then forget to
+`fly deploy`.
+
+### Rotation hygiene cadence
+
+Until a managed scheduler exists, rotation cadence depends on the
+operator's calendar. Recommended baseline:
+
+| Secret class | Cadence |
+|---|---|
+| SESSION_SECRET (Path B) | Quarterly |
+| DATABASE_APP_PASSWORD | Quarterly |
+| Pooler password (DATABASE_URL/DIRECT/PRIVILEGED) | Annually |
+| OIDC client secrets | When the IdP forces it (Microsoft Entra: 24 months) |
+| S3 access/secret key | Annually |
+| SMTP credentials | When the provider forces it |
+| REDIS_URL token | Annually |
+| SENTRY_DSN | Annually (or after a confirmed leak) |
+| TURNSTILE_SECRET | Annually |
+
+A GitHub Actions cron-driven `secrets-rotation-due` issue opener is
+a Round 7 follow-up to enforce the cadence. Until it lands, the
+operator's `.calendar` is the only schedule.
 
 ## Multi-tenant rotation orchestration
 
-Rotating `SESSION_SECRET` across a fleet of hosted-tenant instances
+Rotating any secret across a fleet of hosted-tenant instances
 simultaneously — with audit emission per tenant, scheduled rotation
 queues, and per-customer rotation reports — is a managed-service
-concern and ships in the Enterprise edition. See the
+concern and ships in the **Enterprise edition**. See the
 [feature matrix](../en/feature-matrix.md) row 24 (Observability +
 managed bundle) for the Community-vs-Enterprise positioning. The
-single-tenant procedure above is the Community surface and the
+single-tenant procedures above are the Community surface and the
 self-hoster contract.
+
+## What this runbook does NOT cover
+
+- **Restore drill execution** — `restore.md` ships in Round 6 PR2.
+  Once it lands, follow that runbook for the dump → restore →
+  verify cycle. Cross-reference this runbook from there for each
+  per-secret refresh.
+- **LGPD ANPD notification.** The secret-leak threshold and the
+  3-business-day clock live in [`incident.md`](./incident.md)
+  Phase 4 §"P0 — Critical". This runbook is the *containment*
+  primitive; legal notification is incident.md's job.
+- **Secret managers (Vault, Doppler, Infisical).** Self-hosters
+  using one substitute their manager's set-secret command for the
+  `fly secrets set` step in each procedure; the shape of the
+  rotation is unchanged. The choice of secret manager is the
+  operator's, not Panorama's.
+- **Cloud provider account-level credential rotation** (Cloudflare
+  account token, Fly token, AWS account root). Those are platform
+  ops outside the Panorama deployment's scope. Rotate per the
+  provider's IAM documentation.
+- **Hardware security modules / KMS-managed signing.** Out of
+  scope for the Community edition; an HSM-integrated rotation
+  flow lives behind the Enterprise managed-service surface and is
+  not documented here.
+- **Physical / device security.** Laptops, hardware tokens, YubiKeys
+  used to gate the operator's IdP-side access — handled per the
+  operator's security baseline, not via this runbook.

--- a/docs/runbooks/secrets-rotation.md
+++ b/docs/runbooks/secrets-rotation.md
@@ -25,19 +25,90 @@ the same shape:
 The runbook covers the **Community / single-operator** rotation
 contract. The fleet-wide managed-service variant (one rotation
 across many hosted customer instances at once, with audit emission
-per tenant and a per-customer rotation report) ships in the
+per tenant and a per-customer rotation report) **will ship** in the
 **Enterprise edition** — see the [§Multi-tenant rotation
 orchestration](#multi-tenant-rotation-orchestration) section at the
-end.
+end. Today, Panorama is pre-revenue and Community-only; the
+Enterprise positioning here is forward-looking, not a feature
+present in main.
+
+## Quick navigation
+
+Jump directly to the secret you need to rotate:
+
+- [SESSION_SECRET](#session_secret--iron-session-cookie-encryption-key)
+- [DATABASE pooler password](#database_url--database_direct_url--database_privileged_url--supabase-pooler--direct-connections)
+- [DATABASE_APP_PASSWORD](#database_app_password--panorama_app-role-password)
+- [OIDC client secrets](#oidc_google_client_secret--oidc_microsoft_client_secret--idp-credentials)
+- [S3 / R2 credentials](#s3_access_key--s3_secret_key--object-storage-credentials)
+- [SMTP credentials](#smtp_user--smtp_password--outbound-email-credentials)
+- [REDIS_URL](#redis_url--upstash-connection-url)
+- [SENTRY_DSN](#sentry_dsn--error-reporting-endpoint)
+- [TURNSTILE_SECRET](#turnstile_secret--cloudflare-turnstile-self-serve-signup-captcha)
+
+Cross-cutting topics:
+
+- [Multi-replica rolling-deploy hazards](#multi-replica-rolling-deploy-hazards)
+- [Rotation cadence baseline](#rotation-hygiene-cadence)
+- [What this runbook does NOT cover](#what-this-runbook-does-not-cover)
 
 ## Decision tree — which path?
 
 | Trigger | Path |
 |---|---|
-| Suspected leak (committed `.env` file, departing administrator with shell access, accidental log dump) | **Emergency path** for the leaked secret — invalidates sessions and revokes the leaked credential at the issuer. Skip the wait step. |
+| Suspected leak (committed `.env` file, departing administrator with shell access, accidental log dump, **leaked backup** containing the secret) | **Emergency path** for the leaked secret. Every per-secret section below has a "When to rotate" subtable that calls out the emergency-path variant — typically "revoke OLD at the provider FIRST, then push NEW to Panorama". Accept in-flight failure cost in exchange for closing the leak window. |
 | Scheduled rotation (quarterly hygiene per org policy) | **Routine path** for each secret — zero-downtime where the secret supports it (SESSION_SECRET via `_PREVIOUS`), short-window for the rest. |
-| Active incident already in [Phase 3 Contain](./incident.md#phase-3--contain) | Follow that phase's decision tree. It dispatches into this runbook per-secret; the entry points there are the section anchors below. |
+| Active incident already in [Phase 3 Contain](./incident.md#phase-3--contain) | Follow that phase's decision tree. It dispatches into this runbook per-secret; the entry points there are the section anchors above (§Quick navigation). |
 | New self-host bringing up first deployment | No rotation needed — generate fresh values from scratch per [`secrets-inventory.md`](./secrets-inventory.md). |
+
+## Before you start any rotation — capture the OLD value
+
+Every section below assumes you have the OLD secret captured in a
+shell variable before you overwrite it. The procedure blocks
+default to `OLD_<SECRET>` as the variable name. Capture it FIRST so
+you have a rollback target if the new value doesn't work:
+
+```bash
+# Pattern — adapt per secret.
+OLD_SESSION_SECRET=$(grep '^SESSION_SECRET=' .env | cut -d= -f2-)
+[[ -n "$OLD_SESSION_SECRET" ]] || { echo "OLD empty; abort" >&2; exit 1; }
+```
+
+For credentials that live on Fly secrets (not `.env`), the OLD
+value is NOT recoverable from `fly secrets list` (Fly never
+re-exposes a set secret). You MUST capture from your secret-manager
+of record (1Password, Vault, Doppler) before issuing the new value.
+If you cannot capture the OLD value, treat the rotation as a
+**one-shot** — failure means re-issuing fresh credentials at the
+provider, not rolling back.
+
+## Shell-history hygiene
+
+Several commands below interpolate secret values into argv (`psql
+-c "ALTER ROLE … WITH PASSWORD '$NEW'"`, `DATABASE_URL=...$NEW...
+fly secrets set`). Bash history (`$HISTFILE`), shell process
+listing (`ps`, `/proc/<pid>/cmdline`), and any eBPF or audit
+daemon collect these. Two ways to mitigate:
+
+```bash
+# 1. Prefix every secret-bearing command with a leading space and
+#    set HISTCONTROL=ignorespace at the top of your shell session:
+HISTCONTROL=ignorespace
+ psql "$URL_WITH_PASSWORD" -c "ALTER ROLE panorama_app WITH PASSWORD '$NEW'"
+# The leading space + HISTCONTROL keeps it out of $HISTFILE.
+
+# 2. Preferred for ALTER ROLE: use the `\password` meta-command in
+#    an interactive psql session — never echoed to argv or history:
+psql "$DATABASE_PRIVILEGED_URL"
+# At the psql prompt:
+panorama=# \password panorama_app
+# Postgres prompts (hidden input) for the new password.
+```
+
+The procedures below show the argv form for copy-paste density; the
+`\password` alternative is preferred for production. Per-section
+notes flag where the argv form has unavoidable exposure (e.g., the
+`DATABASE_URL` string embeds the password and there is no `\` shortcut).
 
 ## SESSION_SECRET — iron-session cookie encryption key
 
@@ -98,6 +169,7 @@ fresh primary.
 
 ```bash
 OLD=$(grep '^SESSION_SECRET=' .env | cut -d= -f2-)
+[[ -n "$OLD" ]] || { echo "OLD SESSION_SECRET empty; aborting rotation" >&2; exit 1; }
 NEW=$(node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))")
 sed -i "s|^SESSION_SECRET=.*|SESSION_SECRET=$NEW|" .env
 sed -i "s|^SESSION_SECRET_PREVIOUS=.*|SESSION_SECRET_PREVIOUS=$OLD|" .env
@@ -193,23 +265,55 @@ rotate one without the others. The `panorama_app` role password
 | Quarterly hygiene | **Path B — routine** below |
 | Supabase support rotated it for you (regional incident, account compromise) | The change is already done provider-side; only the Panorama-side `fly secrets set` is left |
 
+### Pre-flight — capture OLD
+
+The Supabase pooler password is **NOT recoverable** post-reset
+(Supabase replaces it; it never re-exposes the previous value).
+Capture the current state into your secret-manager-of-record BEFORE
+clicking "Reset" in the Supabase dashboard:
+
+```bash
+# Fetch current Fly secrets digest (Fly returns the SHA, never the value):
+fly secrets list --app panorama-staging | grep DATABASE_
+
+# The values themselves must come from your secret manager; if not
+# stored anywhere, the rotation is one-shot (no rollback). Document
+# the rotation in your runbook log so future ops know the previous
+# state is gone.
+
+# Capture the local .env.staging if you have one:
+OLD_POOLER_URL=$(grep '^DATABASE_URL=' apps/core-api/.env.staging | cut -d= -f2-)
+OLD_DIRECT_URL=$(grep '^DATABASE_DIRECT_URL=' apps/core-api/.env.staging | cut -d= -f2-)
+: "${OLD_POOLER_URL:?capture OLD before proceeding — no rollback otherwise}"
+```
+
 ### Path A — Emergency rotation
 
 Rotation on Supabase managed Postgres is **not zero-downtime**:
 every connection in the pool must reconnect under the new password.
 For a single-replica Community deployment this is a 5-10s blip; for
-a Fly multi-replica it's a rolling-deploy window.
+a Fly multi-replica it's a rolling-deploy window (single-minutes per
+replica × replica count).
 
 ```bash
 # 1. Supabase dashboard → Project Settings → Database → "Reset
 #    database password". Capture the new pooler URL (a single string
 #    that contains the password and the hostname); the form gives
 #    you the pooler URL (port 6543) and the direct URL (port 5432).
-#
-# 2. Locally regenerate the .env.staging from the new pooler URL:
-./scripts/setup-staging-env.sh
 
-# 3. Push to Fly:
+# 2. Verify NEW_POOLER_URL + NEW_DIRECT_URL are set in your shell
+#    before pushing — `fly secrets set` with an unset variable
+#    blanks the secret silently.
+: "${NEW_POOLER_URL:?set this from Supabase Reset dialog}"
+: "${NEW_DIRECT_URL:?set this from Supabase Reset dialog}"
+
+# 3. Locally regenerate the .env.staging from the new pooler URL:
+./scripts/setup-staging-env.sh
+# `setup-staging-env.sh` reads NEW_POOLER_URL + NEW_DIRECT_URL from
+# your shell and writes apps/core-api/.env.staging. See
+# scripts/setup-staging-env.sh for the exact shape.
+
+# 4. Push to Fly:
 fly secrets set --app panorama-staging \
     DATABASE_URL="$NEW_POOLER_URL" \
     DATABASE_DIRECT_URL="$NEW_DIRECT_URL" \
@@ -217,7 +321,12 @@ fly secrets set --app panorama-staging \
 # `fly secrets set` triggers an automatic redeploy; for rolling
 # behavior add `--stage` then `fly deploy --strategy rolling`.
 
-# 4. Watch the rolling deploy until every instance reports healthy.
+# 5. Watch the rolling deploy until every instance reports healthy.
+#    "Healthy" = `State` column reads `started` AND `Health Check`
+#    column reads `[1/1 passing]` (or higher passing/total ratio
+#    for multi-check apps). The `fly status` output shape varies
+#    by CLI version; if uncertain, follow with `fly checks list
+#    --app panorama-staging` for the explicit per-check view.
 fly status --app panorama-staging
 ```
 
@@ -283,18 +392,40 @@ Supabase-provided role, then Panorama's runtime authenticates as
 `panorama_app` via the connection string in `DATABASE_URL` after
 the pooler hands off.
 
+### Pre-flight — capture OLD
+
+```bash
+OLD_APP_PASSWORD=$(grep '^DATABASE_APP_PASSWORD=' apps/core-api/.env.staging | cut -d= -f2-)
+: "${OLD_APP_PASSWORD:?capture OLD before proceeding — no rollback otherwise}"
+```
+
 ### Procedure
+
+> **Shell-history hygiene.** The `psql -c "ALTER ROLE … '$NEW'"`
+> form below interpolates the new password into argv. Either
+> (a) prefix every line with a leading space + set
+> `HISTCONTROL=ignorespace` at session start, OR (b) issue the
+> ALTER inside an interactive `psql` session via `\password
+> panorama_app` (preferred — no echo, no argv exposure). See the
+> §Shell-history hygiene section at the top of this runbook.
 
 ```bash
 # 1. Generate new app-role password.
 NEW=$(node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))")
+: "${NEW:?random generation failed — abort}"
 
-# 2. Connect to the DB as the privileged role (Supabase dashboard
-#    SQL editor, or psql on $DATABASE_PRIVILEGED_URL):
-psql "$DATABASE_PRIVILEGED_URL" \
-    -c "ALTER ROLE panorama_app WITH PASSWORD '$NEW'"
+# 2. Connect to the DB as the privileged role and rotate.
+#    Preferred: interactive \password (no argv echo).
+#    Fallback: -c form, requires HISTCONTROL=ignorespace + leading space.
+ psql "$DATABASE_PRIVILEGED_URL" -c "ALTER ROLE panorama_app WITH PASSWORD '$NEW'"
 
-# 3. Update the env on Fly:
+# 3. Update the env on Fly.
+#    : "${POOLER_HOST:?set to your Supabase pooler hostname}" — the host
+#    portion comes from the Supabase dashboard's Connection Pooler
+#    section. Treat this command as the bottleneck: both lines must
+#    succeed atomically or the next deploy boots with a stale
+#    DATABASE_URL embedding the OLD password.
+: "${POOLER_HOST:?set POOLER_HOST first}"
 fly secrets set --app panorama-staging \
     DATABASE_APP_PASSWORD="$NEW" \
     DATABASE_URL="postgres://panorama_app:$NEW@$POOLER_HOST:6543/postgres?schema=public"
@@ -310,14 +441,20 @@ fly deploy --strategy rolling --app panorama-staging
 
 ### Blast radius
 
-- **No connection-pool blip** if you set the secret + redeploy in
-  one `fly secrets set` call (the new password takes effect on the
-  next pool connect, and the rolling deploy issues fresh
-  connections).
-- **Pool of in-flight requests** authenticated under the old
-  password continue to work until their connection is recycled.
-  Prisma's idle-connection recycler closes them within
-  `connection_limit` cycles; no manual intervention needed.
+- **Single-replica Community deploy:** "No connection-pool blip" if
+  you set the secret + redeploy in one `fly secrets set` call. The
+  new password takes effect on the next pool connect; the rolling
+  deploy issues fresh connections.
+- **Multi-replica Fly deploys:** `ALTER ROLE` is immediate at the
+  DB. Replicas not yet redeployed during the rolling deploy will
+  exhaust their pool with auth failures within `connection_limit`
+  cycles (default 10 connections; Prisma recycles on auth-failure).
+  Use `fly deploy --strategy rolling` and accept the same per-replica
+  blip as the §DATABASE pooler section above (single-minutes per
+  replica × replica count).
+- **In-flight requests** authenticated under the old password
+  continue to work until their connection is recycled. No manual
+  intervention needed.
 - **`bootstrap.sql` and `apply-migrations.sh`** do not use the app
   role, so migration tooling is unaffected.
 
@@ -333,16 +470,28 @@ fly ssh console --app panorama-staging \
 fly ssh console --app panorama-staging \
     --command "psql \$DATABASE_URL -c 'SHOW row_security'"
 # Expected output: row_security = on
+
+# 3. Confirm the rotation landed in the audit trail.
+psql "$DATABASE_PRIVILEGED_URL" -c \
+  "SELECT id, action, \"occurredAt\" FROM audit_events
+   WHERE action LIKE 'panorama.role.%'
+   AND \"occurredAt\" >= NOW() - INTERVAL '15 minutes'
+   ORDER BY id DESC LIMIT 10"
+# Note: there is no audit-action emitted for ALTER ROLE today —
+# rotation events at the DB role layer are not yet wired into the
+# audit chain. The query above will return zero rows; the empty
+# result IS the current expected output. Track the gap in
+# panorama-issues #235 follow-up.
 ```
 
 ### Rollback
 
 ```bash
-psql "$DATABASE_PRIVILEGED_URL" \
-    -c "ALTER ROLE panorama_app WITH PASSWORD '$OLD'"
+: "${OLD_APP_PASSWORD:?cannot rollback — OLD was not captured pre-flight}"
+ psql "$DATABASE_PRIVILEGED_URL" -c "ALTER ROLE panorama_app WITH PASSWORD '$OLD_APP_PASSWORD'"
 fly secrets set --app panorama-staging \
-    DATABASE_APP_PASSWORD="$OLD" \
-    DATABASE_URL="postgres://panorama_app:$OLD@$POOLER_HOST:6543/postgres?schema=public"
+    DATABASE_APP_PASSWORD="$OLD_APP_PASSWORD" \
+    DATABASE_URL="postgres://panorama_app:$OLD_APP_PASSWORD@$POOLER_HOST:6543/postgres?schema=public"
 ```
 
 ## OIDC_GOOGLE_CLIENT_SECRET / OIDC_MICROSOFT_CLIENT_SECRET — IdP credentials
@@ -357,13 +506,13 @@ client identity.
 
 ### When to rotate
 
-| Trigger | Path |
+| Trigger | Path A or B |
 |---|---|
-| Suspected leak | Emergency path; the procedure is the same as routine but the IdP-side revoke step must precede the Panorama-side set step |
-| IdP-driven rotation (Google or Microsoft expiring the secret on schedule, common for Microsoft Entra) | Routine path; the IdP gives you a window with both secrets active |
-| Quarterly hygiene | Routine path |
+| Suspected leak | **Path A — emergency**: revoke the OLD secret at the IdP FIRST (accept the in-flight-failure cost), THEN set NEW + deploy. The leak window closes immediately at revoke. |
+| IdP-driven rotation (Google or Microsoft expiring the secret on schedule, common for Microsoft Entra) | **Path B — routine**: create NEW at IdP first (both secrets active per provider), set NEW on Fly + deploy, then revoke OLD at the IdP. |
+| Quarterly hygiene | **Path B — routine** |
 
-### Procedure
+### Procedure (Path B — routine, both-secrets-active window)
 
 ```bash
 # 1. At the IdP — Google Cloud Console (Google) or Azure portal
@@ -376,26 +525,46 @@ client identity.
 #    immediately into your secret manager before navigating away.
 #    Google shows it indefinitely under the OAuth client.
 
-# 2. Push the new secret to Fly:
+# 2. Verify NEW_*_SECRET is set in your shell before pushing.
+:  "${NEW_GOOGLE_SECRET:?capture from Google Cloud Console first}"
+# (or NEW_MICROSOFT_SECRET for the Microsoft side)
+
+# 3. Push the new secret to Fly:
 fly secrets set --app panorama-staging \
     OIDC_GOOGLE_CLIENT_SECRET="$NEW_GOOGLE_SECRET"
-# (or OIDC_MICROSOFT_CLIENT_SECRET for the Microsoft side)
 
-# 3. Wait for the rolling deploy to complete:
+# 4. Wait for the rolling deploy to complete:
 fly status --app panorama-staging
+# Wait for `State = started` + `Health Check = [N/N passing]` on
+# every instance before continuing.
 
-# 4. At the IdP — revoke the OLD secret. From this point forward,
+# 5. At the IdP — revoke the OLD secret. From this point forward,
 #    only the new secret is accepted by the IdP for token exchange.
 #    Order matters: revoking before Panorama has the new secret in
 #    effect breaks every in-flight OIDC dance.
 ```
 
+### Procedure (Path A — emergency, leak-closing variant)
+
+```bash
+# 1. At the IdP — revoke the OLD client secret IMMEDIATELY. From
+#    this moment, in-flight OIDC dances (users mid-login) fail at
+#    the token-exchange step.
+# 2. Generate a new secret at the same IdP.
+# 3. Push to Fly (steps 2-4 of Path B above).
+```
+
 ### Blast radius
 
-- **In-flight OIDC dances** (a user mid-login) running against the
-  old secret fail at the token-exchange step. They retry the login
-  and succeed under the new secret. UX: one extra "log in" click,
-  no data loss.
+- **Path B in-flight OIDC dances** (a user mid-login) running
+  against the old secret fail at the token-exchange step ONLY in
+  the gap between the IdP revoking OLD and the rolling deploy
+  reaching the user's replica. Typical window: seconds. The user
+  retries the login and succeeds under the new secret. UX: one
+  extra "log in" click, no data loss.
+- **Path A** widens that window to the rolling-deploy window
+  (single-minutes per replica). Every in-flight login during the
+  window fails; the user retries once the new secret is live.
 - **Active sessions** are unaffected. OIDC client secrets are used
   only at the initial auth code → token exchange; session cookies
   are minted by Panorama from that token, not by the IdP. Existing
@@ -412,9 +581,13 @@ fly status --app panorama-staging
 #    Open https://panorama.example/login → click Google → consent →
 #    callback should succeed. Confirm a session cookie is issued.
 #
-# 2. Check that the audit log emitted the login event:
+# 2. Check that the audit log emitted the login event.
+#    NOTE: do NOT expand the SELECT with `*` or `metadata` — the
+#    audit `metadata` JSONB on session-started rows holds IP and
+#    user-agent (per AuditEventInput); pulling it into operator
+#    scrollback exposes PII unnecessarily.
 psql "$DATABASE_PRIVILEGED_URL" \
-    -c "SELECT id, action, occurredAt FROM audit_events
+    -c "SELECT id, action, \"occurredAt\" FROM audit_events
         WHERE action = 'panorama.auth.session_started'
         ORDER BY id DESC LIMIT 5"
 ```
@@ -422,7 +595,7 @@ psql "$DATABASE_PRIVILEGED_URL" \
 ### Rollback
 
 Re-set the old secret in Fly + at the IdP (don't revoke the OLD
-secret in step 4 above if you're not confident the new one works
+secret in step 5 above if you're not confident the new one works
 end-to-end). Restore the previous active client on Google/Microsoft.
 
 ## S3_ACCESS_KEY / S3_SECRET_KEY — object storage credentials
@@ -436,13 +609,13 @@ forgery or DB access.
 
 ### When to rotate
 
-| Trigger | Path |
+| Trigger | Path A or B |
 |---|---|
-| Suspected leak | Emergency path; provider-side revoke before Panorama-side set |
-| Quarterly hygiene | Routine path; both keys active during the rolling deploy |
-| Bucket migration (changing buckets / providers) | Routine path for the new credentials; the OLD credentials may be retired immediately after migration is verified |
+| Suspected leak | **Path A — emergency**: revoke OLD at the provider FIRST. The provider invalidates every signature bound to the OLD credential immediately on revoke — in-flight photo downloads/uploads on driver phones fail. Accept this; the OLD credential is in attacker hands. |
+| Quarterly hygiene | **Path B — routine**: create NEW, push to Fly, deploy, then revoke OLD. Both credentials active during the rolling deploy. |
+| Bucket migration (changing buckets / providers) | Path B for the new credentials; the OLD credentials may be retired immediately after migration is verified |
 
-### Procedure
+### Procedure (Path B — routine)
 
 ```bash
 # 1. At Cloudflare R2 → API Tokens → "Create R2 API token". Scope
@@ -454,27 +627,54 @@ forgery or DB access.
 #    "Create access key". For other providers: their equivalent
 #    flow.)
 
-# 2. Push the new credentials to Fly:
+# 2. Verify NEW vars are set in your shell.
+: "${NEW_ACCESS_KEY:?capture from R2 dashboard first}"
+: "${NEW_SECRET_KEY:?capture from R2 dashboard first}"
+
+# 3. Push the new credentials to Fly:
 fly secrets set --app panorama-staging \
     S3_ACCESS_KEY="$NEW_ACCESS_KEY" \
     S3_SECRET_KEY="$NEW_SECRET_KEY"
 
-# 3. Wait for the rolling deploy:
+# 4. Wait for the rolling deploy:
 fly status --app panorama-staging
 
-# 4. At Cloudflare R2 (or your provider) — revoke the OLD token.
+# 5. At Cloudflare R2 (or your provider) — revoke the OLD token.
+#    From this moment, every signature bound to OLD is rejected
+#    (see Blast radius below).
+```
+
+### Procedure (Path A — emergency)
+
+```bash
+# 1. At Cloudflare R2 — revoke the OLD token IMMEDIATELY.
+#    Every signed URL minted under OLD is now invalid; in-flight
+#    photo upload + download requests fail with SignatureDoesNotMatch.
+# 2. Create a NEW token (steps 1-4 of Path B above).
+# 3. Push to Fly + deploy.
 ```
 
 ### Blast radius
 
-- **Existing pre-signed URLs minted under the OLD credential
-  continue to work until their TTL expires** — the URL embeds the
-  signature, which is bound to the credential that minted it. Photo
-  download URLs default to `signedUrlTtlSeconds` (typically 60s) per
-  `apps/core-api/src/modules/object-storage/object-storage.service.ts:237-249`;
-  tenant-export download URLs run up to 24h per ADR-0020 §8.
-  Driver phones with a cached presigned URL keep working until that
-  TTL ticks down.
+- **Existing pre-signed URLs are invalidated immediately when the
+  OLD credential is revoked at the provider.** R2 / S3 reject any
+  SigV4 signature bound to a revoked access-key regardless of the
+  URL's `X-Amz-Expires` TTL. During Path B's "both-credentials-active"
+  window (step 3 deploy → step 5 revoke), URLs minted under OLD
+  continue to work. After step 5 revoke, they are dead. This
+  differs from the SESSION_SECRET model, where the cookie payload
+  carries its own state and the SECRET only matters at decode time.
+- **Pre-signed URL TTLs in Panorama today:**
+  - Photo download URLs default to `signedUrlTtlSeconds` (typically
+    60s) per `apps/core-api/src/modules/object-storage/object-storage.service.ts:237-249`
+    (thumbnails 60s; full-size per config).
+  - Tenant-export download URLs are **60s** per
+    `apps/core-api/src/modules/tenant-export/tenant-export.config.ts:35`
+    (`downloadUrlTtlSeconds`). The 24h figure in ADR-0020 §8 is the
+    **job download window** (the period during which the Owner can
+    request a fresh 60s URL via `/exports/:jobId/download`),
+    NOT the URL TTL. The runbook previously conflated the two; do
+    not rely on a 24h-presigned-URL claim.
 - **NEW pre-signed URLs minted post-rotation** require the new
   credentials to be live; the rolling deploy is the boundary. A
   driver's photo upload in-flight at the moment of rotation fails
@@ -490,17 +690,17 @@ fly status --app panorama-staging
 #    detail → camera capture → upload) and confirm it lands in R2.
 #
 # 2. Fetch a download URL and confirm it serves the bytes:
+#    : "${DOWNLOAD_URL:?obtain from staging app photo viewer first}"
 fly ssh console --app panorama-staging \
     --command "curl -fsSL '$DOWNLOAD_URL' | head -c 16 | xxd"
 # Expected: JPEG magic bytes ffd8ffe0
 #
-# 3. Check the audit chain for any S3-related operational errors
-#    emitted during the rotation window:
-psql "$DATABASE_PRIVILEGED_URL" \
-    -c "SELECT id, action, metadata FROM audit_events
-        WHERE action LIKE 'panorama.object_storage.%'
-        AND occurredAt >= NOW() - INTERVAL '1 hour'
-        ORDER BY id DESC"
+# 3. Confirm no S3-presigned-failure errors emitted during rotation.
+#    There is no `panorama.object_storage.*` audit-action namespace
+#    in the codebase as of 2026-05-17; the verification surface is
+#    Sentry-side (per ADR-0018) — confirm via the Sentry dashboard
+#    that no `object_storage_presign_failed` events arrived during
+#    the rotation window.
 ```
 
 ### Rollback
@@ -527,13 +727,13 @@ not a data exfiltration risk.
 
 ### When to rotate
 
-| Trigger | Path |
+| Trigger | Path A or B |
 |---|---|
-| Suspected leak | Emergency path; provider-side revoke before Panorama-side set |
-| Quarterly hygiene | Routine path |
-| Provider-driven (SendGrid API key expiry, Postmark token reissue) | Routine path; pair both old + new for the cutover window |
+| Suspected leak (provider credential confirmed compromised) | **Path A — emergency**: revoke OLD at the provider FIRST. In-flight email sends fail until the rolling deploy completes; BullMQ holds the failed jobs in Redis and retries them under the new credentials. |
+| Quarterly hygiene | **Path B — routine**: create NEW at provider, push to Fly + deploy, then revoke OLD. Both credentials active during the rolling deploy. |
+| Provider-driven (SendGrid API key expiry, Postmark token reissue) | Path B — routine; pair both old + new for the cutover window |
 
-### Procedure
+### Procedure (Path B — routine)
 
 ```bash
 # 1. At the SMTP provider (Mailgun / SendGrid / SES / Postmark /
@@ -545,15 +745,30 @@ not a data exfiltration risk.
 #    - Resend: API Keys → "Sending access"
 #    Capture the new SMTP_USER + SMTP_PASSWORD values.
 
-# 2. Push to Fly:
+# 2. Verify NEW vars are set in your shell.
+: "${NEW_SMTP_USER:?capture from provider first}"
+: "${NEW_SMTP_PASSWORD:?capture from provider first}"
+
+# 3. Push to Fly:
 fly secrets set --app panorama-staging \
     SMTP_USER="$NEW_SMTP_USER" \
     SMTP_PASSWORD="$NEW_SMTP_PASSWORD"
 
-# 3. Wait for rolling deploy:
+# 4. Wait for rolling deploy:
 fly status --app panorama-staging
 
-# 4. Revoke the OLD credentials at the provider.
+# 5. Revoke the OLD credentials at the provider.
+```
+
+### Procedure (Path A — emergency)
+
+```bash
+# 1. At the provider — revoke the OLD credentials IMMEDIATELY.
+#    In-flight email sends fail; BullMQ queues the failures.
+# 2. Create NEW credentials at the same provider.
+# 3. Push to Fly + deploy (steps 2-4 of Path B above).
+#    Once the deploy completes, BullMQ retries the queued failures
+#    under the new credentials.
 ```
 
 ### Blast radius
@@ -578,11 +793,14 @@ fly ssh console --app panorama-staging \
 # (Or trigger a real invitation via the app to a known-good
 # recipient.)
 
-# 2. Confirm the notification queue drained any backed-up events:
+# 2. Confirm the notification queue drained any backed-up events.
+#    The notification_events table uses createdAt (not occurredAt);
+#    aggregate by status only — grouping by id would count one per
+#    row.
 psql "$DATABASE_PRIVILEGED_URL" \
-    -c "SELECT id, status, COUNT(*) FROM notification_events
-        WHERE occurredAt >= NOW() - INTERVAL '1 hour'
-        GROUP BY id, status"
+    -c "SELECT status, COUNT(*) FROM notification_events
+        WHERE \"createdAt\" >= NOW() - INTERVAL '1 hour'
+        GROUP BY status"
 # Expected: a row for status = DISPATCHED matching the post-rotation
 # count; status = DEAD only if a permanent failure (not a transient
 # auth error).
@@ -612,35 +830,61 @@ job tampering** — both have downstream blast radius (signup-flood
 defenses dropped, queued tenant exports inspectable) but neither is
 DB-level confidentiality.
 
+### When to rotate
+
+| Trigger | Notes |
+|---|---|
+| Suspected leak | Treat as emergency — Upstash gives no choice; resetting the token invalidates OLD immediately (see Blast radius below). |
+| Annual hygiene | Same procedure; schedule during a low-traffic window with pre-announce on the status page. |
+
+> **Upstash has no two-secret window.** Unlike SESSION_SECRET, OIDC,
+> S3, or SMTP, you cannot have both OLD and NEW credentials
+> simultaneously active. Reset = immediate invalidation. Read the
+> Blast radius before scheduling.
+
 ### Procedure
 
 ```bash
 # 1. At Upstash dashboard → REST → reset token. The dashboard
 #    issues a new URL; the OLD URL is invalidated server-side at
-#    the moment the new one is created (Upstash does NOT support
-#    a transition window).
+#    the moment the new one is created. Capture the new URL into
+#    your shell immediately — Upstash shows it once.
 
-# 2. Push to Fly:
+# 2. Verify the new URL is set.
+: "${NEW_REDIS_URL:?capture from Upstash dashboard first}"
+
+# 3. Push to Fly:
 fly secrets set --app panorama-staging \
     REDIS_URL="$NEW_REDIS_URL"
+# fly deploy --strategy rolling --app panorama-staging is implicit
+# in fly secrets set; check `fly status` afterward.
 ```
 
 ### Blast radius
 
-- **Brief auth errors** during the rolling deploy as BullMQ workers
-  reconnect and rate-limiter clients re-handshake. Per
-  [`secrets-inventory.md`](./secrets-inventory.md) §Redis: "BullMQ
-  workers will see auth errors briefly. This is expected; the
-  rolling deploy resolves it within the deploy window."
-- **Rate-limiter fail-closed:** sliding-window rate-limiters
-  configured to fail-closed on Redis outage (per ADR-0020 §4) will
-  reject signup attempts during the rotation window. Acceptable
-  for a 5-10s blip; not acceptable if the deploy stalls. Watch the
-  status surface during rotation.
-- **In-flight BullMQ jobs:** held in Redis until a worker acks;
-  the new Redis token sees the same Redis instance (Upstash only
-  rotates the *token*, not the underlying instance), so the jobs
-  are visible to the post-rotation worker.
+- **Rate-limiter fail-closed window** = the whole rolling-deploy
+  window, **not** "5-10s". Per ADR-0020 §4 contract:
+  sliding-window rate-limiters fail-closed on Redis outage. From
+  the moment Upstash issues the new token (which invalidates OLD)
+  until the LAST Fly replica has redeployed with the new URL, any
+  replica still on the OLD URL fails its Redis handshake →
+  rate-limiter trips → signup attempts + rate-limited paths
+  (`/auth/signup`, photo upload throttle, invitation send) reject
+  with the standard rate-limit response.
+- **Window duration on Fly:** single-minutes per replica × replica
+  count. For a 1-replica community deploy: ~30-60s. For a
+  3-replica Fly deploy: 2-3 minutes. **Do NOT rotate during a
+  marketing push, known traffic spike, or any business-critical
+  window.** Pre-announce on the status page (once the page exists
+  per Round 7 §9) and target the lowest-traffic window per your
+  analytics.
+- **In-flight BullMQ jobs:** held in Redis server-side until a
+  worker acks. The new Redis token sees the same Redis instance
+  (Upstash only rotates the *token*, not the underlying instance),
+  so queued jobs are visible to the post-rotation worker once it
+  comes up. No job loss.
+- **Brief auth errors** during the deploy — expected, per the
+  contract above.
 
 ### Verification
 
@@ -653,9 +897,20 @@ curl -fsSL https://api.panorama.example/health | jq .redis
 #    invitation send, observe NotificationEvent status flip from
 #    PENDING to DISPATCHED within a minute):
 psql "$DATABASE_PRIVILEGED_URL" \
-    -c "SELECT id, status, occurredAt FROM notification_events
-        WHERE occurredAt >= NOW() - INTERVAL '5 minutes'
+    -c "SELECT id, status, \"createdAt\" FROM notification_events
+        WHERE \"createdAt\" >= NOW() - INTERVAL '5 minutes'
         ORDER BY id DESC LIMIT 10"
+# Note: notification_events uses createdAt (the row write time),
+# not occurredAt — there is no occurredAt column on this table.
+
+# 3. Verify the rate-limiter is back to allow-state:
+curl -fsSL -X POST https://api.panorama.example/auth/signup \
+     -H "Content-Type: application/json" \
+     -d '{"email":"smoke@example.invalid"}' \
+     -w "%{http_code}\n" -o /dev/null
+# Expected: 400 (invalid email — the request hit the handler, not
+# the rate-limiter); a 503 means the rate-limiter is still
+# fail-closed.
 ```
 
 ### Rollback
@@ -665,9 +920,12 @@ fly secrets set --app panorama-staging \
     REDIS_URL="$OLD_REDIS_URL"
 ```
 
-The OLD URL is invalid post-rotation; you must issue a third token
-at Upstash to recover if the new URL doesn't work. Document the
-dead OLD credentials.
+The OLD URL is invalid post-rotation (Upstash invalidated it at
+the moment the new one was created); this rollback only works as
+a "set the same URL again" if you discover NEW was wrong. If the
+NEW URL is genuinely broken (Upstash misconfiguration, network
+unreachable), you must issue a third token at Upstash and use that.
+Document the dead OLD credentials.
 
 ## SENTRY_DSN — error reporting endpoint
 
@@ -684,13 +942,16 @@ breach).
 # 1. At sentry.io → Project Settings → Client Keys (DSN) → Create
 #    New Key. The new DSN is shown on creation; capture it.
 
-# 2. Push to Fly:
+# 2. Verify NEW DSN is set.
+: "${NEW_SENTRY_DSN:?capture from Sentry dashboard first}"
+
+# 3. Push to Fly:
 fly secrets set --app panorama-staging \
     SENTRY_DSN="$NEW_SENTRY_DSN"
 
-# 3. Wait for rolling deploy.
+# 4. Wait for rolling deploy.
 
-# 4. At sentry.io — revoke (delete) the OLD client key.
+# 5. At sentry.io — revoke (delete) the OLD client key.
 ```
 
 ### Blast radius
@@ -754,13 +1015,16 @@ human-facing CAPTCHA widget).
 #    rotate secret key. Cloudflare keeps the prior secret valid
 #    briefly during rotation; the dashboard shows the exact window.
 
-# 2. Push to Fly:
+# 2. Verify NEW secret is set.
+: "${NEW_TURNSTILE_SECRET:?capture from Cloudflare dashboard first}"
+
+# 3. Push to Fly:
 fly secrets set --app panorama-hosted \
     TURNSTILE_SECRET="$NEW_TURNSTILE_SECRET"
 
-# 3. Wait for rolling deploy.
+# 4. Wait for rolling deploy.
 
-# 4. At Cloudflare — revoke the OLD secret after the rolling deploy
+# 5. At Cloudflare — revoke the OLD secret after the rolling deploy
 #    completes.
 ```
 
@@ -791,9 +1055,9 @@ fly secrets set --app panorama-hosted \
 
 # 2. Check the audit log for the signup attempt:
 psql "$DATABASE_PRIVILEGED_URL" \
-    -c "SELECT id, action, occurredAt FROM audit_events
+    -c "SELECT id, action, \"occurredAt\" FROM audit_events
         WHERE action LIKE 'panorama.signup.%'
-        AND occurredAt >= NOW() - INTERVAL '10 minutes'
+        AND \"occurredAt\" >= NOW() - INTERVAL '10 minutes'
         ORDER BY id DESC"
 ```
 
@@ -861,21 +1125,34 @@ Best practice: every rotation runs through the rolling deploy +
 Until a managed scheduler exists, rotation cadence depends on the
 operator's calendar. Recommended baseline:
 
-| Secret class | Cadence |
-|---|---|
-| SESSION_SECRET (Path B) | Quarterly |
-| DATABASE_APP_PASSWORD | Quarterly |
-| Pooler password (DATABASE_URL/DIRECT/PRIVILEGED) | Annually |
-| OIDC client secrets | When the IdP forces it (Microsoft Entra: 24 months) |
-| S3 access/secret key | Annually |
-| SMTP credentials | When the provider forces it |
-| REDIS_URL token | Annually |
-| SENTRY_DSN | Annually (or after a confirmed leak) |
-| TURNSTILE_SECRET | Annually |
+| Secret class | Cadence | Why |
+|---|---|---|
+| SESSION_SECRET (Path B) | Quarterly | Cheapest secret to rotate (zero-downtime via PREVIOUS); high-value target if leaked (every session forge-able); quarterly hygiene is the default for any session-encryption key. |
+| DATABASE_APP_PASSWORD | Quarterly | Single-statement DB-side change + rolling deploy; medium-cost rotation. Role-level password compromise blast radius is high (whole runtime auth path); quarterly tracks the SESSION_SECRET cadence by analogy. |
+| Pooler password (DATABASE_URL/DIRECT/PRIVILEGED) | Annually | Full connection-pool reset → 5-10s blip on single-replica, single-minutes per replica on Fly. Highest-cost rotation in this runbook. Annual is the right trade-off given the cost: Supabase manages the pooler endpoint; the password is the second factor on top of the pooler ACL. |
+| OIDC client secrets | When the IdP forces it (Microsoft Entra: 24 months) | IdP-driven schedule; the IdP itself is the source of truth for expiry. Rotating early gains nothing — the OIDC consent + audit trail is at the IdP. |
+| S3 access/secret key | Annually | Bucket-scope blast radius; provider-side revoke is the leak-closing primitive. Annual is conservative; tighten to quarterly if a self-host operator's environment includes other reasons to rotate (PCI/SOC-2 expectations, customer-mandated cadence). |
+| SMTP credentials | When the provider forces it | Provider-driven; rotation is operationally expensive (in-flight email-send failures) for low marginal security gain. |
+| REDIS_URL token | Annually | Full rate-limiter fail-closed window per rotation (see Blast radius §REDIS); annual is the cost-vs-risk balance. |
+| SENTRY_DSN | Annually (or after a confirmed leak) | Quasi-secret; leak threat is event-injection quota spam, not confidentiality. Annual is conservative. |
+| TURNSTILE_SECRET | Annually | Same model as Sentry — leak threat is signup-protection bypass, not data exfiltration. Annual is the baseline; tighten on confirmed leak. |
 
-A GitHub Actions cron-driven `secrets-rotation-due` issue opener is
-a Round 7 follow-up to enforce the cadence. Until it lands, the
-operator's `.calendar` is the only schedule.
+**Why the SESSION_SECRET vs Pooler password asymmetry.** Both
+are high-value if leaked, but SESSION_SECRET rotation is
+zero-downtime (Path B via `_PREVIOUS`) while Pooler password
+rotation is single-minutes of measurable user-visible impact. The
+cadence reflects rotation *cost*, not blast radius. If you'd
+genuinely rotate Pooler quarterly without measurable cost, do so;
+the recommendation is conservative.
+
+**Tracking gap.** A GitHub Actions cron-driven
+`secrets-rotation-due` issue opener is a Round 7 follow-up to
+enforce the cadence ([panorama-issues#250 — proposed, not yet
+filed at session of writing]). Until it lands, the operator's
+`.calendar` is the only schedule, and "we forgot to rotate" is a
+foreseeable failure mode. Pre-rotation tracking belongs in your
+secret manager (1Password / Vault items have rotation-reminder
+fields).
 
 ## Multi-tenant rotation orchestration
 


### PR DESCRIPTION
## Summary

Expands `docs/runbooks/secrets-rotation.md` from a SESSION_SECRET-only stub (160 lines) into the full per-secret rotation matrix (916 lines), and bundles the `AuditEvent.requestId` column (#229) that lets a triaging operator join audit rows to log lines without inferring by `tenantId + occurredAt`.

Closes the Wave 0 §8 docs gap that Round 6 PR1's `incident.md` Phase 3 forward-referenced. Wave 0 §8 still has PR2 (restore drill) outstanding before §8 closes.

## What's in scope

### Docs — `secrets-rotation.md` (160 → 916 lines)

Per-secret sections added for every secret in `secrets-inventory.md`:

- DATABASE pooler password (DATABASE_URL / DIRECT / PRIVILEGED — they share one Supabase pooler credential)
- DATABASE_APP_PASSWORD (panorama_app role; rotates independently of the pooler)
- OIDC_GOOGLE_CLIENT_SECRET / OIDC_MICROSOFT_CLIENT_SECRET
- S3_ACCESS_KEY / S3_SECRET_KEY
- SMTP_USER / SMTP_PASSWORD
- REDIS_URL (Upstash token in the URL userinfo)
- SENTRY_DSN (per ADR-0018)
- TURNSTILE_SECRET (feature-gated on `FEATURE_SELF_SERVE_SIGNUP`)

Each section follows the same shape: **when to rotate** (decision tree: emergency vs routine vs in-incident), **procedure** (concrete shell commands; Fly + Cloudflare + Supabase by default with self-host substitutes called out), **blast radius** (what breaks during the window and for how long), **verification** (psql queries + curl), **rollback**.

Plus cross-cutting sections: integration with the restore drill (forward reference to PR2), multi-replica rolling-deploy hazards, rotation cadence baseline, multi-tenant orchestration (Enterprise wedge).

The pre-existing SESSION_SECRET Path A + Path B content is preserved verbatim with one line-ref fix (`auth.config.ts:127` → `:169` — the value moved).

### Code — `AuditEvent.requestId` (#229)

- **Migration 0026** (`20260517040000_0026_audit_event_request_id`) — forward-only `ALTER TABLE audit_events ADD COLUMN requestId TEXT NULL`. No backfill, no new index (the existing `(tenantId, occurredAt DESC)` index covers the realistic query shape per data-architect's #229 pre-impl scoping). `COMMENT ON COLUMN` documents the NULL semantics for legacy rows + trigger-emitted rows + non-HTTP code paths.
- **Schema** — mirroring `requestId String?` field on `AuditEvent` with the standard triple-slash comment block.
- **AuditService.recordWithin** — `requestId: currentRequestId()` added to the create payload. `currentRequestId()` is the helper added in PR #226 (ADR-0018 §3 ALS); returns null for code paths outside an HTTP request (BootAuditModule, BullMQ workers, scripts) per the helper's documented contract.
- **NOT in the digest pre-image.** `requestId` is observational metadata, analogous to `ipAddress` / `userAgent` (per migration 0021's header "What it does NOT cover" section). Including it would invalidate every pre-0026 row's chain verification. The new test asserts the pre-image does NOT include `requestId`.

### Test added

A new `it` block in `audit-chain-integrity.e2e.test.ts` that:

1. Wraps an audit write in `runInContext({ requestId: 'req_audit_chain_test_correlation', ... })` and asserts the column is populated to the same value.
2. Asserts `digestPreImage` does NOT contain `requestId` (locks the "not in the digest" invariant).
3. Writes outside a `runInContext` frame and asserts the column is NULL (documents the BootAuditModule / BullMQ / script behaviour).

All 523 tests across 56 files pass; migration applied locally against Supabase staging-style Postgres (Docker compose dev-stack on :5432).

## Out of scope (and why)

- **`restore.md`** — Round 6 PR2. Cross-referenced from this runbook (forward reference); paired in the same Wave 0 §8 acceptance item.
- **Rotation cron / `secrets-rotation-due` issue opener** — Round 7. Listed in the §Rotation hygiene cadence section as a follow-up.
- **`MAINTENANCE_MODE=true` env that returns 503 from middleware** — Round 7 per `incident.md` Phase 3 §"For cross-tenant data leak" forward-reference. Outside the rotation runbook's surface.
- **HSM / KMS-managed signing flows** — Enterprise edition. Explicitly listed in §"What this runbook does NOT cover".

## Wave 0 acceptance impact

- §8 — Round 6 docs progresses: PR1 incident.md ✅, PR3 secrets-rotation matrix ✅, PR2 restore.md + drill report still outstanding. §8 closes once PR2 lands AND the drill is executed by the maintainer with the observed RTO/RPO captured in a follow-up PR2b.

## Refs

- Issue #229 (AuditEvent.requestId column)
- ADR-0018 §3 (RequestContextMiddleware ALS)
- Migration 0021 (audit digest pre-image; established the "observational metadata not in digest" precedent)
- HANDOFF-2026-05-17-round-5-pr2-complete.md §"Triage" (workaround this column replaces)

## Test plan

- [x] `pnpm exec prisma migrate deploy` against local dev-stack — applies cleanly
- [x] `pnpm exec prisma generate` — Prisma client regenerates with new `requestId` field
- [x] `pnpm exec vitest run test/audit-chain-integrity.e2e.test.ts` — 4 tests pass (existing 3 + new requestId test)
- [x] Full core-api suite — 523 tests, 56 files, all pass
- [x] `pnpm docs:build` — VitePress build clean (no broken cross-refs)
- [ ] Per-PR scan: tech-lead + data-architect + security-reviewer + product-lead + persona-fleet-ops in parallel
- [ ] Apply migration 0026 to Supabase staging via `apply-migrations.sh` after merge