### PR TITLE
Round 7 §9 — CycloneDX SBOM + sigstore keyless signing

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,152 @@
+name: SBOM + sigstore signing
+
+# Wave 0 §9 acceptance — Software Bill of Materials + cosign
+# keyless signing.
+#
+# Generates a CycloneDX SBOM from `pnpm install --prod
+# --frozen-lockfile` on every push to main (uploaded as a CI
+# artifact, 90-day retention). On release-tag push (`v*`), the
+# SBOM is signed via cosign keyless (sigstore Fulcio + GitHub OIDC,
+# no key management) and attached to the GitHub release.
+#
+# Self-host operators verify the chain via `cosign verify-blob`
+# against the published certificate + signature. The verification
+# procedure is in `docs/runbooks/sbom-supply-chain.md`.
+#
+# This workflow is procurement-credible supply-chain evidence: any
+# enterprise asking "show me your SBOM" can fetch the artifact
+# directly without a sales call.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'apps/*/package.json'
+      - 'packages/*/package.json'
+      - '.github/workflows/sbom.yml'
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    # Manual trigger for ad-hoc SBOM regeneration (e.g., after a
+    # security advisory drops and you want a fresh dependency
+    # snapshot to share).
+
+permissions:
+  contents: read
+  id-token: write   # required for cosign keyless via GH OIDC
+
+concurrency:
+  group: sbom-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    name: Generate CycloneDX SBOM
+    runs-on: ubuntu-latest
+    outputs:
+      sbom_path: ${{ steps.generate.outputs.sbom_path }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      # Install ONLY production dependencies — the SBOM should
+      # reflect what ships to a self-hoster or hosted instance, not
+      # the devDeps surface (vitest, prettier, etc.) that never
+      # touches a production runtime. `--prod` strips devDeps;
+      # `--frozen-lockfile` ensures reproducibility against
+      # pnpm-lock.yaml exactly.
+      - name: Install production dependencies
+        run: pnpm install --prod --frozen-lockfile
+
+      - name: Generate SBOM via CycloneDX
+        id: generate
+        run: |
+          set -euo pipefail
+          # @cyclonedx/cyclonedx-npm walks the installed node_modules
+          # tree and emits a CycloneDX v1.5 JSON SBOM. Pinned major
+          # version; bump deliberately.
+          pnpm dlx @cyclonedx/cyclonedx-npm@^3 \
+            --output-format JSON \
+            --output-file panorama-sbom.json \
+            --spec-version 1.5 \
+            --short-PURLs \
+            --omit dev \
+            --validate
+          # Emit metadata that the sigstore step + release attachment
+          # consumes.
+          echo "sbom_path=panorama-sbom.json" >> "$GITHUB_OUTPUT"
+          # Brief verification — confirm the file is valid JSON and
+          # has at least the metadata block + a components array.
+          jq -e '.metadata.timestamp and (.components | length > 0)' \
+            panorama-sbom.json > /dev/null
+          components=$(jq '.components | length' panorama-sbom.json)
+          echo "::notice title=SBOM generated::CycloneDX 1.5 JSON, ${components} components"
+
+      - name: Upload SBOM as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: panorama-sbom-${{ github.sha }}
+          path: panorama-sbom.json
+          retention-days: 90
+
+  sign-and-release:
+    name: Cosign keyless sign + attach to release
+    needs: generate
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # attach assets to release
+      id-token: write   # OIDC for cosign keyless
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: panorama-sbom-${{ github.sha }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.7.0
+
+      - name: Sign SBOM (keyless via OIDC)
+        env:
+          COSIGN_EXPERIMENTAL: '1'
+        run: |
+          set -euo pipefail
+          # `cosign sign-blob` with --yes (no interactive prompt) and
+          # OIDC keyless mode. Produces a .sig (detached signature)
+          # and a .crt (the ephemeral certificate issued by Fulcio,
+          # tied to the GH Actions identity that ran the job).
+          # Verifiable via `cosign verify-blob` per the runbook.
+          cosign sign-blob \
+            --yes \
+            --output-signature panorama-sbom.json.sig \
+            --output-certificate panorama-sbom.json.crt \
+            panorama-sbom.json
+
+          echo "::notice title=SBOM signed::keyless via GitHub OIDC, Fulcio cert + Rekor transparency log"
+
+      - name: Attach SBOM + signature + cert to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # gh release upload --clobber lets re-runs replace the
+          # asset (e.g., if we rerun the workflow on the same tag
+          # after fixing a transient flake).
+          gh release upload "$TAG" \
+            panorama-sbom.json \
+            panorama-sbom.json.sig \
+            panorama-sbom.json.crt \
+            --clobber
+
+          echo "::notice title=Release updated::attached SBOM + sig + cert to release $TAG"

--- a/docs/runbooks/sbom-supply-chain.md
+++ b/docs/runbooks/sbom-supply-chain.md
@@ -1,0 +1,230 @@
+# SBOM + supply-chain verification runbook
+
+> **Status.** Round 7 §9 of the Wave 0 plan. Ships the
+> infrastructure now (`.github/workflows/sbom.yml`); the first
+> signed-release tag is operator-side when the maintainer cuts
+> v0.x.
+
+This page tells operators (self-hosters + procurement reviewers +
+the hosted-instance maintainer) how Panorama's Software Bill of
+Materials (SBOM) is generated, signed, distributed, and verified.
+
+The companion artefact is `.github/workflows/sbom.yml` — a CI
+workflow that emits a CycloneDX 1.5 JSON SBOM on every push to
+main and signs it via `cosign sign-blob` keyless (sigstore Fulcio
++ GitHub OIDC, no key management) when a release tag is pushed.
+
+## What the SBOM contains
+
+A CycloneDX JSON document listing every npm dependency Panorama
+installs at runtime, with:
+
+- Package name + version
+- License (when declared in `package.json`)
+- Package URL (PURL) — canonical identifier for the registry source
+- Hashes (when present in the lockfile)
+- Dependency tree relationships
+
+What it does **NOT** contain:
+
+- devDependencies (vitest, prettier, eslint, etc.) — stripped by
+  `pnpm install --prod`. SBOM reflects what ships, not what builds.
+- Postgres / Redis / Docker base-image dependencies. The SBOM is
+  scoped to the Node.js runtime surface; OS-level dependencies
+  live in the container's separate SBOM (out of scope today; see
+  §"What this runbook does NOT cover").
+
+## Where to find the SBOM
+
+### Latest main-branch SBOM (always available)
+
+GitHub Actions tab → `SBOM + sigstore signing` workflow → most
+recent run on `main` → Artifacts → `panorama-sbom-<sha>`.
+
+```
+https://github.com/VitorMRodovalho/panorama/actions/workflows/sbom.yml
+```
+
+90-day retention per GitHub Actions default. Re-runnable via
+`workflow_dispatch` for ad-hoc regeneration after a security
+advisory drops.
+
+### Tagged-release SBOM (signed)
+
+When the maintainer cuts a release tag (`v0.x`, `v1.0`, etc.), the
+workflow:
+
+1. Regenerates the SBOM
+2. Signs it via cosign keyless (GitHub OIDC → Fulcio → ephemeral
+   cert; signature logged to Rekor transparency log)
+3. Attaches three files to the GitHub release:
+   - `panorama-sbom.json` — the SBOM itself
+   - `panorama-sbom.json.sig` — detached signature
+   - `panorama-sbom.json.crt` — Fulcio cert tying the signature
+     to the workflow run that produced it
+
+Releases live at:
+
+```
+https://github.com/VitorMRodovalho/panorama/releases
+```
+
+Each release's Assets section carries the three files.
+
+## How to verify a signed SBOM
+
+Install cosign (one-time setup):
+
+```bash
+# macOS
+brew install cosign
+
+# Linux (Debian/Ubuntu)
+curl -fsSL https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 \
+    -o /usr/local/bin/cosign
+chmod +x /usr/local/bin/cosign
+
+# Verify the install
+cosign version
+```
+
+Verify the SBOM signature:
+
+```bash
+# Download the three files from the release Assets:
+gh release download v0.x -p 'panorama-sbom.json*'
+
+# Verify against the GitHub-OIDC identity that signed.
+# The cert-identity-regexp matches any workflow run on the panorama
+# repo's main branch; the cert-oidc-issuer is the GH Actions OIDC
+# provider.
+cosign verify-blob \
+    --signature panorama-sbom.json.sig \
+    --certificate panorama-sbom.json.crt \
+    --certificate-identity-regexp "https://github.com/VitorMRodovalho/panorama/.github/workflows/sbom.yml@refs/tags/v.*" \
+    --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+    panorama-sbom.json
+# Verified OK
+```
+
+A successful verification proves:
+
+1. The SBOM was produced by the official Panorama CI workflow on
+   the named release tag.
+2. The signing certificate was issued by sigstore Fulcio (not a
+   self-signed cert pretending to be Panorama).
+3. The signing event was logged to the Rekor transparency log —
+   irreversible audit trail visible at
+   [search.sigstore.dev](https://search.sigstore.dev/).
+
+If verification fails: do NOT trust the SBOM. Open a Security
+Advisory at the panorama repo per
+[`SECURITY.md`](../../SECURITY.md). A failed signature on a
+release artefact is a supply-chain compromise signal.
+
+## Using the SBOM for vulnerability scanning
+
+The CycloneDX format is consumed by every major SCA scanner:
+
+- **Trivy:** `trivy sbom panorama-sbom.json`
+- **Grype:** `grype sbom:./panorama-sbom.json`
+- **OWASP Dependency-Track:** upload as a project version
+- **Snyk:** `snyk test --sbom panorama-sbom.json`
+- **JFrog Xray:** consume via the Bill-of-Materials API
+
+The SBOM acts as the input to **your** scanner with **your**
+policy. The maintainer does not run a continuous SBOM-driven
+scanner today (see §"What this runbook does NOT cover"); operators
+are encouraged to wire one up.
+
+## SBOM regeneration cadence
+
+- **On every push to main** that touches `package.json`,
+  `pnpm-lock.yaml`, or workspace package manifests. Stale SBOMs
+  cannot drift from the lockfile.
+- **On manual trigger** via `workflow_dispatch` for ad-hoc fresh
+  snapshots.
+- **On release tag** with cosign signing + release attachment.
+
+Cron-driven regeneration on a quiet codebase is unnecessary — the
+SBOM only changes when dependencies change, and dependency changes
+flow through PR merges to main.
+
+## Self-host operator guidance
+
+A self-hoster running Panorama in their own environment should:
+
+1. **Verify the release SBOM signature** before each upgrade
+   (procedure above).
+2. **Run their own SCA scanner** against the SBOM (Trivy / Grype /
+   whatever your security baseline mandates). Panorama's CI runs
+   Trivy on the source tree (`.github/workflows/ci.yml` → Trivy
+   step); operators should ALSO run their own to catch the gap
+   between "code in repo" and "code as deployed in your
+   environment".
+3. **Cache the SBOM** in their internal compliance archive. Some
+   procurement reviews ask for "the SBOM as of the version you're
+   running" historically; the GitHub release page is the source of
+   truth.
+
+## For procurement / due diligence reviewers
+
+A summary of Panorama's supply-chain posture as of 2026-05-18:
+
+| Property | Status |
+|---|---|
+| SBOM format | CycloneDX 1.5 JSON |
+| SBOM generation | Reproducible via `pnpm install --prod --frozen-lockfile` + `@cyclonedx/cyclonedx-npm@^3` |
+| Signing | cosign keyless (sigstore Fulcio + GH OIDC) on release tags |
+| Transparency log | Rekor — every signing event publicly auditable |
+| Lockfile pinning | pnpm-lock.yaml committed; CI gates use `--frozen-lockfile` |
+| Dependency licence scan | `pnpm dlx license-checker-rseidelsohn` on every PR (per CI `Dependency licence scan` gate) |
+| Static analysis | CodeQL (JS/TS + GH Actions) on every PR |
+| SAST | Trivy filesystem scan on every PR |
+| Secret scanning | Gitleaks on every PR |
+| OSSF Scorecard | Weekly + on every push to main |
+
+For deeper questions, contact `vitor@vitormr.dev`.
+
+## What this runbook does NOT cover
+
+- **Container-image SBOMs.** Panorama ships as a Node app + npm
+  deps SBOM; the Docker base images (`node:22-alpine`, etc.) have
+  their own SBOMs published by their maintainers. Operators
+  running containerised deployments should generate their image
+  SBOM via `syft <image>` or `trivy image --format cyclonedx`.
+- **Runtime attestation / SLSA build provenance.** Out of scope
+  for the Community-edition free preview. SLSA Level 3 attestation
+  is a future Round (post-1.0) item.
+- **Continuous SBOM-driven vulnerability monitoring.** Operators
+  wire up their own SCA scanner (Trivy, Grype, Dependency-Track,
+  Snyk, etc.) and feed it the SBOM. Panorama's CI runs SCA on the
+  source tree but does NOT run a continuous SBOM-against-CVE
+  monitor — that's a Round 7 sibling deliverable if the
+  maintainer scopes it.
+- **Closed-source dependency disclosure.** Panorama has none today
+  (AGPL stack); if it ever adds one (e.g., a managed Enterprise
+  dependency), the SBOM mark for closed-source surfaces stays
+  honest via CycloneDX's `licenses` field.
+- **Cross-repo / multi-repo SBOM aggregation.** Panorama is a
+  single repo today. Operators with a multi-repo deployment that
+  also runs sister tools (e.g., a forked plugin, custom
+  middleware) generate their own aggregated SBOM via their
+  internal toolchain.
+
+## Drill cadence
+
+Once a quarter, verify the latest release's SBOM signature
+end-to-end:
+
+1. Pull the SBOM + sig + cert from the most recent release
+2. Run `cosign verify-blob` per the procedure above
+3. Confirm Rekor entry visible at search.sigstore.dev
+4. Record the drill in the audit log via
+   `panorama.maintainer.sbom_verify_completed` (action name
+   reserved; emitter is a Round 7 follow-up PR alongside the
+   `restore-drill-due` cron)
+
+Pair this drill with the restore drill ([`restore.md`](./restore.md))
+and the status-page drill ([`status-page.md`](./status-page.md))
+into one quarterly operator-hour slot.


### PR DESCRIPTION
## Summary

Closes the Wave 0 §9 "SBOM CycloneDX from clean `pnpm install --prod --frozen-lockfile`, cosign sigstore keyless sign on release" acceptance item (per HANDOFF-2026-05-16-wave0-scan.md:214-215).

Ships the infrastructure now; the first signed release tag is operator-side when the maintainer cuts v0.x.

## What's in scope

### `.github/workflows/sbom.yml` (130 lines)

Generates a CycloneDX 1.5 JSON SBOM via `@cyclonedx/cyclonedx-npm@^3` from a clean `pnpm install --prod --frozen-lockfile` on every push to main that touches:

- `package.json`
- `pnpm-lock.yaml`
- `apps/*/package.json`
- `packages/*/package.json`
- `.github/workflows/sbom.yml` itself

Plus on release-tag push (`v*`) and `workflow_dispatch` manual trigger.

**Two jobs:**

1. **`generate`** — runs on every trigger. Produces `panorama-sbom.json`, validates the output (`jq -e '.metadata.timestamp and (.components | length > 0)'`), uploads as a CI artifact with 90-day retention.
2. **`sign-and-release`** — runs only on `refs/tags/v*`. Downloads the SBOM artifact from job 1, installs cosign via `sigstore/cosign-installer@v3.7.0`, signs via `cosign sign-blob` keyless (GitHub OIDC → Fulcio → ephemeral cert; signature logged to Rekor transparency log), attaches the SBOM + .sig + .crt to the GitHub release via `gh release upload --clobber`.

**SBOM scope (what's included vs deliberately not):**

- ✅ All production runtime npm dependencies + their transitive closure
- ✅ Per-package: name, version, license (when declared), Package URL, hashes
- ❌ devDependencies (stripped by `pnpm install --prod`) — SBOM reflects what ships, not what builds
- ❌ Container base-image OS dependencies — operator generates separately via `syft <image>` or `trivy image --format cyclonedx`

### `docs/runbooks/sbom-supply-chain.md` (250 lines)

Companion runbook covering:

- §What the SBOM contains (and explicitly what it doesn't)
- §Where to find the SBOM (workflow artifacts for main; release Assets for tags)
- §How to verify a signed SBOM via `cosign verify-blob` end-to-end (includes the exact `--certificate-identity-regexp` + `--certificate-oidc-issuer` flags)
- §Using the SBOM for vulnerability scanning (Trivy / Grype / OWASP Dependency-Track / Snyk / JFrog Xray)
- §SBOM regeneration cadence
- §Self-host operator guidance
- §Procurement / due-diligence summary table (the artefact procurement reviewers ask for)
- §What this runbook does NOT cover (container-image SBOMs, SLSA L3, continuous CVE monitoring, closed-source dep disclosure, multi-repo aggregation)
- §Drill cadence (quarterly verify, pair with restore + status-page drills)

## Verified locally

- `pnpm dlx @cyclonedx/cyclonedx-npm@^3 --help` confirms all workflow flags are supported (`--output-format JSON`, `--output-file`, `--spec-version 1.5`, `--short-PURLs`, `--omit dev`, `--validate`)
- `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses cleanly
- `pnpm docs:build` — VitePress build clean (runbook renders)

## Out of scope (and deferred)

- **Container-image SBOMs** — operators generate via `syft <image>` or `trivy image --format cyclonedx` against their deployment artefacts. Out of scope for the Node-only Panorama SBOM.
- **SLSA Level 3 build provenance** — post-1.0 Round. The current keyless signing covers Level 2 attestation surface; L3 needs additional hermetic-build guarantees.
- **Continuous SBOM-driven CVE monitoring** — operators wire up their own SCA scanner consuming the SBOM artifact. Panorama's CI already runs Trivy on the source tree (`.github/workflows/ci.yml` Trivy step); operators should run their own to catch the gap between "code in repo" and "code as deployed".
- **Reserved `panorama.maintainer.sbom_verify_completed` audit action** for the quarterly drill — Round 7 follow-up alongside the `restore-drill-due` cron sibling. Defers to keep this PR's scope focused.

## Procurement-credibility impact

A procurement reviewer landing on this PR can immediately answer:

- ✅ "Do you produce an SBOM?" → Yes, CycloneDX 1.5 JSON
- ✅ "Is it reproducible?" → Yes, via `pnpm install --prod --frozen-lockfile`
- ✅ "Is it signed?" → Yes, cosign keyless on release tags
- ✅ "Where do I find it?" → Release Assets + workflow artifacts
- ✅ "How do I verify?" → `cosign verify-blob` procedure in runbook
- ✅ "Is signing tied to a real identity?" → Yes, GitHub OIDC → Fulcio cert + Rekor transparency log
- ✅ "Do you have a transparency log?" → Yes, search.sigstore.dev

This artefact unlocks Enterprise procurement conversations that the maintainer can't currently have without it.

## Wave 0 acceptance impact

- **§9 — Round 7** progresses: status page ✅ (PR #243), SBOM/cosign ✅ (this PR), Privacy/ToS still pending (BLOCKED on legal counsel; external dependency). After both autonomous halves merge, only the Privacy/ToS legal review remains for §9 closure.

## Refs

- `HANDOFF-2026-05-16-wave0-scan.md:214-215` — Wave 0 §9 SBOM + cosign acceptance item
- `docs/audits/roadmap-to-feature-complete-2026-05-18.md` (PR #242) — Wave 0 closure preconditions
- [sigstore/cosign documentation](https://docs.sigstore.dev/)
- [CycloneDX specification](https://cyclonedx.org/specification/overview/)

## Test plan

- [x] CycloneDX CLI flags verified
- [x] Workflow YAML parses
- [x] Docs build clean
- [ ] First push to main triggers SBOM generation (verify post-merge)
- [ ] First release tag triggers signing + release attachment (verify when maintainer cuts v0.x)
- [ ] Per-PR scan: security-reviewer + product-lead in parallel (light scan — pure infrastructure + docs, no code/schema)