### PR TITLE
Round 7 §9 — Privacy Policy + Terms of Service plain-language v1

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -672,3 +672,88 @@ select.panorama-select {
   color: var(--pan-muted);
   margin-left: 6px;
 }
+
+/* Legal pages — public, server-rendered, long-form reading.
+   Optimised for readability over visual flourish. Per ux-critic per-PR
+   scan: ≥48px tap targets, AA contrast, status-by-text-not-colour. */
+.panorama-legal {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 32px 24px 64px;
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.panorama-legal-article header {
+  margin-bottom: 32px;
+  border-bottom: 1px solid var(--pan-border);
+  padding-bottom: 16px;
+}
+
+.panorama-legal-article h1 {
+  font-size: 28px;
+  margin-bottom: 8px;
+}
+
+.panorama-legal-updated {
+  color: var(--pan-muted);
+  font-size: 13px;
+  margin: 4px 0;
+}
+
+.panorama-legal-status {
+  background: rgba(255, 196, 87, 0.12);
+  border-left: 3px solid #ffc457;
+  padding: 12px 16px;
+  font-size: 14px;
+  margin-top: 12px;
+  border-radius: 4px;
+}
+
+.panorama-legal-body h2 {
+  font-size: 20px;
+  margin: 32px 0 12px;
+  padding-top: 8px;
+}
+
+.panorama-legal-body p,
+.panorama-legal-body li {
+  margin: 8px 0;
+}
+
+.panorama-legal-body ul,
+.panorama-legal-body ol {
+  padding-left: 24px;
+  margin: 12px 0;
+}
+
+.panorama-legal-body code {
+  background: var(--pan-border);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 0.92em;
+}
+
+.panorama-legal-body hr {
+  border: 0;
+  border-top: 1px solid var(--pan-border);
+  margin: 32px 0;
+}
+
+.panorama-legal-footer {
+  margin-top: 48px;
+  padding-top: 16px;
+  border-top: 1px solid var(--pan-border);
+  font-size: 14px;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.panorama-legal-footer a {
+  color: var(--pan-accent, #3fb69a);
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+}

--- a/apps/web/src/app/legal/layout.tsx
+++ b/apps/web/src/app/legal/layout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Public legal-page layout — used for /legal/privacy + /legal/terms.
+ *
+ * Unauthenticated by design. Visitors landing here from a homepage CTA
+ * or a footer link should NOT be redirected to /login. The pages render
+ * server-side with no client JS; navigation back to the marketing site
+ * is via the in-page anchor + the docs link.
+ *
+ * Wave 0 §9 plain-language v1 draft — final language pending counsel
+ * review per ADR-0014 §C6 trigger.
+ */
+export default function LegalLayout({ children }: { children: ReactNode }): ReactNode {
+  return <div className="panorama-legal">{children}</div>;
+}

--- a/apps/web/src/app/legal/privacy/content.ts
+++ b/apps/web/src/app/legal/privacy/content.ts
@@ -1,0 +1,540 @@
+/**
+ * Plain-language Privacy Policy content, per locale.
+ *
+ * Wave 0 §9 plain-language v1 draft — covers LGPD Art. 9 mandatories
+ * + names sub-processor CATEGORIES (not vendors, per security-reviewer
+ * C2 threat-model reasoning). Final language pending counsel review.
+ *
+ * Last updated: 2026-05-18. The page exposes this date to readers via
+ * `LAST_UPDATED_ISO`.
+ *
+ * Per the i18n CI gate, all three locale keys must exist. EN is the
+ * canonical pre-counsel draft. PT-BR is a parallel draft (the home
+ * regulatory regime is LGPD/Brazil; pt-br is the load-bearing
+ * translation). ES is a placeholder + pointer to the EN canon until
+ * counsel review covers all three.
+ */
+
+export const LAST_UPDATED_ISO = '2026-05-18';
+
+export const PRIVACY_CONTENT = {
+  en: `
+This Privacy Policy explains what data Panorama collects, why we collect
+it, with whom we share it (in categories — never named vendors), and
+what rights you have over it. We try to write it in plain language so
+you do not need a lawyer to read it. The official mandatory headings
+under Brazilian LGPD (Lei Geral de Proteção de Dados, Art. 9) are
+covered below in the order LGPD prescribes.
+
+## Who is the controller?
+
+For the **hosted Panorama instance** at panorama.vitormr.dev (and any
+future panorama.app deployment by the same maintainer): the controller
+is the individual maintainer of the Panorama project, contactable at
+vitor@vitormr.dev.
+
+For **self-hosted Panorama deployments** (every Panorama instance you
+or a third party runs on your own infrastructure under the AGPL
+licence): the controller is the operator of that deployment, not the
+Panorama project maintainer. This Privacy Policy describes what
+Panorama is BUILT to do; the operator of your deployment decides
+exactly how it is used and is responsible for their own privacy
+notice to their data subjects.
+
+If you are unsure whether you are using the hosted instance or a
+self-hosted deployment, look at the URL in your browser. Anything
+other than the addresses listed above is self-hosted.
+
+## What we collect
+
+The data Panorama processes is the data needed to operate a multi-
+tenant fleet and asset management service. In the hosted instance
+this includes:
+
+- **Account data**: name, email address, organisation slug, role
+  within your tenant, and your chosen interface language.
+- **Authentication data**: a hashed session token, OIDC subject
+  identifier (when you log in via Google or Microsoft), and
+  per-request correlation identifiers (added in Round 6 audit work).
+- **Operational data**: the records you create or that are created
+  on your behalf — assets, reservations, inspections, maintenance
+  tickets, photos uploaded as inspection evidence, comments, audit
+  events. This is the working dataset of your fleet operations.
+- **Technical telemetry**: HTTP request metadata, IP address (for
+  rate-limiting and abuse detection only — not retained for
+  analytics), user-agent string, and structured server logs.
+
+We do not run third-party analytics scripts. There is no Google
+Analytics, no Mixpanel, no Hotjar, no Facebook Pixel in the hosted
+instance. We do not sell, rent, or syndicate your data to
+advertisers.
+
+## Why we collect it
+
+Each data class has a single specific purpose:
+
+- **Account data** — to identify you and the tenant you belong to,
+  and to enforce that you can only see your own tenant's records
+  (the multi-tenant isolation contract).
+- **Authentication data** — to keep you signed in across requests
+  and to detect anomalies (rotation, password breach, OIDC issuer
+  mismatch).
+- **Operational data** — to provide the fleet management service
+  you signed up for. Every record you create exists because you or
+  another user in your tenant created it for a specific operational
+  purpose.
+- **Technical telemetry** — to keep the service available (rate-
+  limiting), to debug operator errors (request-id correlation in
+  audit + log streams), and to detect attacks (failed login spikes,
+  audit-chain tamper signals).
+
+Under LGPD Art. 7, our legal bases for processing are: (a) the
+contract with you to provide the service (Art. 7 V), (b) our
+legitimate interest in keeping the service secure and operational
+(Art. 7 IX), and (c) for some specific categories, your explicit
+consent (Art. 7 I — applicable when you opt into optional features).
+
+## How long we keep it
+
+- **Account + authentication data**: while your account is active.
+  When you delete your account or your tenant, see "Your rights"
+  below for the deletion path.
+- **Operational data**: while your tenant exists. We never
+  pro-actively delete operational data; the tenant owner controls
+  retention.
+- **Audit log**: forever, for as long as the tenant exists. The
+  audit log is append-only and hash-chained for tamper-evidence —
+  it is the legal record of what happened in your tenant.
+- **Technical telemetry**: HTTP server logs are retained for 30
+  days. Audit events created from telemetry (rate-limit trips,
+  failed logins) follow the audit-log retention above.
+- **Tenant export tarballs**: created by you on demand, retained
+  for 24 hours, then automatically deleted from object storage.
+
+## Who we share it with — sub-processor categories
+
+We use the following categories of third-party services to operate
+the hosted Panorama instance. We name CATEGORIES, not specific
+vendors, by design — this reduces the attack surface against the
+operator's vendor relationships. The maintainer can disclose the
+specific vendor in a category to a tenant on request, under NDA, if
+the tenant has a contractual or regulatory need for the specific
+identity.
+
+- **Cloud hosting (IaaS).** Where the Panorama runtime executes.
+- **Managed Postgres.** Where the tenant database lives.
+- **Object storage (S3-compatible).** Where uploaded photos and
+  tenant-export tarballs are stored.
+- **Email delivery (SMTP).** Where transactional emails
+  (invitations, notifications) are sent through.
+- **OIDC identity providers.** Google + Microsoft — only when you
+  choose to sign in via one of them. They learn that you signed
+  into Panorama; they do not see your operational data.
+- **Error monitoring (opt-in).** If the operator has configured
+  Sentry, server-side errors include a stack trace and request-id.
+  Tenant data is NOT included in error payloads by design; the
+  Sentry integration is configured to redact PII per ADR-0018.
+- **CAPTCHA (signup-only).** When the operator enables self-serve
+  signup, Cloudflare Turnstile is consulted at the signup form to
+  block bots. They see the signup attempt; they do not see your
+  operational data.
+
+We do NOT use third-party advertising or analytics services.
+
+For self-hosted deployments, this list does not apply — your
+operator chooses their own infrastructure providers and is
+responsible for disclosing them to their tenants.
+
+## How we protect it
+
+- **Multi-tenant isolation** is enforced at the database layer via
+  PostgreSQL row-level security (RLS), not just in application code.
+  A bug in the application code cannot cause one tenant's query to
+  return another tenant's rows.
+- **Encryption in transit** — every connection to the hosted
+  instance uses HTTPS / TLS. We do not accept HTTP traffic.
+- **Encryption at rest** — your database and object storage are
+  encrypted at rest by the cloud-hosting and managed-Postgres
+  providers.
+- **Tamper-evident audit log** — every administrative or operational
+  action is recorded in a SHA-256 hash-chained audit log. Any
+  modification to a past event breaks the chain at the next
+  verification check.
+- **Backups + restore drills** — the audit log and operational
+  data are backed up by the managed-Postgres provider; the
+  maintainer exercises restore drills on a documented cadence
+  (\`docs/runbooks/restore.md\`).
+
+## Your rights under LGPD Art. 18
+
+You have the following rights with respect to your data. Any
+request can be sent to vitor@vitormr.dev. We respond within 15
+days unless we need more time, in which case we tell you why.
+
+1. **Access**. You can ask what data we have about you. You can
+   also generate a tenant-export tarball from inside the
+   application (Settings → Export tenant data) to download a copy
+   of your tenant's operational data.
+2. **Correction**. You can update most data fields directly in
+   the application. For data you cannot edit (e.g., audit events,
+   which are immutable by design), email us to request a correction
+   note appended to the record.
+3. **Deletion**. You can delete your tenant from Settings → Delete
+   tenant. Deletion is irreversible after a 7-day grace period;
+   tenant-data is purged from the database, audit log entries about
+   the deletion itself are retained for legal record.
+4. **Portability**. The tenant export above is a structured JSON
+   archive of all your tenant's data; that is the portable format.
+5. **Information about who we share with**. See the sub-processor
+   categories above. We can disclose the specific vendor under NDA
+   for a contractual or regulatory need.
+6. **Withdrawal of consent**. Where processing is based on consent
+   (rare; most processing is contract-necessary), you can withdraw
+   consent in the application or by email.
+7. **Objection** to processing that is based on legitimate interest
+   only. Note that objecting to security telemetry processing
+   typically means the account cannot continue operating.
+8. **Information about the legal basis** of any processing — see
+   "Why we collect it" above; ask if anything is unclear.
+
+For data-subject requests where we cannot verify your identity
+through your account (e.g., a closed account), we will ask for
+additional identity verification before responding.
+
+## Children
+
+Panorama is built for fleet operations — it is not directed at
+children under 18. We do not knowingly collect data about people
+under 18. If a tenant operator creates accounts for users under
+18 (for example, in a youth-organisation transport setting), the
+operator is the controller of that data and is responsible for
+parental consent under their local law.
+
+## Cookies and similar technologies
+
+We use two strictly-necessary cookies in the hosted instance:
+
+- A **session cookie** (\`panorama_session\`) — encrypted with a
+  rotating key, lasts 7 days, refreshes on use. Required for you
+  to stay signed in.
+- A **locale cookie** (\`panorama_locale\`) — stores your interface-
+  language preference. Set when you change languages.
+
+We do not use any analytics, marketing, or tracking cookies.
+
+## International transfers
+
+The hosted Panorama instance runs in the region you select at
+sign-up time. We do not transfer your data to a different region
+without your consent. The maintainer is based in Brazil; data
+transferred to providers outside Brazil is subject to LGPD Art. 33
+(adequacy decisions or standard contractual clauses); the specific
+vendor disclosure includes the data residency for each category.
+
+## Changes to this policy
+
+When this policy changes, we will notify the email address on
+your account at least 30 days before the change takes effect.
+The current version date is shown at the top of the page. Previous
+versions are tracked in the public Panorama repository's git
+history at github.com/VitorMRodovalho/panorama.
+
+## Contact
+
+For any privacy-related question, complaint, or data-subject
+request: vitor@vitormr.dev.
+
+Our LGPD data-protection officer (DPO / encarregado) function is
+currently performed by the same maintainer. When the hosted
+instance has paying tenants and a separate DPO is appointed, this
+section will name them. The reporter email at
+vitor@vitormr.dev is monitored either way.
+
+You may also contact the Brazilian data-protection authority
+(ANPD) at gov.br/anpd if you believe we have not handled your
+request adequately.
+
+---
+
+**Status notice (this draft).** This is the plain-language v1
+draft per Round 7 of the Wave 0 acceptance plan. The maintainer
+will engage qualified legal counsel before the hosted Panorama
+URL is announced publicly to a paying audience. The policy text
+may change as a result of counsel review; the change-notice
+above (30-day window) applies to any post-counsel revision.
+`,
+
+  'pt-br': `
+Esta Política de Privacidade explica quais dados a Panorama coleta,
+por que coletamos, com quem compartilhamos (em categorias — nunca
+fornecedores nomeados) e quais direitos você tem sobre eles.
+Tentamos escrever em linguagem clara para que você não precise de
+advogado para entender. Os títulos obrigatórios sob a LGPD (Lei
+Geral de Proteção de Dados, Art. 9) estão cobertos abaixo na ordem
+prescrita pela LGPD.
+
+## Quem é o controlador?
+
+Para a **instância hospedada da Panorama** em panorama.vitormr.dev
+(e qualquer futura implantação em panorama.app pelo mesmo
+mantenedor): o controlador é o mantenedor individual do projeto
+Panorama, contato em vitor@vitormr.dev.
+
+Para **implantações auto-hospedadas da Panorama** (qualquer
+instância da Panorama que você ou terceiros executem em
+infraestrutura própria sob a licença AGPL): o controlador é o
+operador dessa implantação, não o mantenedor do projeto Panorama.
+Esta Política de Privacidade descreve o que a Panorama é PROJETADA
+para fazer; o operador da sua implantação decide exatamente como
+ela é usada e é responsável pelo próprio aviso de privacidade aos
+seus titulares de dados.
+
+Se não souber se está usando a instância hospedada ou uma
+implantação auto-hospedada, veja a URL no seu navegador. Qualquer
+endereço diferente dos listados acima é auto-hospedado.
+
+## O que coletamos
+
+Os dados que a Panorama processa são aqueles necessários para
+operar um serviço multi-tenant de gestão de frota e ativos. Na
+instância hospedada, isso inclui:
+
+- **Dados de conta**: nome, e-mail, slug da organização, papel no
+  seu tenant e idioma escolhido para a interface.
+- **Dados de autenticação**: token de sessão com hash, identificador
+  OIDC (quando você entra via Google ou Microsoft) e identificadores
+  de correlação por requisição (Round 6 do plano de auditoria).
+- **Dados operacionais**: os registros que você ou outros usuários
+  do seu tenant criam — ativos, reservas, inspeções, chamados de
+  manutenção, fotos enviadas como evidência de inspeção, comentários,
+  eventos de auditoria. Este é o conjunto de dados de trabalho da
+  sua operação de frota.
+- **Telemetria técnica**: metadados de requisição HTTP, endereço IP
+  (apenas para rate-limiting e detecção de abuso — não retido para
+  analytics), string user-agent e logs estruturados do servidor.
+
+Não executamos scripts de analytics de terceiros. Não há Google
+Analytics, Mixpanel, Hotjar nem Facebook Pixel na instância
+hospedada. Não vendemos, alugamos nem distribuímos seus dados para
+anunciantes.
+
+## Por que coletamos
+
+Cada classe de dado tem uma finalidade específica única:
+
+- **Dados de conta** — para identificar você e o tenant ao qual
+  pertence, e para garantir que só veja registros do seu próprio
+  tenant (contrato de isolamento multi-tenant).
+- **Dados de autenticação** — para mantê-lo conectado entre
+  requisições e detectar anomalias (rotação, vazamento de senha,
+  divergência de emissor OIDC).
+- **Dados operacionais** — para prover o serviço de gestão de frota
+  que você contratou. Cada registro existe porque você ou outro
+  usuário do tenant o criou para uma finalidade operacional
+  específica.
+- **Telemetria técnica** — para manter o serviço disponível
+  (rate-limiting), depurar erros de operador (correlação por
+  request-id em auditoria + logs) e detectar ataques (picos de
+  login com falha, sinais de adulteração da cadeia de auditoria).
+
+Sob a LGPD Art. 7, nossas bases legais de tratamento são: (a) o
+contrato com você para prestar o serviço (Art. 7, V), (b) nosso
+legítimo interesse em manter o serviço seguro e operacional (Art.
+7, IX), e (c) para algumas categorias específicas, seu
+consentimento explícito (Art. 7, I — aplicável quando opta por
+recursos opcionais).
+
+## Por quanto tempo guardamos
+
+- **Dados de conta + autenticação**: enquanto sua conta estiver
+  ativa. Quando você excluir sua conta ou seu tenant, veja "Seus
+  direitos" abaixo para o caminho de exclusão.
+- **Dados operacionais**: enquanto seu tenant existir. Nunca
+  excluímos dados operacionais proativamente; o titular do tenant
+  controla a retenção.
+- **Log de auditoria**: para sempre, enquanto o tenant existir. O
+  log de auditoria é apenas-anexo (append-only) e encadeado por
+  hash para evidência de adulteração — é o registro legal do que
+  aconteceu no seu tenant.
+- **Telemetria técnica**: logs de servidor HTTP são retidos por 30
+  dias. Eventos de auditoria criados a partir de telemetria
+  (tentativas de rate-limit, logins com falha) seguem a retenção
+  do log de auditoria acima.
+- **Tarballs de exportação do tenant**: criados por você sob
+  demanda, retidos por 24 horas, depois excluídos automaticamente
+  do object storage.
+
+## Com quem compartilhamos — categorias de sub-processadores
+
+Usamos as seguintes categorias de serviços de terceiros para
+operar a instância hospedada da Panorama. Nomeamos CATEGORIAS, não
+fornecedores específicos, por design — isso reduz a superfície de
+ataque contra as relações com fornecedores do operador. O
+mantenedor pode revelar o fornecedor específico de uma categoria
+a um tenant sob NDA, mediante necessidade contratual ou regulatória.
+
+- **Hospedagem em nuvem (IaaS).** Onde o runtime Panorama executa.
+- **Postgres gerenciado.** Onde o banco do tenant vive.
+- **Object storage (compatível com S3).** Onde fotos enviadas e
+  tarballs de exportação são armazenados.
+- **Entrega de e-mail (SMTP).** Por onde e-mails transacionais
+  (convites, notificações) são enviados.
+- **Provedores de identidade OIDC.** Google + Microsoft — apenas
+  quando você escolhe entrar via um deles. Eles sabem que você
+  entrou na Panorama; não veem seus dados operacionais.
+- **Monitoramento de erros (opt-in).** Se o operador configurou
+  Sentry, erros do servidor incluem stack trace e request-id.
+  Dados de tenant NÃO são incluídos em payloads de erro por design;
+  a integração Sentry é configurada para redigir PII conforme
+  ADR-0018.
+- **CAPTCHA (apenas cadastro).** Quando o operador habilita
+  cadastro self-serve, Cloudflare Turnstile é consultado no
+  formulário para bloquear bots. Ele vê a tentativa de cadastro;
+  não vê seus dados operacionais.
+
+NÃO usamos serviços de publicidade ou analytics de terceiros.
+
+Para implantações auto-hospedadas, esta lista não se aplica — seu
+operador escolhe os provedores de infraestrutura próprios e é
+responsável por divulgá-los aos seus tenants.
+
+## Como protegemos
+
+- **Isolamento multi-tenant** é aplicado na camada de banco via
+  row-level security (RLS) do PostgreSQL, não apenas no código da
+  aplicação. Um bug no código não pode fazer uma consulta de um
+  tenant retornar linhas de outro tenant.
+- **Criptografia em trânsito** — toda conexão com a instância
+  hospedada usa HTTPS / TLS. Não aceitamos tráfego HTTP.
+- **Criptografia em repouso** — seu banco e object storage são
+  criptografados em repouso pelos provedores de nuvem.
+- **Log de auditoria com evidência de adulteração** — toda ação
+  administrativa ou operacional é registrada em um log com cadeia
+  de hashes SHA-256. Qualquer modificação a um evento passado
+  quebra a cadeia na próxima verificação.
+- **Backups + drills de restauração** — log de auditoria e dados
+  operacionais são backupeados pelo provedor de Postgres
+  gerenciado; o mantenedor executa drills de restauração em
+  cadência documentada (\`docs/runbooks/restore.md\`).
+
+## Seus direitos sob a LGPD Art. 18
+
+Você tem os seguintes direitos sobre seus dados. Qualquer pedido
+pode ser enviado para vitor@vitormr.dev. Respondemos em até 15
+dias, salvo se precisarmos de mais tempo — nesse caso explicamos
+por quê.
+
+1. **Acesso**. Você pode perguntar quais dados temos sobre você.
+   Também pode gerar um tarball de exportação do tenant dentro do
+   aplicativo (Configurações → Exportar dados do tenant) para
+   baixar uma cópia dos dados operacionais do seu tenant.
+2. **Correção**. Você pode atualizar a maioria dos campos
+   diretamente no aplicativo. Para dados que não pode editar (por
+   exemplo, eventos de auditoria, que são imutáveis por design),
+   envie e-mail solicitando uma nota de correção anexada ao
+   registro.
+3. **Exclusão**. Você pode excluir seu tenant em Configurações →
+   Excluir tenant. A exclusão é irreversível após período de 7
+   dias de graça; dados do tenant são removidos do banco; entradas
+   do log de auditoria sobre a própria exclusão são retidas para
+   registro legal.
+4. **Portabilidade**. A exportação do tenant acima é um arquivo
+   JSON estruturado com todos os dados do tenant; esse é o formato
+   portável.
+5. **Informação sobre com quem compartilhamos**. Veja as categorias
+   de sub-processadores acima. Podemos divulgar o fornecedor
+   específico sob NDA mediante necessidade contratual ou regulatória.
+6. **Revogação de consentimento**. Onde o tratamento se baseia em
+   consentimento (raro; a maioria do tratamento é necessária ao
+   contrato), você pode revogar no aplicativo ou por e-mail.
+7. **Objeção** ao tratamento baseado em legítimo interesse apenas.
+   Note que objetar à telemetria de segurança normalmente significa
+   que a conta não pode continuar operando.
+8. **Informação sobre a base legal** de qualquer tratamento — veja
+   "Por que coletamos" acima; pergunte se algo estiver pouco claro.
+
+Para pedidos de titular onde não podemos verificar sua identidade
+pela conta (por exemplo, conta encerrada), pediremos verificação
+adicional antes de responder.
+
+## Crianças
+
+A Panorama foi construída para operações de frota — não é direcionada
+a crianças menores de 18 anos. Não coletamos dados conscientemente
+sobre menores de 18. Se um operador de tenant criar contas para
+usuários menores de 18 (por exemplo, em contexto de organização
+juvenil), o operador é o controlador desses dados e responsável
+pelo consentimento parental conforme a lei local aplicável.
+
+## Cookies e tecnologias similares
+
+Usamos dois cookies estritamente necessários na instância hospedada:
+
+- Um **cookie de sessão** (\`panorama_session\`) — criptografado com
+  chave rotativa, dura 7 dias, atualiza no uso. Necessário para
+  manter você conectado.
+- Um **cookie de idioma** (\`panorama_locale\`) — guarda sua
+  preferência de idioma da interface. Definido quando você muda
+  de idioma.
+
+Não usamos cookies de analytics, marketing ou tracking.
+
+## Transferências internacionais
+
+A instância hospedada da Panorama roda na região que você
+selecionar no cadastro. Não transferimos seus dados para região
+diferente sem seu consentimento. O mantenedor está sediado no
+Brasil; dados transferidos a provedores fora do Brasil estão
+sujeitos à LGPD Art. 33 (decisões de adequação ou cláusulas
+contratuais padrão); a divulgação específica de fornecedor inclui
+a residência de dados de cada categoria.
+
+## Alterações nesta política
+
+Quando esta política mudar, notificaremos o e-mail da sua conta
+com pelo menos 30 dias de antecedência. A data da versão atual
+aparece no topo da página. Versões anteriores são rastreadas no
+histórico git público do repositório Panorama em
+github.com/VitorMRodovalho/panorama.
+
+## Contato
+
+Para qualquer dúvida, reclamação ou pedido de titular relacionado
+a privacidade: vitor@vitormr.dev.
+
+A função de DPO (Encarregado de Proteção de Dados) sob a LGPD é
+atualmente exercida pelo mesmo mantenedor. Quando a instância
+hospedada tiver tenants pagantes e um DPO separado for nomeado,
+esta seção o nomeará. O e-mail vitor@vitormr.dev é monitorado de
+qualquer forma.
+
+Você também pode contactar a Autoridade Nacional de Proteção de
+Dados (ANPD) em gov.br/anpd se considerar que não tratamos seu
+pedido adequadamente.
+
+---
+
+**Aviso de status (este rascunho).** Esta é a versão v1 em
+linguagem clara do plano Round 7 da aceitação Wave 0. O mantenedor
+contratará assessoria jurídica qualificada antes de a URL hospedada
+da Panorama ser anunciada publicamente a uma audiência pagante. O
+texto pode mudar após revisão jurídica; o aviso de alteração de 30
+dias acima se aplica a qualquer revisão pós-revisão jurídica.
+`,
+
+  es: `
+**Versión en español pendiente.** El texto canónico de la Política
+de Privacidade de Panorama está disponible en inglés y portugués
+brasileño en esta misma página, por favor seleccione su idioma en
+el selector de idiomas o use el contenido en inglés / portugués
+como referencia.
+
+La traducción al español será publicada después de la revisión
+jurídica de Round 7 (Wave 0 — antes del lanzamiento público de la
+URL hospedada). Hasta entonces, la versión en inglés (canónica) o
+portugués (mercado brasileño / LGPD) son los textos vigentes.
+
+Para cualquier pregunta sobre privacidad, contacte:
+vitor@vitormr.dev.
+`,
+} as const;

--- a/apps/web/src/app/legal/privacy/page.tsx
+++ b/apps/web/src/app/legal/privacy/page.tsx
@@ -1,0 +1,126 @@
+import type { Metadata, ResolvingMetadata } from 'next';
+import type { ReactNode } from 'react';
+import { loadMessages, resolveRequestLocale } from '@/lib/i18n';
+import { PRIVACY_CONTENT, LAST_UPDATED_ISO } from './content';
+
+export async function generateMetadata(
+  _props: unknown,
+  _parent: ResolvingMetadata,
+): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
+  const messages = loadMessages(locale);
+  return {
+    title: `${messages.t('legal.privacy.title')} · Panorama`,
+    description: messages.t('legal.privacy.metaDescription'),
+  };
+}
+
+/**
+ * Privacy policy — Wave 0 §9 plain-language v1 draft.
+ *
+ * Server-rendered, public route (no auth). Content per locale lives
+ * in `./content.ts`. Pre-counsel-review draft per ADR-0014 §C6
+ * trigger; the "Status notice" at the bottom of each locale block
+ * makes the pre-review state explicit to readers.
+ */
+export default async function PrivacyPage(): Promise<ReactNode> {
+  const locale = await resolveRequestLocale();
+  const messages = loadMessages(locale);
+  const content = PRIVACY_CONTENT[locale];
+  return (
+    <article className="panorama-legal-article">
+      <header>
+        <h1>{messages.t('legal.privacy.title')}</h1>
+        <p className="panorama-legal-updated">
+          {messages.t('legal.lastUpdated', { date: LAST_UPDATED_ISO })}
+        </p>
+        <p className="panorama-legal-status">
+          {messages.t('legal.preCounselDraftBanner')}
+        </p>
+      </header>
+      <PolicyContent body={content} />
+      <footer className="panorama-legal-footer">
+        <a href="/legal/terms">{messages.t('legal.terms.title')}</a>
+        <span> · </span>
+        <a href="/">{messages.t('legal.backToHome')}</a>
+      </footer>
+    </article>
+  );
+}
+
+/**
+ * Render the long-form policy body. The body uses simple markdown-ish
+ * shape (## headings, * bullets) — we parse it server-side into <h2>
+ * + <p> + <ul> elements. No client JS.
+ *
+ * NOT a full markdown renderer — only the subset the policy content
+ * actually uses. Adding markdown library + sanitiser was an
+ * over-engineering trap for a v1 draft.
+ */
+function PolicyContent({ body }: { body: string }): ReactNode {
+  const sections = body.trim().split(/\n\n+/);
+  return (
+    <div className="panorama-legal-body">
+      {sections.map((section, idx) => renderSection(section, idx))}
+    </div>
+  );
+}
+
+function renderSection(section: string, idx: number): ReactNode {
+  const trimmed = section.trim();
+  if (trimmed.startsWith('## ')) {
+    return <h2 key={idx}>{trimmed.slice(3)}</h2>;
+  }
+  if (trimmed.startsWith('---')) {
+    return <hr key={idx} />;
+  }
+  if (/^[-*] /m.test(trimmed) && trimmed.split('\n').every((line) => /^[-*] /.test(line))) {
+    const items = trimmed.split('\n').map((line) => line.replace(/^[-*] /, ''));
+    return (
+      <ul key={idx}>
+        {items.map((item, i) => (
+          <li key={i}>{renderInline(item)}</li>
+        ))}
+      </ul>
+    );
+  }
+  if (/^\d+\. /m.test(trimmed) && trimmed.split('\n').every((line) => /^\d+\. /.test(line))) {
+    const items = trimmed.split('\n').map((line) => line.replace(/^\d+\. /, ''));
+    return (
+      <ol key={idx}>
+        {items.map((item, i) => (
+          <li key={i}>{renderInline(item)}</li>
+        ))}
+      </ol>
+    );
+  }
+  return <p key={idx}>{renderInline(trimmed)}</p>;
+}
+
+/**
+ * Inline rendering: **bold** and `code` only. No links, no images, no
+ * arbitrary HTML. Policy text uses these patterns deliberately.
+ */
+function renderInline(text: string): ReactNode {
+  // Split on the markdown patterns we support; preserve order.
+  const parts: ReactNode[] = [];
+  const regex = /(\*\*[^*]+\*\*|`[^`]+`)/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+    const token = match[0];
+    if (token.startsWith('**')) {
+      parts.push(<strong key={match.index}>{token.slice(2, -2)}</strong>);
+    } else if (token.startsWith('`')) {
+      parts.push(<code key={match.index}>{token.slice(1, -1)}</code>);
+    }
+    lastIndex = match.index + token.length;
+  }
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+  return <>{parts}</>;
+}

--- a/apps/web/src/app/legal/privacy/page.tsx
+++ b/apps/web/src/app/legal/privacy/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, ResolvingMetadata } from 'next';
 import type { ReactNode } from 'react';
+import Link from 'next/link';
 import { loadMessages, resolveRequestLocale } from '@/lib/i18n';
 import { PRIVACY_CONTENT, LAST_UPDATED_ISO } from './content';
 
@@ -40,9 +41,9 @@ export default async function PrivacyPage(): Promise<ReactNode> {
       </header>
       <PolicyContent body={content} />
       <footer className="panorama-legal-footer">
-        <a href="/legal/terms">{messages.t('legal.terms.title')}</a>
+        <Link href="/legal/terms">{messages.t('legal.terms.title')}</Link>
         <span> · </span>
-        <a href="/">{messages.t('legal.backToHome')}</a>
+        <Link href="/">{messages.t('legal.backToHome')}</Link>
       </footer>
     </article>
   );

--- a/apps/web/src/app/legal/terms/content.ts
+++ b/apps/web/src/app/legal/terms/content.ts
@@ -1,0 +1,470 @@
+/**
+ * Plain-language Terms of Service content, per locale.
+ *
+ * Wave 0 §9 plain-language v1 draft. Final language pending counsel
+ * review per ADR-0014 §C6 trigger. The "Status notice" at the bottom
+ * of each locale block makes the pre-counsel state explicit.
+ *
+ * Last updated: 2026-05-18 — exposed via `LAST_UPDATED_ISO`.
+ */
+
+export const LAST_UPDATED_ISO = '2026-05-18';
+
+export const TERMS_CONTENT = {
+  en: `
+These Terms of Service ("Terms") govern your use of the hosted
+Panorama instance at panorama.vitormr.dev. If you are running
+Panorama yourself under the AGPL licence, your relationship is
+with the LICENSE.md text, not this document — see the "Self-host
+vs hosted" section below.
+
+We try to write these in plain language. Where a Brazilian-law
+term has a precise legal meaning that does not translate cleanly,
+we keep the Portuguese term in parentheses.
+
+## Self-host vs hosted
+
+Panorama is offered in two ways:
+
+1. **Self-hosted** — you, or a third party on your behalf, run
+   Panorama on your own infrastructure under the GNU AGPLv3
+   licence. Your relationship is with the LICENSE.md file in the
+   public repository at github.com/VitorMRodovalho/panorama. These
+   Terms do NOT govern that use. The AGPL governs.
+2. **Hosted** — the maintainer runs Panorama at
+   panorama.vitormr.dev and you log in as a tenant. These Terms
+   govern THAT use.
+
+The rest of this document is about the hosted offering.
+
+## What Panorama is
+
+Panorama is a fleet and asset management service. You and your
+tenant's members use it to track vehicles or other assets, create
+reservations, run inspections, manage maintenance, and produce
+audit-trail records of operational decisions. The complete current
+feature surface is described at \`https://panorama.vitormr.dev/en/feature-matrix\`.
+
+## Who can use it
+
+You can use the hosted Panorama instance if:
+
+- You are 18 years old or older, or are using it on behalf of
+  an organisation that you are authorised to bind to these Terms.
+- You provide accurate registration information.
+- You are not prohibited from using the service under applicable
+  law (e.g., you are not on a sanctions list the maintainer is
+  required to honour).
+
+If you are using Panorama for an organisation (which is the
+typical case), you confirm that you have the organisation's
+authority to do so. The tenant Owner role in Panorama is
+authoritative for the tenant; if you create accounts for other
+people in your tenant, you are responsible to those people for
+the data Panorama holds about them.
+
+## Account responsibilities
+
+- Keep your login credentials secret. If you use OIDC (Google or
+  Microsoft) to sign in, keep your IdP account secure.
+- Notify the maintainer at vitor@vitormr.dev if you suspect your
+  account has been compromised.
+- Do not share an account between multiple people; create one
+  account per person.
+
+## Acceptable use
+
+You agree NOT to:
+
+- Use the hosted instance for illegal activity in your
+  jurisdiction or in the maintainer's jurisdiction (Brazil).
+- Attempt to access another tenant's data. The multi-tenant
+  isolation contract is enforced by row-level security and any
+  attempt to bypass it is an out-of-scope action under our
+  security policy and may be reported to the relevant authorities.
+- Send unsolicited bulk email through the invitation surface.
+- Reverse-engineer the API to scrape data you would not otherwise
+  see, even within your own tenant if it violates your
+  organisation's own policies.
+- Run automated load tests against the hosted instance without
+  prior written agreement from the maintainer.
+- Use the hosted instance as a back-channel to attack other
+  third-party systems (no SSRF chain via the photo-upload pipeline,
+  no spam relay via SMTP, etc.).
+- Upload content (photos, comments, asset descriptions) that
+  contains child sexual abuse material, content depicting
+  non-consensual sexual acts, or content that incites violence
+  against identifiable persons.
+
+We can suspend or terminate your access without notice if you
+violate the acceptable-use rules.
+
+## Open-source licence
+
+Panorama's source code is published under the GNU Affero General
+Public License v3 (AGPLv3). The full licence text is at
+github.com/VitorMRodovalho/panorama/blob/main/LICENSE.
+
+These Terms govern your USE of the hosted instance. The AGPL
+governs the code itself — including any modifications to the
+hosted instance the maintainer might make. Per AGPL, the source
+of the running hosted instance is published in the repository's
+main branch (each release tag corresponds to a deployed version).
+
+## Hosted instance specifics
+
+While Panorama is in **public-preview** phase (as of the date
+above):
+
+- **No uptime SLA.** The hosted instance is offered as-is. We try
+  to keep it available but the preview is operated by a single
+  individual maintainer with bus-factor of 1.
+- **No paid support.** Bug reports go to the public GitHub repo
+  issues. Security reports go to vitor@vitormr.dev per
+  SECURITY.md.
+- **Data export available at any time.** Settings → Export
+  tenant data produces a tarball you can download for 24 hours.
+- **Backups** are managed by the underlying database provider;
+  see \`docs/runbooks/restore.md\` for the maintainer-side restore
+  drill cadence and observed RTO/RPO.
+- **Service may be discontinued** with 30 days notice. In that
+  event, you can export your data and migrate to a self-hosted
+  Panorama deployment (the same code, on your own infrastructure)
+  using the migration path documented at
+  \`https://panorama.vitormr.dev/en/self-hosting\`.
+
+When the hosted instance moves out of preview to a paid offering,
+these Terms will be updated and the 30-day change notice
+described below will apply.
+
+## Liability
+
+The hosted instance is offered AS-IS, WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED. Per AGPL Section 15, the maintainer is
+not liable for damages arising from your use of the hosted
+instance, except to the extent that Brazilian law (CDC, LGPD)
+imposes a non-waivable liability we cannot disclaim.
+
+Specifically, the maintainer is NOT responsible for:
+
+- Decisions you or your tenant members make based on data shown
+  in Panorama (e.g., a reservation conflict that the system
+  failed to surface — you should still verify in person).
+- Data loss resulting from your own action (deleting your own
+  tenant, revoking your own session, etc.).
+- Third-party services you choose to integrate with Panorama.
+- Compliance with regulatory frameworks that apply to YOUR
+  business but not to a generic SaaS fleet manager (e.g., DOT
+  hours-of-service compliance for commercial drivers — Panorama
+  surfaces the data, your operator interprets it).
+
+To the extent any liability is non-waivable under Brazilian law,
+it is limited to the amount you paid to the maintainer for the
+hosted service in the 12 months preceding the event giving rise
+to the liability. During the public-preview phase, this amount is
+zero, but Brazilian law may impose limits independent of that.
+
+Indemnification: you agree to defend, indemnify and hold the
+maintainer harmless from any claims arising out of your use of
+the hosted instance in violation of these Terms or applicable
+law.
+
+## Termination
+
+You can terminate by deleting your tenant (Settings → Delete
+tenant). Deletion has a 7-day grace period during which the
+tenant can be restored.
+
+The maintainer can terminate your access:
+
+- Immediately, without notice, for an acceptable-use violation
+  (see above).
+- With 30 days notice, for any other reason, including
+  discontinuation of the hosted instance.
+
+On termination, you can export your data during the grace
+period; after that, your tenant's data is purged from the
+database, except for audit-trail events about the deletion
+itself (retained for legal record).
+
+## Governing law and disputes
+
+These Terms are governed by the laws of the Federative Republic
+of Brazil. Disputes that cannot be resolved by good-faith
+communication go to the courts of the maintainer's residence
+(currently Brasília, DF, Brazil), unless Brazilian law mandates
+a different forum (e.g., consumer-protection cases under CDC,
+which can be brought in the consumer's home court).
+
+This choice of forum does not deprive you of mandatory
+consumer-protection rights under your local law.
+
+## Changes to these Terms
+
+When these Terms change, we will notify the email address on
+your account at least 30 days before the change takes effect.
+The current version date is shown at the top of the page.
+
+For material changes (e.g., introducing paid plans, changing
+the data-residency region, restricting acceptable-use scope),
+you can decline by terminating your tenant during the 30-day
+notice period; we will provide a data export at no cost.
+
+For non-material changes (typos, link updates, clarifying
+language), the 30-day notice still applies but no material
+decision-point is presented.
+
+## Contact
+
+Any question about these Terms: vitor@vitormr.dev.
+
+---
+
+**Status notice (this draft).** This is the plain-language v1
+draft per Round 7 of the Wave 0 acceptance plan. The maintainer
+will engage qualified legal counsel before the hosted Panorama
+URL is announced publicly to a paying audience. The terms may
+change as a result of counsel review; the change-notice above
+(30-day window) applies to any post-counsel revision.
+`,
+
+  'pt-br': `
+Estes Termos de Serviço ("Termos") regem seu uso da instância
+hospedada da Panorama em panorama.vitormr.dev. Se você está
+executando a Panorama por conta própria sob a licença AGPL, sua
+relação é com o texto do LICENSE.md, não com este documento — veja
+a seção "Auto-hospedado vs hospedado" abaixo.
+
+Tentamos escrever em linguagem clara. Onde um termo de direito
+brasileiro tem significado jurídico preciso que não traduz bem,
+mantemos o termo em inglês entre parênteses.
+
+## Auto-hospedado vs hospedado
+
+A Panorama é oferecida de duas formas:
+
+1. **Auto-hospedado** — você, ou um terceiro em seu nome, executa
+   a Panorama na própria infraestrutura sob a licença GNU AGPLv3.
+   Sua relação é com o arquivo LICENSE.md no repositório público
+   em github.com/VitorMRodovalho/panorama. Estes Termos NÃO regem
+   esse uso. A AGPL rege.
+2. **Hospedado** — o mantenedor executa a Panorama em
+   panorama.vitormr.dev e você entra como tenant. Estes Termos
+   regem ESSE uso.
+
+O restante deste documento trata da oferta hospedada.
+
+## O que é a Panorama
+
+A Panorama é um serviço de gestão de frota e ativos. Você e os
+membros do seu tenant a usam para rastrear veículos ou outros
+ativos, criar reservas, executar inspeções, gerenciar manutenção
+e produzir registros de auditoria de decisões operacionais. A
+superfície atual completa de recursos está descrita em
+\`https://panorama.vitormr.dev/en/feature-matrix\`.
+
+## Quem pode usar
+
+Você pode usar a instância hospedada da Panorama se:
+
+- Tiver 18 anos ou mais, ou estiver usando em nome de uma
+  organização que você esteja autorizado a vincular a estes Termos.
+- Fornecer informações de registro precisas.
+- Não estiver proibido de usar o serviço sob a lei aplicável
+  (por exemplo, não estiver em lista de sanções que o mantenedor
+  deva honrar).
+
+Se está usando a Panorama por uma organização (caso típico),
+confirma ter a autoridade da organização para fazê-lo. O papel
+Owner do tenant na Panorama é autoritativo para o tenant; se
+criar contas para outras pessoas no seu tenant, é responsável
+perante essas pessoas pelos dados que a Panorama mantém sobre
+elas.
+
+## Responsabilidades de conta
+
+- Mantenha suas credenciais de login em segredo. Se usar OIDC
+  (Google ou Microsoft) para entrar, mantenha sua conta IdP
+  segura.
+- Notifique o mantenedor em vitor@vitormr.dev se suspeitar que
+  sua conta foi comprometida.
+- Não compartilhe uma conta entre várias pessoas; crie uma conta
+  por pessoa.
+
+## Uso aceitável
+
+Você concorda em NÃO:
+
+- Usar a instância hospedada para atividade ilegal na sua
+  jurisdição ou na do mantenedor (Brasil).
+- Tentar acessar dados de outro tenant. O contrato de isolamento
+  multi-tenant é aplicado por row-level security e qualquer
+  tentativa de contorná-lo é ação fora de escopo sob nossa
+  política de segurança e pode ser reportada às autoridades.
+- Enviar e-mail em massa não solicitado via convites.
+- Reverter-engenharia da API para coletar dados que de outra
+  forma não veria, mesmo dentro do próprio tenant se isso violar
+  as políticas internas da sua organização.
+- Executar testes de carga automatizados contra a instância
+  hospedada sem acordo prévio por escrito do mantenedor.
+- Usar a instância hospedada como canal lateral para atacar
+  outros sistemas de terceiros (sem cadeia SSRF via pipeline de
+  upload de fotos, sem relay de spam via SMTP, etc.).
+- Enviar conteúdo (fotos, comentários, descrições de ativos) que
+  contenha material de abuso sexual infantil, conteúdo
+  retratando atos sexuais não consensuais ou conteúdo que incite
+  violência contra pessoas identificáveis.
+
+Podemos suspender ou encerrar seu acesso sem aviso se você violar
+as regras de uso aceitável.
+
+## Licença open-source
+
+O código-fonte da Panorama é publicado sob a GNU Affero General
+Public License v3 (AGPLv3). O texto completo da licença está em
+github.com/VitorMRodovalho/panorama/blob/main/LICENSE.
+
+Estes Termos regem seu USO da instância hospedada. A AGPL rege
+o código em si — incluindo modificações que o mantenedor possa
+fazer à instância hospedada. Por AGPL, o código-fonte da
+instância em execução é publicado na main branch do repositório
+(cada tag de release corresponde a uma versão implantada).
+
+## Especificidades da instância hospedada
+
+Enquanto a Panorama estiver na fase de **public-preview** (na
+data acima):
+
+- **Sem SLA de uptime.** A instância hospedada é oferecida como
+  está. Tentamos mantê-la disponível, mas o preview é operado
+  por um único mantenedor individual com bus-factor 1.
+- **Sem suporte pago.** Relatórios de bugs vão para issues do
+  repositório GitHub público. Relatórios de segurança vão para
+  vitor@vitormr.dev conforme SECURITY.md.
+- **Exportação de dados disponível a qualquer momento.**
+  Configurações → Exportar dados do tenant produz um tarball que
+  você pode baixar por 24 horas.
+- **Backups** são gerenciados pelo provedor de banco subjacente;
+  veja \`docs/runbooks/restore.md\` para a cadência de drill de
+  restauração do mantenedor e RTO/RPO observados.
+- **O serviço pode ser descontinuado** com aviso prévio de 30
+  dias. Nesse caso, pode exportar seus dados e migrar para uma
+  implantação auto-hospedada da Panorama (mesmo código, em
+  infraestrutura própria) usando o caminho de migração
+  documentado em \`https://panorama.vitormr.dev/en/self-hosting\`.
+
+Quando a instância hospedada sair do preview para uma oferta
+paga, estes Termos serão atualizados e o aviso de alteração de
+30 dias descrito abaixo se aplicará.
+
+## Responsabilidade
+
+A instância hospedada é oferecida COMO ESTÁ, SEM GARANTIA DE
+QUALQUER TIPO, EXPRESSA OU IMPLÍCITA. Conforme a AGPL Seção 15,
+o mantenedor não é responsável por danos decorrentes do seu uso
+da instância hospedada, exceto na medida em que a lei brasileira
+(CDC, LGPD) imponha responsabilidade não-renunciável que não
+podemos afastar.
+
+Especificamente, o mantenedor NÃO é responsável por:
+
+- Decisões que você ou membros do seu tenant tomam com base em
+  dados exibidos na Panorama (por exemplo, conflito de reserva
+  que o sistema não tenha sinalizado — verifique pessoalmente).
+- Perda de dados resultante de sua própria ação (excluir o
+  próprio tenant, revogar a própria sessão, etc.).
+- Serviços de terceiros que você escolhe integrar com a Panorama.
+- Conformidade com marcos regulatórios aplicáveis ao SEU negócio
+  mas não a um SaaS genérico de frota (por exemplo, conformidade
+  com a jornada de trabalho de motoristas profissionais —
+  a Panorama exibe os dados, seu operador os interpreta).
+
+Na medida em que qualquer responsabilidade seja não-renunciável
+sob a lei brasileira, fica limitada ao valor que você pagou ao
+mantenedor pelo serviço hospedado nos 12 meses anteriores ao
+evento que ensejou a responsabilidade. Durante a fase de
+public-preview, esse valor é zero, mas a lei brasileira pode
+impor limites independentes disso.
+
+Indenização: você concorda em defender, indenizar e isentar o
+mantenedor de quaisquer reivindicações decorrentes do seu uso da
+instância hospedada em violação destes Termos ou da lei
+aplicável.
+
+## Rescisão
+
+Você pode rescindir excluindo seu tenant (Configurações →
+Excluir tenant). A exclusão tem período de graça de 7 dias
+durante o qual o tenant pode ser restaurado.
+
+O mantenedor pode rescindir seu acesso:
+
+- Imediatamente, sem aviso, por violação de uso aceitável (veja
+  acima).
+- Com aviso prévio de 30 dias, por qualquer outra razão,
+  incluindo descontinuidade da instância hospedada.
+
+Na rescisão, você pode exportar seus dados durante o período de
+graça; após isso, os dados do seu tenant são removidos do banco,
+exceto eventos de trilha de auditoria sobre a própria exclusão
+(retidos para registro legal).
+
+## Lei aplicável e disputas
+
+Estes Termos são regidos pelas leis da República Federativa do
+Brasil. Disputas que não possam ser resolvidas por comunicação
+de boa-fé vão para os tribunais da residência do mantenedor
+(atualmente Brasília, DF, Brasil), salvo se a lei brasileira
+mandar foro diverso (por exemplo, casos de proteção do consumidor
+sob CDC, que podem ser ajuizados no foro do consumidor).
+
+Esta escolha de foro não afasta direitos mandatórios de proteção
+do consumidor sob sua lei local.
+
+## Alterações nestes Termos
+
+Quando estes Termos mudarem, notificaremos o e-mail da sua conta
+com pelo menos 30 dias de antecedência. A data da versão atual
+aparece no topo da página.
+
+Para mudanças materiais (por exemplo, introdução de planos pagos,
+alteração da região de residência de dados, restrição do uso
+aceitável), você pode declinar rescindindo seu tenant durante o
+período de aviso de 30 dias; faremos a exportação dos dados sem
+custo.
+
+Para mudanças não-materiais (typos, atualizações de links,
+linguagem de esclarecimento), o aviso de 30 dias ainda se aplica
+mas nenhuma decisão material é apresentada.
+
+## Contato
+
+Qualquer pergunta sobre estes Termos: vitor@vitormr.dev.
+
+---
+
+**Aviso de status (este rascunho).** Esta é a versão v1 em
+linguagem clara do plano Round 7 da aceitação Wave 0. O mantenedor
+contratará assessoria jurídica qualificada antes de a URL
+hospedada da Panorama ser anunciada publicamente a uma audiência
+pagante. Os termos podem mudar após revisão jurídica; o aviso de
+alteração de 30 dias acima se aplica a qualquer revisão
+pós-revisão jurídica.
+`,
+
+  es: `
+**Versión en español pendiente.** El texto canónico de los
+Términos de Servicio de Panorama está disponible en inglés y
+portugués brasileño en esta misma página, por favor seleccione su
+idioma en el selector de idiomas o use el contenido en inglés /
+portugués como referencia.
+
+La traducción al español será publicada después de la revisión
+jurídica de Round 7 (Wave 0 — antes del lanzamiento público de
+la URL hospedada). Hasta entonces, la versión en inglés (canónica)
+o portugués (mercado brasileño / LGPD) son los textos vigentes.
+
+Para cualquier pregunta sobre los Términos, contacte:
+vitor@vitormr.dev.
+`,
+} as const;

--- a/apps/web/src/app/legal/terms/page.tsx
+++ b/apps/web/src/app/legal/terms/page.tsx
@@ -1,0 +1,118 @@
+import type { Metadata, ResolvingMetadata } from 'next';
+import type { ReactNode } from 'react';
+import { loadMessages, resolveRequestLocale } from '@/lib/i18n';
+import { TERMS_CONTENT, LAST_UPDATED_ISO } from './content';
+
+export async function generateMetadata(
+  _props: unknown,
+  _parent: ResolvingMetadata,
+): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
+  const messages = loadMessages(locale);
+  return {
+    title: `${messages.t('legal.terms.title')} · Panorama`,
+    description: messages.t('legal.terms.metaDescription'),
+  };
+}
+
+/**
+ * Terms of Service — Wave 0 §9 plain-language v1 draft.
+ *
+ * Server-rendered, public route (no auth). Content per locale lives
+ * in `./content.ts`. Pre-counsel-review draft per ADR-0014 §C6
+ * trigger; the "Status notice" at the bottom of each locale block
+ * makes the pre-review state explicit to readers.
+ *
+ * Same parsing/rendering primitives as the privacy page; the parser
+ * is duplicated rather than imported because the legal pages each
+ * own their own scope and we don't want a shared "legal-render" lib
+ * to become a god-file. If a third legal page ships (e.g., DPA),
+ * THEN extract per the rule-of-three.
+ */
+export default async function TermsPage(): Promise<ReactNode> {
+  const locale = await resolveRequestLocale();
+  const messages = loadMessages(locale);
+  const content = TERMS_CONTENT[locale];
+  return (
+    <article className="panorama-legal-article">
+      <header>
+        <h1>{messages.t('legal.terms.title')}</h1>
+        <p className="panorama-legal-updated">
+          {messages.t('legal.lastUpdated', { date: LAST_UPDATED_ISO })}
+        </p>
+        <p className="panorama-legal-status">
+          {messages.t('legal.preCounselDraftBanner')}
+        </p>
+      </header>
+      <PolicyContent body={content} />
+      <footer className="panorama-legal-footer">
+        <a href="/legal/privacy">{messages.t('legal.privacy.title')}</a>
+        <span> · </span>
+        <a href="/">{messages.t('legal.backToHome')}</a>
+      </footer>
+    </article>
+  );
+}
+
+function PolicyContent({ body }: { body: string }): ReactNode {
+  const sections = body.trim().split(/\n\n+/);
+  return (
+    <div className="panorama-legal-body">
+      {sections.map((section, idx) => renderSection(section, idx))}
+    </div>
+  );
+}
+
+function renderSection(section: string, idx: number): ReactNode {
+  const trimmed = section.trim();
+  if (trimmed.startsWith('## ')) {
+    return <h2 key={idx}>{trimmed.slice(3)}</h2>;
+  }
+  if (trimmed.startsWith('---')) {
+    return <hr key={idx} />;
+  }
+  if (/^[-*] /m.test(trimmed) && trimmed.split('\n').every((line) => /^[-*] /.test(line))) {
+    const items = trimmed.split('\n').map((line) => line.replace(/^[-*] /, ''));
+    return (
+      <ul key={idx}>
+        {items.map((item, i) => (
+          <li key={i}>{renderInline(item)}</li>
+        ))}
+      </ul>
+    );
+  }
+  if (/^\d+\. /m.test(trimmed) && trimmed.split('\n').every((line) => /^\d+\. /.test(line))) {
+    const items = trimmed.split('\n').map((line) => line.replace(/^\d+\. /, ''));
+    return (
+      <ol key={idx}>
+        {items.map((item, i) => (
+          <li key={i}>{renderInline(item)}</li>
+        ))}
+      </ol>
+    );
+  }
+  return <p key={idx}>{renderInline(trimmed)}</p>;
+}
+
+function renderInline(text: string): ReactNode {
+  const parts: ReactNode[] = [];
+  const regex = /(\*\*[^*]+\*\*|`[^`]+`)/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index));
+    }
+    const token = match[0];
+    if (token.startsWith('**')) {
+      parts.push(<strong key={match.index}>{token.slice(2, -2)}</strong>);
+    } else if (token.startsWith('`')) {
+      parts.push(<code key={match.index}>{token.slice(1, -1)}</code>);
+    }
+    lastIndex = match.index + token.length;
+  }
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+  return <>{parts}</>;
+}

--- a/apps/web/src/app/legal/terms/page.tsx
+++ b/apps/web/src/app/legal/terms/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, ResolvingMetadata } from 'next';
 import type { ReactNode } from 'react';
+import Link from 'next/link';
 import { loadMessages, resolveRequestLocale } from '@/lib/i18n';
 import { TERMS_CONTENT, LAST_UPDATED_ISO } from './content';
 
@@ -46,9 +47,9 @@ export default async function TermsPage(): Promise<ReactNode> {
       </header>
       <PolicyContent body={content} />
       <footer className="panorama-legal-footer">
-        <a href="/legal/privacy">{messages.t('legal.privacy.title')}</a>
+        <Link href="/legal/privacy">{messages.t('legal.privacy.title')}</Link>
         <span> · </span>
-        <a href="/">{messages.t('legal.backToHome')}</a>
+        <Link href="/">{messages.t('legal.backToHome')}</Link>
       </footer>
     </article>
   );

--- a/packages/i18n/en/common.json
+++ b/packages/i18n/en/common.json
@@ -581,5 +581,12 @@
   "inspection.template.error.category_not_found": "Category not found in this tenant.",
   "inspection.template.error.name_required": "Name is required.",
   "inspection.template.error.pick_scope": "Pick a scope.",
-  "inspection.template.error.generic": "Something went wrong. Please try again."
+  "inspection.template.error.generic": "Something went wrong. Please try again.",
+  "legal.privacy.title": "Privacy Policy",
+  "legal.privacy.metaDescription": "How Panorama collects, uses, and protects your data. LGPD-aligned plain-language draft.",
+  "legal.terms.title": "Terms of Service",
+  "legal.terms.metaDescription": "Terms governing your use of the hosted Panorama instance. AGPL self-hosted use is governed by LICENSE.md.",
+  "legal.lastUpdated": "Last updated: {{date}}",
+  "legal.preCounselDraftBanner": "Pre-counsel-review plain-language draft. Final wording may change after counsel review per ADR-0014 §C6 trigger. Status notice at end of document.",
+  "legal.backToHome": "Back to home"
 }

--- a/packages/i18n/es/common.json
+++ b/packages/i18n/es/common.json
@@ -581,5 +581,12 @@
   "inspection.template.error.category_not_found": "Categoría no encontrada en este tenant.",
   "inspection.template.error.name_required": "Nombre es obligatorio.",
   "inspection.template.error.pick_scope": "Elija un alcance.",
-  "inspection.template.error.generic": "Algo salió mal. Inténtelo de nuevo."
+  "inspection.template.error.generic": "Algo salió mal. Inténtelo de nuevo.",
+  "legal.privacy.title": "Política de Privacidad",
+  "legal.privacy.metaDescription": "Cómo Panorama recopila, usa y protege sus datos. Borrador en lenguaje claro alineado con LGPD.",
+  "legal.terms.title": "Términos de Servicio",
+  "legal.terms.metaDescription": "Términos que rigen el uso de la instancia hospedada de Panorama. El uso auto-hospedado bajo AGPL se rige por LICENSE.md.",
+  "legal.lastUpdated": "Actualizado: {{date}}",
+  "legal.preCounselDraftBanner": "Borrador en lenguaje claro, pre-revisión jurídica. El texto puede cambiar tras la revisión legal por el disparador ADR-0014 §C6. Aviso de estado al final del documento.",
+  "legal.backToHome": "Volver al inicio"
 }

--- a/packages/i18n/pt-br/common.json
+++ b/packages/i18n/pt-br/common.json
@@ -581,5 +581,12 @@
   "inspection.template.error.category_not_found": "Categoria não encontrada neste tenant.",
   "inspection.template.error.name_required": "Nome é obrigatório.",
   "inspection.template.error.pick_scope": "Escolha um escopo.",
-  "inspection.template.error.generic": "Algo deu errado. Tente novamente."
+  "inspection.template.error.generic": "Algo deu errado. Tente novamente.",
+  "legal.privacy.title": "Política de Privacidade",
+  "legal.privacy.metaDescription": "Como a Panorama coleta, usa e protege seus dados. Rascunho em linguagem clara alinhado à LGPD.",
+  "legal.terms.title": "Termos de Serviço",
+  "legal.terms.metaDescription": "Termos que regem o uso da instância hospedada da Panorama. Uso auto-hospedado sob AGPL é regido pelo LICENSE.md.",
+  "legal.lastUpdated": "Atualizado em: {{date}}",
+  "legal.preCounselDraftBanner": "Rascunho em linguagem clara, pré-revisão jurídica. O texto pode mudar após revisão por advogado conforme gatilho ADR-0014 §C6. Aviso de status ao final do documento.",
+  "legal.backToHome": "Voltar para o início"
 }


### PR DESCRIPTION
## Summary

Closes the Wave 0 §9 "Privacy + ToS at `apps/web/src/app/legal/*`" acceptance item per HANDOFF-2026-05-16-wave0-scan.md:208-211.

**Plain-language v1 drafts, pre-counsel-review** per ADR-0014 §C6 trigger. The "Status notice (this draft)" block at the bottom of each locale's content explicitly tells readers the text may change after counsel review.

## What's in scope

### Web routes

- **`/legal/privacy`** (`apps/web/src/app/legal/privacy/page.tsx`) — Privacy Policy, server-rendered, zero client JS, public (no auth)
- **`/legal/terms`** (`apps/web/src/app/legal/terms/page.tsx`) — Terms of Service, same shape
- **`apps/web/src/app/legal/layout.tsx`** — public legal-page wrapper

Each page imports its content from a sibling `content.ts` keyed by locale and renders via a minimal markdown-ish parser (handles `##` headings / `-` bullets / `1.` numbered lists / `**bold**` / `` `code` `` — no external markdown library; rule-of-three deferred until a third legal page lands).

### LGPD Art. 9 mandatories explicitly covered

The Privacy Policy hits every item LGPD Art. 9 requires:

| LGPD Art. 9 item | Privacy Policy section |
|---|---|
| I — specific purpose of processing | "Why we collect it" |
| II — form and duration | "How long we keep it" |
| III — controller identification | "Who is the controller?" |
| IV — contact information | "Contact" + maintainer email |
| V — shared data + purpose | "Sub-processor categories" |
| VI — responsibilities of agents | implicit in sub-processor + self-host vs hosted split |
| VII — data subject rights (Art. 18) | "Your rights under LGPD Art. 18" (8 sub-points) |

### Sub-processor categories (not vendors)

Per security-reviewer C2 from the 2026-05-16 Wave 0 6-agent scan, the Privacy Policy names CATEGORIES not specific vendors. Reduces attack surface against the operator's vendor relationships; specific vendor names available to tenants under NDA on contractual or regulatory need.

Categories: cloud hosting (IaaS), managed Postgres, object storage (S3-compatible), email delivery (SMTP), OIDC identity providers, error monitoring (opt-in), CAPTCHA (signup-only). Explicitly: NO third-party analytics or advertising services.

### Locale coverage

- **EN** (~3000 words total) — canonical pre-counsel draft
- **PT-BR** (~3000 words total) — parallel translation; the load-bearing locale since LGPD/Brazil is the regulatory regime
- **ES** — placeholder + pointer to EN/PT-BR. Full Spanish translation ships after counsel review covers all three locales coherently.

### Terms of Service highlights

- Self-host vs hosted distinction (self-host is governed by LICENSE.md AGPL, not these Terms)
- Acceptable use rules (no cross-tenant access attempts, no spam-relay via SMTP, no SSRF via photo-upload, etc.)
- Hosted instance specifics: no SLA in preview, no paid support, data export anytime, 30-day discontinuation notice
- Liability AS-IS per AGPL §15 with Brazilian non-waivable carve-out (CDC/LGPD); during preview the paid-amount limiter is zero
- Termination via Settings → Delete tenant with 7-day grace period
- Governing law Brazilian; CDC consumer-protection forum carve-out

### i18n

7 new keys in `packages/i18n/{en,pt-br,es}/common.json`:
- `legal.privacy.title` / `legal.terms.title`
- `legal.privacy.metaDescription` / `legal.terms.metaDescription`
- `legal.lastUpdated` (with `{{date}}` placeholder)
- `legal.preCounselDraftBanner`
- `legal.backToHome`

`pnpm i18n:check` passes — EN/PT-BR/ES key parity confirmed locally.

### Styling

`apps/web/src/app/globals.css` extended with `.panorama-legal*` classes optimised for long-form reading:

- 760px max-width column for readability
- 16px base font + 1.65 line-height
- ≥48px tap-target on footer links (ux-critic concern from the planning round)
- Status notice block uses background tint + left border for emphasis (status-by-text-not-colour discipline preserved — the text explicitly says "pre-counsel-review draft")

## Verified locally

- `pnpm i18n:check` — i18n coverage OK (EN/PT-BR/ES in sync across 3 locales)
- `pnpm docs:build` — VitePress build clean
- Backticks inside TS template literals escaped correctly (`\``)
- The pre-existing typecheck issues on main (Node 24 local vs Node 22 CI mismatch; `Type 'bigint' is not assignable to AwaitedReactNode`) pre-exist this PR; not regressions

## Out of scope (and deferred)

- **Counsel-review pass.** Maintainer engages a Brazilian-LGPD-qualified lawyer before announcing the URL flip publicly to paying tenants. Post-counsel revisions land in a follow-up PR with the 30-day change notice the document itself promises.
- **ES full translation** — ships after counsel-review covers all three locales coherently.
- **Marketing-site footer links** to `/legal/privacy` + `/legal/terms` — operator-side follow-up; the legal pages exist at the routes regardless.
- **DPA (Data Processing Agreement)** — Enterprise wedge per ADR-0002; not in scope for the Community / public-preview surface.

## Wave 0 §9 status after this PR

| Item | Status |
|---|---|
| Status page (Upptime on GH Actions) | ✅ (#243) |
| SBOM + cosign keyless signing | ✅ (#244) |
| Privacy / ToS plain-language v1 | ✅ (this PR — pre-counsel draft) |
| Counsel-review pass | ⏳ External dependency; gates URL flip alone |

After this PR merges + counsel review completes, Wave 0 §9 closes fully. §10 (v2 6-agent scan + ADR-0014 amendment with URL-flip go/no-go) is the last item.

## Refs

- `HANDOFF-2026-05-16-wave0-scan.md:208-211` — Wave 0 §9 Privacy + ToS acceptance item
- `HANDOFF-2026-05-16-wave0-scan.md` §security C2 — sub-processor CATEGORIES not vendors threat model
- ADR-0014 §C6 — counsel-review trigger
- `docs/audits/roadmap-to-feature-complete-2026-05-18.md` (PR #242) — Wave 0 closure preconditions

## Test plan

- [x] `pnpm i18n:check` — i18n parity verified
- [x] `pnpm docs:build` — VitePress build clean
- [x] Backticks escaped correctly in TS template literals
- [ ] CI green on push (Lint + typecheck + unit tests + i18n coverage + etc.)
- [ ] Manual review of legal text by maintainer (you) for tone/accuracy
- [ ] Counsel-review pass before URL flip (external; tracked separately)