### PR TITLE
feat(auth): emit panorama.auth.session_secret_rotated audit row on boot (#234)

### DIFF
--- a/apps/core-api/src/modules/audit/audit-actions.ts
+++ b/apps/core-api/src/modules/audit/audit-actions.ts
@@ -107,6 +107,32 @@ export const PanoramaAuditAction = {
    * `idpErrorCode` (sanitized; only set when `reason === 'idp_error'`).
    */
   AuthSignupOidcStateMismatch: 'panorama.auth.signup_oidc_state_mismatch',
+  /**
+   * SESSION_SECRET rotation window is active (#234). Cluster-wide event
+   * (`tenantId=null`) emitted by BootAuditService on every boot when
+   * `SESSION_SECRET_PREVIOUS` is set — the configuration state the
+   * `auth_config_session_secret_rotation_active` boot INFO log already
+   * captures in stdout (#232). The boot log is sufficient for self-host
+   * triage; this row gives security-conscious tenant admins the same
+   * signal inside the tamper-detected audit chain so a config change
+   * with security implications doesn't live only in operator stdout.
+   *
+   * Implementation per the issue's option (a): emit every boot with
+   * the secondary set, accept that a restart-heavy day produces N rows
+   * for the same logical "rotation window active" fact. Operators
+   * dedupe by `occurredAt` window (e.g., collapse rows within the same
+   * deploy fingerprint or rolling restart cycle) — see
+   * `docs/runbooks/secrets-rotation.md` Step 2 for the recommended
+   * filter. Trade-off accepted because alternatives (b) a persisted
+   * state table or (c) RELOAD-only emission both reach into Round 6
+   * schema work or a future SIGHUP feature, neither of which is
+   * justified by the dedup cost.
+   *
+   * Metadata: `rotationActive: true` (always — the absence of the row
+   * is the "no rotation" signal). Never includes the secret values or
+   * lengths — same hard-rule as the existing boot INFO log.
+   */
+  AuthSessionSecretRotated: 'panorama.auth.session_secret_rotated',
 
   // -------- panorama.tenant.* --------
   /**

--- a/apps/core-api/src/modules/boot-audit/boot-audit.module.ts
+++ b/apps/core-api/src/modules/boot-audit/boot-audit.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module.js';
 import { BootAuditService } from './boot-audit.service.js';
 
 /**
@@ -12,8 +13,14 @@ import { BootAuditService } from './boot-audit.service.js';
  * of AuditModule. The constructor's PrismaService injection is the
  * dependency-graph signal that makes Nest wait until Prisma is
  * connected before instantiating us.
+ *
+ * AuthModule is imported explicitly (not @Global) so we can inject
+ * AuthConfigService — needed to check the SESSION_SECRET rotation
+ * state when emitting the `panorama.auth.session_secret_rotated`
+ * row (#234). AuthConfigService is in AuthModule's `exports` list.
  */
 @Module({
+  imports: [AuthModule],
   providers: [BootAuditService],
 })
 export class BootAuditModule {}

--- a/apps/core-api/src/modules/boot-audit/boot-audit.service.ts
+++ b/apps/core-api/src/modules/boot-audit/boot-audit.service.ts
@@ -22,6 +22,8 @@ import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { URL } from 'node:url';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { AuditService } from '../audit/audit.service.js';
+import { AuthConfigService } from '../auth/auth.config.js';
+import { PanoramaAuditAction } from '../audit/audit-actions.js';
 
 @Injectable()
 export class BootAuditService implements OnModuleInit {
@@ -30,6 +32,7 @@ export class BootAuditService implements OnModuleInit {
   constructor(
     private readonly prisma: PrismaService,
     private readonly audit: AuditService,
+    private readonly authConfig: AuthConfigService,
   ) {
     // Reference the prisma field so the linter doesn't flag it as
     // unused — we depend on PrismaModule being initialised before we
@@ -52,6 +55,14 @@ export class BootAuditService implements OnModuleInit {
       await this.recordRedisAudit();
     } catch (err) {
       this.log.warn({ err: String(err) }, 'redis_boot_audit_failed');
+    }
+    try {
+      await this.recordSessionSecretRotationAudit();
+    } catch (err) {
+      this.log.warn(
+        { err: String(err) },
+        'session_secret_rotation_boot_audit_failed',
+      );
     }
   }
 
@@ -99,6 +110,46 @@ export class BootAuditService implements OnModuleInit {
         },
       });
     }
+  }
+
+  /**
+   * Emit a `panorama.auth.session_secret_rotated` audit row when the
+   * SESSION_SECRET rotation window is active at boot — i.e., when
+   * `AuthConfig.sessionSecretPrevious` is set (#234).
+   *
+   * Option (a) from the issue: emit every boot with the secondary
+   * set, accept that a restart-heavy day produces N duplicates of
+   * the same logical "rotation window active" fact. The boot INFO
+   * log `auth_config_session_secret_rotation_active` already exists
+   * in stdout (#232); this row lands the same signal in the audit
+   * chain so non-stdout consumers (security-conscious tenant admins)
+   * can observe security-relevant config state from the audit feed.
+   *
+   * Hard rule mirrored from the boot INFO log: NEVER log the secret
+   * values themselves. Metadata carries only the boolean
+   * `rotationActive` — the absence of the row is the "no rotation"
+   * signal, the presence is the rotation-active signal.
+   *
+   * Operators dedupe the inevitable boot-N-times duplication by
+   * `occurredAt` window — see
+   * `docs/runbooks/secrets-rotation.md` Step 2 for the recommended
+   * filter.
+   */
+  private async recordSessionSecretRotationAudit(): Promise<void> {
+    if (this.authConfig.config.sessionSecretPrevious === undefined) {
+      // No rotation in flight — absence of the row IS the signal.
+      return;
+    }
+    await this.audit.record({
+      action: PanoramaAuditAction.AuthSessionSecretRotated,
+      resourceType: 'auth_config',
+      resourceId: 'session_secret',
+      tenantId: null,
+      actorUserId: null,
+      metadata: {
+        rotationActive: true,
+      },
+    });
   }
 
   private async recordRedisAudit(): Promise<void> {

--- a/apps/core-api/test/boot-audit-session-secret-rotation.test.ts
+++ b/apps/core-api/test/boot-audit-session-secret-rotation.test.ts
@@ -1,0 +1,111 @@
+import 'reflect-metadata';
+import { describe, expect, it, vi } from 'vitest';
+import { BootAuditService } from '../src/modules/boot-audit/boot-audit.service.js';
+import type {
+	AuditEventInput,
+	AuditService,
+} from '../src/modules/audit/audit.service.js';
+import type {
+	AuthConfig,
+	AuthConfigService,
+} from '../src/modules/auth/auth.config.js';
+import type { PrismaService } from '../src/modules/prisma/prisma.service.js';
+import { PanoramaAuditAction } from '../src/modules/audit/audit-actions.js';
+
+/**
+ * Unit coverage for the SESSION_SECRET rotation boot-audit (#234).
+ *
+ * Calls the private method directly via `as any` to avoid having to
+ * stub the db-pool / redis paths that `onModuleInit` also walks
+ * through — those have their own assertion surface (e2e). The
+ * rotation-state branch is what this PR adds and what this suite
+ * pins:
+ *   - rotation active (`sessionSecretPrevious` set) → exactly one
+ *     row with action / resourceType / resourceId / tenantId /
+ *     actorUserId pinned, and metadata `{ rotationActive: true }`
+ *     (no secret values or lengths — security-reviewer hard-rule
+ *     mirrored from the existing boot INFO log).
+ *   - rotation inactive (`sessionSecretPrevious === undefined`) →
+ *     zero rows. The absence of the row IS the "no rotation" signal
+ *     per the action's JSDoc; this is the canary that ensures a
+ *     future refactor cannot silently flip presence semantics.
+ */
+
+interface RecordingAudit extends AuditService {
+	calls: AuditEventInput[];
+}
+
+function makeAudit(): RecordingAudit {
+	const calls: AuditEventInput[] = [];
+	const audit = {
+		record: vi.fn(async (input: AuditEventInput) => {
+			calls.push(input);
+		}),
+		calls,
+	};
+	return audit as unknown as RecordingAudit;
+}
+
+function makeAuthConfig(
+	sessionSecretPrevious: string | undefined,
+): AuthConfigService {
+	// Only the rotation state matters for this test — the other
+	// AuthConfig fields are out of scope and stubbed to plausible
+	// values just to satisfy the type shape.
+	const config: AuthConfig = {
+		sessionSecret: 'a'.repeat(32),
+		...(sessionSecretPrevious !== undefined ? { sessionSecretPrevious } : {}),
+		sessionPassword:
+			sessionSecretPrevious !== undefined
+				? { 1: sessionSecretPrevious, 2: 'a'.repeat(32) }
+				: 'a'.repeat(32),
+		sessionCookieName: 'panorama_session',
+		oauthStateCookieName: 'panorama_oauth',
+		sessionMaxAgeSeconds: 60 * 60 * 24 * 7,
+		oauthStateMaxAgeSeconds: 5 * 60,
+		baseUrl: 'http://localhost:4000',
+		isProduction: false,
+		providers: {},
+		csrf: { trustedOrigins: new Set(['http://localhost:4000']) },
+	};
+	return { config } as AuthConfigService;
+}
+
+const fakePrisma = {} as PrismaService;
+
+describe('BootAuditService — session-secret rotation audit (#234)', () => {
+	it('emits panorama.auth.session_secret_rotated when sessionSecretPrevious is set', async () => {
+		const audit = makeAudit();
+		const authConfig = makeAuthConfig('b'.repeat(32));
+		const service = new BootAuditService(fakePrisma, audit, authConfig);
+
+		await (service as any).recordSessionSecretRotationAudit();
+
+		expect(audit.calls).toHaveLength(1);
+		const row = audit.calls[0]!;
+		expect(row.action).toBe(PanoramaAuditAction.AuthSessionSecretRotated);
+		expect(row.action).toBe('panorama.auth.session_secret_rotated');
+		expect(row.resourceType).toBe('auth_config');
+		expect(row.resourceId).toBe('session_secret');
+		expect(row.tenantId).toBeNull();
+		expect(row.actorUserId).toBeNull();
+		expect(row.metadata).toEqual({ rotationActive: true });
+		// Hard rule: metadata must NEVER carry secret values or lengths
+		// — mirroring `auth_config_session_secret_rotation_active`'s
+		// existing INFO-log constraint. Spot-check by serializing.
+		const blob = JSON.stringify(row.metadata);
+		expect(blob).not.toContain('a'.repeat(32));
+		expect(blob).not.toContain('b'.repeat(32));
+		expect(blob).not.toMatch(/length|len|size/i);
+	});
+
+	it('does NOT emit when sessionSecretPrevious is undefined (no rotation in flight)', async () => {
+		const audit = makeAudit();
+		const authConfig = makeAuthConfig(undefined);
+		const service = new BootAuditService(fakePrisma, audit, authConfig);
+
+		await (service as any).recordSessionSecretRotationAudit();
+
+		expect(audit.calls).toHaveLength(0);
+	});
+});

--- a/docs/runbooks/secrets-rotation.md
+++ b/docs/runbooks/secrets-rotation.md
@@ -205,6 +205,33 @@ users routed to the other.
 Also verify a fresh login succeeds AND an existing browser session
 (opened before the flip) continues to work without re-login.
 
+**Audit-chain alternative (recommended for non-operators).** The stdout
+grep above requires log access; tenant admins reviewing the in-app
+audit feed can confirm the same state from the audit chain — the
+`panorama.auth.session_secret_rotated` row (#234) is emitted at every
+boot when `SESSION_SECRET_PREVIOUS` is set:
+
+```sql
+SELECT id, occurred_at, metadata
+FROM audit_events
+WHERE action = 'panorama.auth.session_secret_rotated'
+  AND occurred_at >= now() - interval '1 hour'
+ORDER BY occurred_at DESC;
+```
+
+Expected: at least one row per replica in the window since the
+post-flip restart, each with `metadata = {"rotationActive": true}`.
+The row carries `tenantId = NULL` (cluster-wide event) and no secret
+values or lengths — only the boolean signal.
+
+Dedup: a restart-heavy day will emit one row per replica per boot, so
+the same logical "rotation window active" fact produces N rows in the
+operator's window. Filter to the most recent boot fingerprint (or
+collapse rows within the deploy's restart-spread window) when
+quoting the count to stakeholders. The boot INFO log above is the
+operationally cheaper signal when log access exists; this audit row
+is for the in-app review path.
+
 #### Step 3 — wait
 
 Wait at least `SESSION_MAX_AGE_SECONDS` (default 7 days,


### PR DESCRIPTION
Closes #234

## Summary

Bridges the gap between #232's boot INFO log (stdout-only, ops-visible) and the tenant-visible audit chain. `BootAuditService` now emits a `panorama.auth.session_secret_rotated` row on every boot when `SESSION_SECRET_PREVIOUS` is set, so a tenant admin reviewing the audit feed sees the rotation window from inside the app.

## Decision: option (a) per the issue

- Emit every boot with the secondary set (operators filter dedupe by `occurredAt` windows).
- Alternatives rejected: (b) persisted `session_secret_state` table reaches into Round 6 schema work; (c) RELOAD-only emission punts to a future SIGHUP/hot-reload feature. Neither is justified by the dedup cost.
- Restart-heavy day produces N duplicate rows; the runbook update documents the recommended `occurred_at >= now() - interval '1 hour'` filter.

## Hard rule

Metadata is **only** `{ rotationActive: true }`. NEVER the secret values, NEVER lengths — mirroring the existing `auth_config_session_secret_rotation_active` boot INFO log's constraint. The unit test serializes the metadata and asserts neither value-strings nor `length`/`len`/`size` words appear.

## Acceptance (per #234)

- [x] Audit row emitted at boot when `SESSION_SECRET_PREVIOUS` is set
- [x] Documented in `docs/runbooks/secrets-rotation.md` Step 2 as a verification alternative to the stdout grep
- [x] Test asserts the row is written on boot under the rotation-active config

## Diff

```
apps/core-api/src/modules/audit/audit-actions.ts   | 26 ++++++
apps/core-api/src/modules/boot-audit/boot-audit.module.ts    |  7 ++
apps/core-api/src/modules/boot-audit/boot-audit.service.ts   | 51 +++++++
apps/core-api/test/boot-audit-session-secret-rotation.test.ts | NEW
docs/runbooks/secrets-rotation.md                  | 27 ++++++
```

## Why the AuthConfigService injection (vs reading env directly)

`AuthConfigService` already curates the `sessionSecretPrevious` state with validation. Reading `process.env.SESSION_SECRET_PREVIOUS` directly inside BootAuditService would duplicate the length/equality validation logic and could drift on a future config rule change. `AuthModule` already exports `AuthConfigService`, so the injection is a one-line `imports: [AuthModule]` add in `BootAuditModule`.

## Validation

- [x] `pnpm --filter core-api typecheck` — clean
- [x] `pnpm --filter core-api lint`      — clean (0 errors / 0 warnings, `--max-warnings=0`)
- [x] `pnpm --filter core-api test`      — 525 / 525 (was 523 + 2 new)
- [x] `pnpm build`                        — 7 / 7 tasks

## Cross-references

- HANDOFF-2026-05-17-round-5-complete.md "Follow-ups filed" #2
- Security pre-impl scan (agentId a9e361829b14e1b70) — N2
- PR #232 — SESSION_SECRET rotation primitive
- ADR-0003 — NULL-strand convention for cluster-wide events
- Follows the established `BootAuditService` pattern (`panorama.boot.db_pool_configured`, `panorama.boot.redis_configured`)

## Test plan (post-merge)

- [ ] Deploy to staging with `SESSION_SECRET_PREVIOUS` set and confirm exactly one `panorama.auth.session_secret_rotated` row per replica in the audit_events table
- [ ] Deploy with `SESSION_SECRET_PREVIOUS` UNSET and confirm zero rows of that action are emitted in the boot window
- [ ] Cross-check with the existing `auth_config_session_secret_rotation_active` boot log to confirm both surfaces agree on the rotation state