### PR TITLE
refactor(auth): drop AuthConfig.sessionSecret field (#235)

### DIFF
--- a/apps/core-api/src/modules/auth/auth.config.ts
+++ b/apps/core-api/src/modules/auth/auth.config.ts
@@ -34,13 +34,17 @@ export interface OidcProviderConfig {
 }
 
 export interface AuthConfig {
-  sessionSecret: string;
   /**
    * Optional previous SESSION_SECRET retained during a rotation
    * window per ADR-0018-adjacent / runbooks/secrets-rotation.md.
-   * When set, iron-session will decrypt cookies sealed under the
-   * previous key while issuing all new cookies under
-   * `sessionSecret`. Undefined outside a rotation.
+   * When set, iron-session decrypts cookies sealed under the
+   * previous key while `sessionPassword` issues all new cookies
+   * under the new primary. Undefined outside a rotation.
+   *
+   * Diagnostics-only — DO NOT pass to iron-session directly. The
+   * iron-session contract is `sessionPassword` below; reading this
+   * field during a rotation window gives the OLD value, not the
+   * encrypt key for new cookies. See #235.
    */
   sessionSecretPrevious?: string;
   /**
@@ -49,6 +53,14 @@ export interface AuthConfig {
    * highest numeric key wins for encrypt; all keys are tried for
    * decrypt). Built once at config time so SessionService does not
    * carry the rotation logic.
+   *
+   * **THIS is the contract — never reach for the raw primary.**
+   * `sessionSecret` (the raw primary) was previously exposed on
+   * this interface but dropped in #235: a future caller reaching
+   * for the primary directly during a rotation window would get
+   * the NEW primary, NOT the encrypt key for cookies sealed under
+   * the previous secret. Use `sessionPassword`; iron-session
+   * handles encrypt-with-newest, decrypt-with-any internally.
    */
   sessionPassword: IronSessionPassword;
   sessionCookieName: string;
@@ -161,7 +173,6 @@ export class AuthConfigService {
     }
 
     this.config = {
-      sessionSecret,
       ...(sessionSecretPrevious !== undefined ? { sessionSecretPrevious } : {}),
       sessionPassword,
       sessionCookieName: process.env.SESSION_COOKIE_NAME ?? 'panorama_session',

--- a/apps/core-api/test/auth-config-session-secret.test.ts
+++ b/apps/core-api/test/auth-config-session-secret.test.ts
@@ -6,7 +6,8 @@ import { AuthConfigService } from '../src/modules/auth/auth.config.js';
 /**
  * Regression coverage for SEC-03 / #35 — the dev-only session-secret
  * fallback (`'dev-only-insecure-session-secret-replace-me-32b'`) used
- * to land in `config.sessionSecret` for any non-production environment
+ * to land in `config.sessionPassword` (and the now-removed
+ * `config.sessionSecret` per #235) for any non-production environment
  * when `SESSION_SECRET` was unset or too short. That meant staging,
  * UAT, and CI environments carrying real tenant data ended up
  * signing sessions with a value committed in source — full session
@@ -49,8 +50,13 @@ describe('AuthConfigService — SESSION_SECRET enforcement (#35)', () => {
     vi.stubEnv('SESSION_SECRET', 'a'.repeat(32));
 
     const cfg = new AuthConfigService();
-    expect(cfg.config.sessionSecret).toBe('a'.repeat(32));
-    expect(cfg.config.sessionSecret).not.toContain('dev-only-insecure');
+    // Single-key path: sessionPassword is a bare string equal to the
+    // primary value. Post-#235 this is the only surface to assert on
+    // (the raw `sessionSecret` field was dropped — its diagnostic
+    // value is below the cost of the stale-value foot-gun documented
+    // in the field's removal rationale).
+    expect(cfg.config.sessionPassword).toBe('a'.repeat(32));
+    expect(cfg.config.sessionPassword).not.toContain('dev-only-insecure');
   });
 
   it('accepts a valid 32-char secret', () => {
@@ -65,7 +71,7 @@ describe('AuthConfigService — SESSION_SECRET enforcement (#35)', () => {
     vi.stubEnv('SESSION_SECRET', 'b'.repeat(64));
 
     const cfg = new AuthConfigService();
-    expect(cfg.config.sessionSecret).toBe('b'.repeat(64));
+    expect(cfg.config.sessionPassword).toBe('b'.repeat(64));
     expect(cfg.config.isProduction).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #235

## Summary

Drops the `AuthConfig.sessionSecret` field. Path (2) from the issue — tech-lead-recommended; cleaner contract than the path-(1) `@deprecated` JSDoc.

## Why

PR3 (#232) exposed both `sessionSecret` (raw primary, kept \"for diagnostics\" + #35 regression test) and `sessionPassword` (iron-session-ready value). A future contributor reaching for `sessionSecret` directly during a rotation window gets the **NEW** primary — not the encrypt key for cookies sealed under the previous secret — and silently breaks decrypt for those sessions for 1+ week (until `SESSION_MAX_AGE_SECONDS` elapses per the runbook). The diagnostic value of the raw field is below that cost.

## Diff

```
apps/core-api/src/modules/auth/auth.config.ts       | 21 ++++++++++++++++-----
apps/core-api/test/auth-config-session-secret.test.ts | 14 ++++++++++----
2 files changed, 26 insertions(+), 9 deletions(-)
```

## What changed

- **`AuthConfig.sessionSecret` removed from interface.** Constructor no longer assigns it to `this.config`. The internal `const sessionSecret` local stays — it's still the input to the rotation/no-rotation branch that builds `sessionPassword`.
- **JSDoc on `sessionPassword` documents the contract**: \"never reach for the raw primary; the field that used to hide there is gone for the foot-gun rationale\". Inline anchor to #235.
- **JSDoc on `sessionSecretPrevious` updated** to call out the same diagnostics-only nature (it stays on the interface because the rotation tests need to assert presence vs absence).
- **Test (`auth-config-session-secret.test.ts`)** — 3 assertion sites migrated: `cfg.config.sessionSecret` → `cfg.config.sessionPassword`. In the single-key path `sessionPassword` is a bare string equal to the primary, so assertion semantics are preserved. File-level JSDoc rewritten to document the #235 removal so a future reader of the #35 regression knows where the raw primary went.

## No runtime behavior change

`SessionService` consumes `sessionPassword`. Nothing else read `sessionSecret`. The grep confirmed: the only other mentions in the codebase are `pino-logger.service.ts` redaction string literals (which redact ANY field named `sessionSecret` from logs — kept as defense-in-depth even though the field no longer exists; harmless and future-proofs against accidental reintroduction).

## Validation

- [x] `pnpm --filter core-api typecheck` — clean. The type-system removal is the pin: every caller has been migrated.
- [x] `pnpm --filter core-api lint`      — clean (0 errors / 0 warnings, `--max-warnings=0`)
- [x] `pnpm --filter core-api test`      — 523 / 523 (no regression vs main)

## Cross-references

- HANDOFF-2026-05-17-round-5-complete.md \"Follow-ups filed\" #3
- Tech-lead per-PR scan (agentId aa43860cb1d2d143e) \"CONCERNS\" item 1
- PR #232 — rotation primitive that introduced the dual surface
- PR #256 (sibling) — emits the `panorama.auth.session_secret_rotated` audit row that #234 asked for; semantically related but operates on a different layer (audit chain vs interface).

## Test plan (post-merge)

- [ ] Standard CI run — type drift on any caller still reading `cfg.config.sessionSecret` would fail typecheck on this branch already; CI is the canary that no other PR-in-flight reintroduces it
- [ ] Smoke `pnpm test` in a fresh clone to confirm the 523-passing baseline holds