### PR TITLE
chore(ci): pin all Actions to SHA + scope token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,21 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Minimal default token for every job. The only job that needs more is
+# container-scan (security-events: write to upload SARIF), which escalates
+# locally. Closes OSSF Scorecard TokenPermissions + CodeQL
+# actions/missing-workflow-permissions on this workflow.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint + typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -90,9 +97,9 @@ jobs:
       SMTP_HOST: localhost
       SMTP_PORT: "1025"
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -196,7 +203,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: core-api-coverage
           path: apps/core-api/coverage/
@@ -206,9 +213,9 @@ jobs:
     name: Web unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -223,9 +230,9 @@ jobs:
     name: i18n coverage (EN = PT-BR = ES)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -237,9 +244,9 @@ jobs:
     name: Dependency licence scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -250,9 +257,9 @@ jobs:
     name: No enterprise imports in community sources
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -289,9 +296,9 @@ jobs:
     # Pinned action version (was @master) per OSSF Scorecard
     # pinned-deps. Bumps go through deliberate review.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Trivy report (SARIF, never blocks)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           severity: HIGH,CRITICAL
@@ -300,12 +307,12 @@ jobs:
           output: trivy-results.sarif
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: trivy-results.sarif
           category: trivy
       - name: Trivy gate (blocks on HIGH/CRITICAL)
-        uses: aquasecurity/trivy-action@v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           severity: HIGH,CRITICAL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,10 +9,11 @@ on:
     # Weekly run so we pick up newly published queries without a push
     - cron: '23 4 * * 1'
 
+# Default read-only at the workflow level; the analyze job escalates to the
+# writes CodeQL needs. Keeps token scope job-local (OSSF Scorecard
+# TokenPermissions).
 permissions:
   contents: read
-  security-events: write
-  actions: read
 
 concurrency:
   group: codeql-${{ github.ref }}
@@ -22,18 +23,22 @@ jobs:
   analyze:
     name: Analyze ${{ matrix.language }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # upload analysis results to the Security tab
+      actions: read            # required for the `actions` language pack
     strategy:
       fail-fast: false
       matrix:
         language: [javascript-typescript, actions]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: github/codeql-action/init@v3
+      - uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
-      - uses: github/codeql-action/analyze@v3
+      - uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,17 +31,17 @@ jobs:
     name: Build VitePress
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm docs:build
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
         if: github.ref == 'refs/heads/main'
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         if: github.ref == 'refs/heads/main'
         with:
           path: dist-docs
@@ -55,5 +55,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
         id: deployment

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -14,14 +14,14 @@ jobs:
     name: Scan for committed secrets
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Full history so we catch secrets added in older commits too
           fetch-depth: 0
       # Pinned per Wave 2d.H / #72 — improves OSSF Scorecard
       # pinned-dependencies score. Bump this tag deliberately; the
       # floating `@v2` would let upstream changes land without review.
-      - uses: gitleaks/gitleaks-action@v2.3.9
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -21,19 +21,19 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@v2.4.3
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -33,9 +33,11 @@ on:
     # security advisory drops and you want a fresh dependency
     # snapshot to share).
 
+# Read-only default. `id-token: write` (cosign keyless OIDC) is needed only
+# by sign-and-release, which requests it job-locally — keeping the OIDC
+# token off the generate job (OSSF Scorecard TokenPermissions).
 permissions:
   contents: read
-  id-token: write   # required for cosign keyless via GH OIDC
 
 concurrency:
   group: sbom-${{ github.ref }}
@@ -45,14 +47,16 @@ jobs:
   generate:
     name: Generate CycloneDX SBOM
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       sbom_path: ${{ steps.generate.outputs.sbom_path }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
@@ -91,7 +95,7 @@ jobs:
           echo "::notice title=SBOM generated::CycloneDX 1.5 JSON, ${components} components"
 
       - name: Upload SBOM as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: panorama-sbom-${{ github.sha }}
           path: panorama-sbom.json
@@ -106,15 +110,15 @@ jobs:
       contents: write   # attach assets to release
       id-token: write   # OIDC for cosign keyless
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download SBOM artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: panorama-sbom-${{ github.sha }}
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3.7.0
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       - name: Sign SBOM (keyless via OIDC)
         env:


### PR DESCRIPTION
Clears the **bulk of the open code-scanning queue** — the ~55 OSSF Scorecard + ~19 CodeQL `actions/*` alerts were almost all "unpinned action" and "missing/over-broad token permission" findings on the workflow tree.

## Pinning (all 7 workflows, 15 distinct actions)
Every `uses: owner/repo@vN` → `@<40-char-sha> # vN`. SHAs resolved from each tag's current tip via the GitHub API; the `# vN` comment keeps Dependabot's actions ecosystem able to bump the pins.

Closes the `actions/unpinned-tag` (CodeQL) and `PinnedDependenciesID` (Scorecard) alerts on `*.yml`.

## Token permissions
| File | Change | Clears |
|---|---|---|
| `ci.yml` | add top-level `permissions: contents: read` (was absent) | TokenPermissions HIGH `ci.yml:1` + `missing-workflow-permissions` on lint/test/web-test/i18n/license/no-enterprise jobs |
| `codeql.yml` | move `security-events: write` / `actions: read` from workflow level down to the `analyze` job | TokenPermissions HIGH `codeql.yml:14` |
| `sbom.yml` | drop workflow-level `id-token: write`; only `sign-and-release` keeps it; `generate` is read-only | tightens OIDC scope |

`container-scan` (ci.yml) keeps its existing job-local `security-events: write`; `sign-and-release` (sbom.yml) keeps `contents: write` (required to attach release assets).

## Out of scope (separate / accepted)
- Dockerfile `PinnedDependenciesID` (base-image digest pinning) — deferred; pinning base images by digest is a heavier maintenance trade-off.
- Repo-level Scorecard meta findings (Maintained / Code-Review / CII-Best-Practices / Fuzzing / Vulnerabilities) — not fixable by a file edit.
- `sign-and-release` `contents: write` — required for `gh release upload`.

## Verification
All 7 workflows re-validated as parseable YAML. No functional change to job behaviour.